### PR TITLE
use furcation max argument directly in kmer generation

### DIFF
--- a/src/algorithms/kmer.hpp
+++ b/src/algorithms/kmer.hpp
@@ -30,6 +30,7 @@ struct kmer_t {
     /// Used in construction
     pos_t end; /// one past the (current) end of the kmer
     handle_t curr; /// the next handle we extend into
+    uint16_t forks; /// how many branching edge crossings we took to get here
 };
 
 /// Print a kmer_t to a stream.
@@ -38,7 +39,7 @@ std::ostream& operator<<(std::ostream& out, const kmer_t& kmer);
 namespace algorithms {
 
 /// Iterate over all the kmers in the graph, running lambda on each
-void for_each_kmer(const HandleGraph& graph, size_t k,
+void for_each_kmer(const HandleGraph& graph, size_t k, size_t edge_max,
                    const std::function<void(const kmer_t&)>& lambda);
 
 }

--- a/src/algorithms/prune.cpp
+++ b/src/algorithms/prune.cpp
@@ -28,7 +28,7 @@ std::vector<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size
                     if (walk.length < k) {
                         // are we branching over more than one edge?
                         size_t next_count = 0;
-                        graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
+                        graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; return next_count <= 1; });
                         graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
                                 if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
                                     int tid = omp_get_thread_num();
@@ -65,7 +65,7 @@ std::vector<edge_t> find_edges_to_prune(const HandleGraph& graph, size_t k, size
                             if (walk.length < k) {
                                 // if not, we need to expand through the node then follow on
                                 size_t next_count = 0;
-                                graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; });
+                                graph.follow_edges(walk.curr, false, [&](const handle_t& next) { ++next_count; return next_count <= 1; });
                                 graph.follow_edges(walk.curr, false, [&](const handle_t& next) {
                                         if (next_count > 1 && edge_max == walk.forks) { // our next step takes us over the max
                                             int tid = omp_get_thread_num();

--- a/src/subcommand/kmers_main.cpp
+++ b/src/subcommand/kmers_main.cpp
@@ -62,6 +62,7 @@ int main_kmers(int argc, char** argv) {
     if (args::get(max_degree)) {
         algorithms::remove_high_degree_nodes(graph, args::get(max_degree));
     }
+    /*
     if (args::get(max_furcations)) {
         std::vector<edge_t> to_prune = algorithms::find_edges_to_prune(graph, args::get(kmer_length), args::get(max_furcations));
         std::cerr << "edges to prune: " << to_prune.size() << std::endl;
@@ -70,9 +71,10 @@ int main_kmers(int argc, char** argv) {
         }
         std::cerr << "done prune" << std::endl;
     }
+    */
     std::vector<std::vector<kmer_t>> buffers(get_thread_count());
     if (args::get(kmers_stdout)) {
-        algorithms::for_each_kmer(graph, args::get(kmer_length), [&](const kmer_t& kmer) {
+        algorithms::for_each_kmer(graph, args::get(kmer_length), args::get(max_furcations), [&](const kmer_t& kmer) {
                 int tid = omp_get_thread_num();
                 auto& buffer = buffers.at(tid);
                 buffer.push_back(kmer);
@@ -97,7 +99,7 @@ int main_kmers(int argc, char** argv) {
         //ska::flat_hash_map<uint32_t, uint32_t> kmer_table;
         vector<uint64_t> kmers;
         uint64_t seen_kmers = 0;
-        algorithms::for_each_kmer(graph, args::get(kmer_length), [&](const kmer_t& kmer) {
+        algorithms::for_each_kmer(graph, args::get(kmer_length), args::get(max_furcations), [&](const kmer_t& kmer) {
                 //int tid = omp_get_thread_num();
 //#pragma omp atomic
                 uint64_t hash = djb2_hash64(kmer.seq.c_str());


### PR DESCRIPTION
This avoids us having to collect all the edges to remove, remove them, and then run kmerization.

It also generates a different set of kmers. This set would not be valid input to GCSA2, but that's not a problem here because the target application is direct kmer indexing.