### PR TITLE
improve path coding to handle higher path depths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ ExternalProject_Add(sdsl-lite
   GIT_REPOSITORY "https://github.com/simongog/sdsl-lite.git"
   GIT_TAG "d52aa9a71513d132e30c09491b5899af449ebb94"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR} # TODO ADD static build flag
+  UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(sdsl-lite INSTALL_DIR)
 set(sdsl-lite_INCLUDE "${INSTALL_DIR}/src/sdsl-lite-build/include")
@@ -63,7 +64,7 @@ set(sdsl-lite-divsufsort_LIB "${INSTALL_DIR}/src/sdsl-lite-build/external/libdiv
 # DYNAMIC (full build using its cmake config)
 ExternalProject_Add(dynamic
   GIT_REPOSITORY "https://github.com/vgteam/DYNAMIC.git"
-  GIT_TAG "615d8be5276bcd4c5a3d8e31679b4f8e81b2eefc"
+  GIT_TAG "625da93483a50cc9888270325017df4e7be9a36b"
   # we don't actually install dynamic... it's header only
   #CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
   UPDATE_COMMAND ""
@@ -79,6 +80,7 @@ ExternalProject_Add(gfakluge
   GIT_TAG "d99d927ab286c3dfaeb4db15c15d306d1fab0806"
   BUILD_IN_SOURCE TRUE
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR} # TODO ADD static build flag
+  UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
   CONFIGURE_COMMAND "")
@@ -92,6 +94,7 @@ ExternalProject_Add(handlegraph
   GIT_REPOSITORY "https://github.com/vgteam/libhandlegraph.git"
   GIT_TAG "62bd408c3428e0a1f93528910415f68686912399"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
+  UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(handlegraph INSTALL_DIR)
 set(handlegraph_INCLUDE "${INSTALL_DIR}/src/handlegraph/src/include")
@@ -101,6 +104,7 @@ set(handlegraph_LIB "${INSTALL_DIR}/src/handlegraph-build")
 ExternalProject_Add(tayweeargs
   GIT_REPOSITORY "https://github.com/Taywee/args.git"
   GIT_TAG "3de44ec671db452cc0c4ef86399b108939768abb"
+  UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(tayweeargs SOURCE_DIR)
 set(tayweeargs_INCLUDE "${SOURCE_DIR}")
@@ -131,6 +135,7 @@ ExternalProject_Add(backwardscpp
   GIT_REPOSITORY "https://github.com/bombela/backward-cpp.git"
   GIT_TAG "b353585d4bd19f9e51816bc11d2e53b0e5b4a760"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
+  UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(backwardscpp SOURCE_DIR)
 set(backwardscpp_INCLUDE "${SOURCE_DIR}")
@@ -141,6 +146,7 @@ ExternalProject_Add(sparsepp
   GIT_TAG "1c5a285e87b2244383efe0398f9992acd61234e9"
   BUILD_IN_SOURCE TRUE
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR} # TODO ADD static build flag
+  UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
   CONFIGURE_COMMAND "")
@@ -152,6 +158,7 @@ set(sparsepp_LIB "${INSTALL_DIR}/src/sparsepp/sparsepp/")
 ExternalProject_Add(ska
   GIT_REPOSITORY "https://github.com/skarupke/flat_hash_map.git"
   GIT_TAG "2c4687431f978f02a3780e24b8b701d22aa32d9c"
+  UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
   CONFIGURE_COMMAND "")
@@ -162,6 +169,7 @@ set(ska_INCLUDE "${SOURCE_DIR}")
 ExternalProject_Add(intervaltree
   GIT_REPOSITORY "https://github.com/ekg/intervaltree.git"
   GIT_TAG "e8082c74a6f5c18de99d8b4cc4a55e2e62a1150d"
+  UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
   CONFIGURE_COMMAND "")
@@ -172,6 +180,7 @@ set(intervaltree_INCLUDE "${SOURCE_DIR}")
 ExternalProject_Add(lodepng
   GIT_REPOSITORY "https://github.com/ekg/lodepng.git"
   GIT_TAG "6b7f7b2b1c0eaab7042b0137fa19129618d1bb9f"
+  UPDATE_COMMAND ""
   INSTALL_COMMAND "")
 ExternalProject_Get_property(lodepng SOURCE_DIR)
 set(lodepng_INCLUDE "${SOURCE_DIR}")
@@ -181,6 +190,7 @@ set(lodepng_LIB "${SOURCE_DIR}/lib")
 ExternalProject_Add(structures
   GIT_REPOSITORY "https://github.com/jeizenga/structures.git"
   GIT_TAG "71722385665aa724b466889bbec1afbfd375201f"
+  UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
   CONFIGURE_COMMAND "")
@@ -192,6 +202,7 @@ ExternalProject_Add(sonlib
   GIT_TAG "d25257e7ba615081078c41ac82dd70fffdc8baad"
   BUILD_IN_SOURCE TRUE
   INSTALL_COMMAND ""
+  UPDATE_COMMAND ""
   BUILD_COMMAND "make"
   CONFIGURE_COMMAND "")
 ExternalProject_Get_property(sonlib SOURCE_DIR)
@@ -202,6 +213,7 @@ set(sonLib_LIB "${SOURCE_DIR}/sonLib/lib")
 ExternalProject_Add(picosha256
   GIT_REPOSITORY "https://github.com/okdshin/PicoSHA2.git"
   GIT_TAG "b699e6c900be6e00152db5a3d123c1db42ea13d0"
+  UPDATE_COMMAND ""
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
   CONFIGURE_COMMAND "")

--- a/src/algorithms/eades_algorithm.cpp
+++ b/src/algorithms/eades_algorithm.cpp
@@ -15,11 +15,17 @@ using namespace handlegraph;
 #endif
         
         // decide which strand will be "forward" for each node
+        /*
         vector<handle_t> canonical_orientation = single_stranded_orientation(graph);
         if (canonical_orientation.size() < graph->node_size()) {
             cerr << "error:[eades_algorithm] Eades' algorithm only valid on graphs with a single stranded orientation" << endl;
             exit(1);
         }
+        */
+        vector<handle_t> canonical_orientation;
+        graph->for_each_handle([&canonical_orientation](const handle_t& h) {
+                canonical_orientation.push_back(h);
+            });
         
 #ifdef debug_eades
         cerr << "got canonical orientation:" << endl;

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -262,7 +262,7 @@ std::vector<handle_t> topological_order(const HandleGraph* g) {
 std::vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazier) {
     
     // map that will contain the orientation and the in degree for each node
-    unordered_map<handle_t, int64_t> inward_degree;
+    hash_map<handle_t, int64_t> inward_degree;
     inward_degree.reserve(g->node_size());
     
     // stack for the traversal

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -50,7 +50,7 @@ std::vector<handle_t> tail_nodes(const HandleGraph* g) {
 }
 
 std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads) {
-    
+
     // Make a vector to hold the ordered and oriented nodes.
     std::vector<handle_t> sorted;
     sorted.reserve(g->node_size());

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -49,7 +49,7 @@ std::vector<handle_t> tail_nodes(const HandleGraph* g) {
     
 }
 
-std::vector<handle_t> topological_order(const HandleGraph* g) {
+std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads) {
     
     // Make a vector to hold the ordered and oriented nodes.
     std::vector<handle_t> sorted;
@@ -63,23 +63,28 @@ std::vector<handle_t> topological_order(const HandleGraph* g) {
     map<handlegraph::nid_t, handle_t> s;
 
     // We find the head and tails, if there are any
-    std::vector<handle_t> heads{head_nodes(g)};
+    //std::vector<handle_t> heads{head_nodes(g)};
     // No need to fetch the tails since we don't use them
 
     
     // Maps from node ID to first orientation we suggested for it.
     map<handlegraph::nid_t, handle_t> seeds;
     
-    
-    for(handle_t& head : heads) {
-        // Dump all the heads into the oriented set, rather than having them as
-        // seeds. We will only go for cycle-breaking seeds when we run out of
-        // heads. This is bad for contiguity/ordering consistency in cyclic
-        // graphs and reversing graphs, but makes sure we work out to just
-        // topological sort on DAGs. It mimics the effect we used to get when we
-        // joined all the head nodes to a new root head node and seeded that. We
-        // ignore tails since we only orient right from nodes we pick.
-        s[g->get_id(head)] = head;
+    // Dump all the heads into the oriented set, rather than having them as
+    // seeds. We will only go for cycle-breaking seeds when we run out of
+    // heads. This is bad for contiguity/ordering consistency in cyclic
+    // graphs and reversing graphs, but makes sure we work out to just
+    // topological sort on DAGs. It mimics the effect we used to get when we
+    // joined all the head nodes to a new root head node and seeded that. We
+    // ignore tails since we only orient right from nodes we pick.
+    if (use_heads) {
+        for(const handle_t& head : head_nodes(g)) {
+            s[g->get_id(head)] = head;
+        }
+    } else {
+        for(const handle_t& tail : tail_nodes(g)) {
+            s[g->get_id(tail)] = tail;
+        }
     }
 
     // We will use an ordered map handles by ID for nodes we have not visited
@@ -258,7 +263,33 @@ std::vector<handle_t> topological_order(const HandleGraph* g) {
     // Send away our sorted ordering.
     return sorted;
 }
-    
+
+std::vector<handle_t> two_way_topological_order(const HandleGraph* g) {
+    // take the average assigned order for each handle
+    hash_map<handle_t, uint64_t> avg_order;
+    uint64_t i = 0;
+    for (auto& handle : topological_order(g, true)) {
+        avg_order[handle] = ++i;
+    }
+    i = 0;
+    for (auto& handle : topological_order(g, false)) {
+        avg_order[handle] = max(avg_order[handle], (++i));
+    }
+    std::vector<std::pair<handle_t, uint64_t>> order;
+    for (auto& p : avg_order) {
+        order.push_back(p);
+    }
+    std::sort(order.begin(), order.end(), [](const std::pair<handle_t, uint64_t>& a,
+                                             const std::pair<handle_t, uint64_t>& b) {
+                  return a.second < b.second;
+              });
+    std::vector<handle_t> result;
+    for (auto& p : order) {
+        result.push_back(p.first);
+    }
+    return result;
+}
+
 std::vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazier) {
     
     // map that will contain the orientation and the in degree for each node

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -3,11 +3,10 @@
 namespace odgi {
 namespace algorithms {
 
-using namespace std;
 using namespace handlegraph;
 
-vector<handle_t> head_nodes(const HandleGraph* g) {
-    vector<handle_t> to_return;
+std::vector<handle_t> head_nodes(const HandleGraph* g) {
+    std::vector<handle_t> to_return;
     g->for_each_handle([&](const handle_t& found) {
         // For each (locally forward) node
         
@@ -28,8 +27,8 @@ vector<handle_t> head_nodes(const HandleGraph* g) {
     
 }
 
-vector<handle_t> tail_nodes(const HandleGraph* g) {
-    vector<handle_t> to_return;
+std::vector<handle_t> tail_nodes(const HandleGraph* g) {
+    std::vector<handle_t> to_return;
     g->for_each_handle([&](const handle_t& found) {
         // For each (locally forward) node
         
@@ -50,10 +49,10 @@ vector<handle_t> tail_nodes(const HandleGraph* g) {
     
 }
 
-vector<handle_t> topological_order(const HandleGraph* g) {
+std::vector<handle_t> topological_order(const HandleGraph* g) {
     
     // Make a vector to hold the ordered and oriented nodes.
-    vector<handle_t> sorted;
+    std::vector<handle_t> sorted;
     sorted.reserve(g->node_size());
     
     // Instead of actually removing edges, we add them to this set of masked edges.
@@ -64,7 +63,7 @@ vector<handle_t> topological_order(const HandleGraph* g) {
     map<handlegraph::nid_t, handle_t> s;
 
     // We find the head and tails, if there are any
-    vector<handle_t> heads{head_nodes(g)};
+    std::vector<handle_t> heads{head_nodes(g)};
     // No need to fetch the tails since we don't use them
 
     
@@ -260,14 +259,14 @@ vector<handle_t> topological_order(const HandleGraph* g) {
     return sorted;
 }
     
-vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazier) {
+std::vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazier) {
     
     // map that will contain the orientation and the in degree for each node
     unordered_map<handle_t, int64_t> inward_degree;
     inward_degree.reserve(g->node_size());
     
     // stack for the traversal
-    vector<handle_t> stack;
+    std::vector<handle_t> stack;
     
     if (lazier) {
         // take the locally forward orientation as a single stranded orientation
@@ -284,7 +283,7 @@ vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazi
     }
     else {
         // get an orientation over which we can consider the graph single stranded
-        vector<handle_t> orientation = single_stranded_orientation(g);
+        std::vector<handle_t> orientation = single_stranded_orientation(g);
         
         if (orientation.size() != g->node_size()) {
             cerr << "error:[algorithms] attempting to use lazy topological sort on unorientable graph" << endl;
@@ -305,7 +304,7 @@ vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazi
     }
     
     // the return value
-    vector<handle_t> order;
+    std::vector<handle_t> order;
     order.reserve(g->node_size());
     
     while (!stack.empty()) {
@@ -340,11 +339,11 @@ vector<handle_t> lazy_topological_order_internal(const HandleGraph* g, bool lazi
 }
     
     
-vector<handle_t> lazy_topological_order(const HandleGraph* g) {
+std::vector<handle_t> lazy_topological_order(const HandleGraph* g) {
     return lazy_topological_order_internal(g, false);
 }
     
-vector<handle_t> lazier_topological_order(const HandleGraph* g) {
+std::vector<handle_t> lazier_topological_order(const HandleGraph* g) {
     return lazy_topological_order_internal(g, true);
 }
 

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -19,14 +19,13 @@
 namespace odgi {
 namespace algorithms {
 
-using namespace std;
 using namespace handlegraph;
 
 /// Find all of the nodes with no edges on their left sides.
-vector<handle_t> head_nodes(const HandleGraph* g);
+std::vector<handle_t> head_nodes(const HandleGraph* g);
 
 /// Find all of the nodes with no edges on their right sides.
-vector<handle_t> tail_nodes(const HandleGraph* g);
+std::vector<handle_t> tail_nodes(const HandleGraph* g);
 
 /**
  * Order and orient the nodes in the graph using a topological sort. The sort is
@@ -58,7 +57,7 @@ vector<handle_t> tail_nodes(const HandleGraph* g);
  *                     (This helps start at natural entry points to cycles)
  *     return L (a topologically sorted order and orientation)
  */
-vector<handle_t> topological_order(const HandleGraph* g);
+std::vector<handle_t> topological_order(const HandleGraph* g);
 
 /**
  * Order the nodes in a graph using a topological sort. The sort is NOT guaranteed
@@ -66,7 +65,7 @@ vector<handle_t> topological_order(const HandleGraph* g);
  * is invalid in a graph that has any cycles. For safety, consider this property with
  * algorithms::is_directed_acyclic().
  */
-vector<handle_t> lazy_topological_order(const HandleGraph* g);
+std::vector<handle_t> lazy_topological_order(const HandleGraph* g);
     
 /**
  * Order the nodes in a graph using a topological sort. Similar to lazy_topological_order
@@ -74,7 +73,7 @@ vector<handle_t> lazy_topological_order(const HandleGraph* g);
  * any reversing edges. For safety, consider these properties with algorithms::is_acyclic()
  * and algorithms::is_single_stranded().
  */
-vector<handle_t> lazier_topological_order(const HandleGraph* g);
+std::vector<handle_t> lazier_topological_order(const HandleGraph* g);
 
 void topological_sort(MutableHandleGraph& g, bool compact_ids);
 

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -57,7 +57,9 @@ std::vector<handle_t> tail_nodes(const HandleGraph* g);
  *                     (This helps start at natural entry points to cycles)
  *     return L (a topologically sorted order and orientation)
  */
-std::vector<handle_t> topological_order(const HandleGraph* g);
+std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads = true);
+
+std::vector<handle_t> two_way_topological_order(const HandleGraph* g);
 
 /**
  * Order the nodes in a graph using a topological sort. The sort is NOT guaranteed

--- a/src/cactus.cpp
+++ b/src/cactus.cpp
@@ -5,7 +5,7 @@ extern "C" {
 #include "stCactusGraphs.h"
 }
 
-#define debug
+//#define debug
 
 namespace odgi {
 

--- a/src/dynamic_types.hpp
+++ b/src/dynamic_types.hpp
@@ -7,7 +7,7 @@ namespace odgi {
 
 typedef dyn::succinct_bitvector<dyn::spsi<dyn::packed_vector,256,16> > suc_bv;
 //typedef dyn::spsi<dyn::packed_vector,1024,1> spsi_iv;
-typedef dyn::lciv<dyn::packed_vector,256,16> lciv_iv;
+typedef dyn::lciv<dyn::packed_vector,512,1> lciv_iv;
 typedef dyn::wt_string<dyn::succinct_bitvector<dyn::spsi<dyn::packed_vector,256,16> > > wt_str;
 typedef dyn::hacked_vector suc_iv;
 

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -906,6 +906,7 @@ handle_t graph_t::combine_handles(const std::vector<handle_t>& handles) {
             create_edge(h, combined);
         }
     }
+    return combined;
 }
 
 /**

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -783,7 +783,6 @@ handle_t graph_t::apply_orientation(const handle_t& handle) {
         as_integers(step)[1] = r.second.first;
         p.last = step;
     }
-
     // reconnect it to the graph
     for (auto& h : edges_fwd_fwd) {
         create_edge(handle, h);

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -605,10 +605,7 @@ void graph_t::destroy_edge(const handle_t& left_h, const handle_t& right_h) {
         
 /// Remove all nodes and edges. Does not update any stored paths.
 void graph_t::clear(void) {
-    wt_str null_wt;
     suc_bv null_bv;
-    lciv_iv null_iv;
-    dyn::packed_vector null_pv;
     _max_node_id = 0;
     _min_node_id = 0;
     _node_count = 0;

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -340,20 +340,29 @@ bool graph_t::is_empty(const path_handle_t& path_handle) const {
 
 /// Loop over all the steps along a path, from first through last
 void graph_t::for_each_step_in_path(const path_handle_t& path, const std::function<void(const step_handle_t&)>& iteratee) const {
+    auto& p = path_metadata_v[as_integer(path)];
     if (is_empty(path)) return;
     bool is_circular = get_is_circular(path);
     step_handle_t begin_step = path_begin(path);
     step_handle_t step = begin_step; // copy
-    iteratee(step); // run the first time
     bool keep_going = true;
-    while (keep_going) {
-        step = get_next_step(step);
+    do {
         iteratee(step);
-        if (!(is_circular && step != begin_step
-              || has_next_step(step))) {
-            keep_going = false;
+        // if it's circular, and there is a next step that isn't the same as the beginning, continue
+        // if it's not circular, and there is a next step, continue
+        if (is_circular) {
+            step = get_next_step(step);
+            if (step == begin_step) {
+                keep_going = false;
+            }
+        } else {
+            if (has_next_step(step)) {
+                step = get_next_step(step);
+            } else {
+                keep_going = false;
+            }
         }
-    }
+    } while (keep_going);
 }
     
 /// Create a new node with the given sequence and return the handle.

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -340,13 +340,18 @@ bool graph_t::is_empty(const path_handle_t& path_handle) const {
 
 /// Loop over all the steps along a path, from first through last
 void graph_t::for_each_step_in_path(const path_handle_t& path, const std::function<void(const step_handle_t&)>& iteratee) const {
+    std::cerr << "on path " << get_path_name(path) << std::endl;
     auto& p = path_metadata_v[as_integer(path)];
+    std::cerr << as_integer(path) << ":" << p.name << ":"
+              << as_integers(p.first)[0] << "/" << as_integers(p.first)[1] << "->"
+              << as_integers(p.last)[0] << "/" << as_integers(p.last)[1] << " ";
     if (is_empty(path)) return;
     bool is_circular = get_is_circular(path);
     step_handle_t begin_step = path_begin(path);
     step_handle_t step = begin_step; // copy
     bool keep_going = true;
     do {
+        std::cerr << "on step " << as_integers(step)[0] << ":" << as_integers(step)[1] << std::endl;
         iteratee(step);
         // if it's circular, and there is a next step that isn't the same as the beginning, continue
         // if it's not circular, and there is a next step, continue

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -340,18 +340,13 @@ bool graph_t::is_empty(const path_handle_t& path_handle) const {
 
 /// Loop over all the steps along a path, from first through last
 void graph_t::for_each_step_in_path(const path_handle_t& path, const std::function<void(const step_handle_t&)>& iteratee) const {
-    std::cerr << "on path " << get_path_name(path) << std::endl;
     auto& p = path_metadata_v[as_integer(path)];
-    std::cerr << as_integer(path) << ":" << p.name << ":"
-              << as_integers(p.first)[0] << "/" << as_integers(p.first)[1] << "->"
-              << as_integers(p.last)[0] << "/" << as_integers(p.last)[1] << " ";
     if (is_empty(path)) return;
     bool is_circular = get_is_circular(path);
     step_handle_t begin_step = path_begin(path);
     step_handle_t step = begin_step; // copy
     bool keep_going = true;
     do {
-        std::cerr << "on step " << as_integers(step)[0] << ":" << as_integers(step)[1] << std::endl;
         iteratee(step);
         // if it's circular, and there is a next step that isn't the same as the beginning, continue
         // if it's not circular, and there is a next step, continue

--- a/src/graph.hpp
+++ b/src/graph.hpp
@@ -367,7 +367,6 @@ private:
     /// Records the handle to node_id mapping
     /// Use the special value "0" to indicate deleted nodes so that
     /// handle references in the id_map and elsewhere are not immediately destroyed
-    //lciv_iv graph_id_iv;
     std::vector<node_t> node_v;
     /// Mark deleted nodes here for translating graph ids into internal ranks
     suc_bv deleted_node_bv;

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -4,93 +4,58 @@
 
 namespace odgi {
 
-node_t::layout_t node_t::get_layout(void) const {
-    node_t::layout_t layout;
-    sqvarint::decode(&layout.data[0], (uint8_t*)bytes.data(), 5);
-    return layout;
-}
-
-node_t::layout_t node_t::set_layout(node_t::layout_t layout) {
-    // should we realloc the layout?
-    uint64_t old_size = sqvarint::bytes(bytes.data(), 5);
-    uint64_t new_size = sqvarint::length(layout.data, 5);
-    if (new_size < old_size) {
-        bytes.erase(bytes.begin(), bytes.begin()+(old_size-new_size));
-    } else if (new_size > old_size) {
-        bytes.insert(bytes.begin(), new_size-old_size, 0);
-    }
-    // we can get away with this because our layout bytes are always going to fit in a single byte
-    layout.set_layout_bytes(new_size);
-    sqvarint::encode(layout.data, bytes.data(), 5);
-    return layout;
-}
-
 uint64_t node_t::sequence_size(void) const {
-    node_t::layout_t layout = get_layout();
-    return layout.seq_bytes();
+    return seq_bytes();
 }
 
 const std::string node_t::sequence(void) const {
-    node_t::layout_t layout = get_layout();
-    const std::string res((char*)bytes.data()+layout.seq_start(), layout.seq_bytes());
+    const std::string res((char*)bytes.data()+seq_start(), seq_bytes());
     return res;
 }
 
 void node_t::set_sequence(const std::string& seq) {
-    node_t::layout_t layout = get_layout();
-    if (seq.size() > layout.seq_bytes()) {
-        bytes.reserve(bytes.size()+seq.size()-layout.seq_bytes());
-        bytes.insert(bytes.begin()+layout.seq_start(), seq.size() - layout.seq_bytes(), 0);
-        layout.set_seq_bytes(seq.size());
-        layout = set_layout(layout);
-    } else if (seq.size() < layout.seq_bytes()) {
-        bytes.erase(bytes.begin()+layout.seq_start(), bytes.begin()+layout.seq_start()+(layout.seq_bytes()-seq.size()));;
-        layout.set_seq_bytes(seq.size());
-        layout = set_layout(layout);
+    if (seq.size() > seq_bytes()) {
+        bytes.reserve(bytes.size()+seq.size()-seq_bytes());
+        bytes.insert(bytes.begin()+seq_start(), seq.size() - seq_bytes(), 0);
+        set_seq_bytes(seq.size());
+    } else if (seq.size() < seq_bytes()) {
+        bytes.erase(bytes.begin()+seq_start(), bytes.begin()+seq_start()+(seq_bytes()-seq.size()));;
+        set_seq_bytes(seq.size());
     }
-    memcpy(bytes.data()+layout.seq_start(), seq.c_str(), seq.size());
+    memcpy(bytes.data()+seq_start(), seq.c_str(), seq.size());
 }
 
 std::vector<uint64_t> node_t::edges(void) const {
     std::vector<uint64_t> res;
-    const node_t::layout_t& layout = get_layout();
-    if (layout.edge_count()) {
-        res.resize(layout.edge_count()*EDGE_RECORD_LENGTH);
+    if (edge_count()) {
+        res.resize(edge_count()*EDGE_RECORD_LENGTH);
         sqvarint::decode(res.data(),
-                       (uint8_t*)bytes.data()+layout.edge_start(),
-                       layout.edge_count()*EDGE_RECORD_LENGTH);
+                       (uint8_t*)bytes.data()+edge_start(),
+                       edge_count()*EDGE_RECORD_LENGTH);
     }
-    assert(res.size() == layout.edge_count);
+    assert(res.size() == edge_count);
     return res;
 }
 
 void node_t::add_edge(const uint64_t& relative_id, const uint64_t& edge_type) {
     //std::cerr << "add edge " << "relative_id " << relative_id << " edge_type " << edge_type << std::endl;
-    node_t::layout_t layout = get_layout();
-    uint64_t edge_bytes = sqvarint::length({relative_id, edge_type});
-    bytes.reserve(bytes.size()+edge_bytes);
-    bytes.insert(bytes.begin()+layout.edge_start(), edge_bytes, 0);
-    sqvarint::encode({relative_id, edge_type}, bytes.data()+layout.edge_start());
-    layout.set_edge_bytes(layout.edge_bytes() + edge_bytes);
-    layout.set_edge_count(layout.edge_count() + 1);
-    set_layout(layout);
+    uint64_t add_edge_bytes = sqvarint::length({relative_id, edge_type});
+    bytes.reserve(bytes.size()+add_edge_bytes);
+    bytes.insert(bytes.begin()+edge_start(), add_edge_bytes, 0);
+    sqvarint::encode({relative_id, edge_type}, bytes.data()+edge_start());
+    set_edge_bytes(edge_bytes() + add_edge_bytes);
+    set_edge_count(edge_count() + 1);
 }
 
 void node_t::remove_edge(const uint64_t& rank) {
     assert(rank < edge_count());
-    node_t::layout_t layout = get_layout();
-    if (rank > layout.edge_count()) assert(false);
-    uint64_t edge_offset = layout.edge_start() + sqvarint::bytes(bytes.data()+layout.edge_start(), EDGE_RECORD_LENGTH*rank);
+    if (rank > edge_count()) assert(false);
+    uint64_t edge_offset = edge_start() + sqvarint::bytes(bytes.data()+edge_start(), EDGE_RECORD_LENGTH*rank);
     // a bit redundant
     uint64_t j = sqvarint::bytes(bytes.data()+edge_offset, EDGE_RECORD_LENGTH);
     bytes.erase(bytes.begin()+edge_offset, bytes.begin()+edge_offset+j);
-    layout.set_edge_count(layout.edge_count()-1);
-    layout.set_edge_bytes(layout.edge_bytes()-j);
-    set_layout(layout);
-}
-
-uint64_t node_t::edge_count(void) const {
-    return get_layout().edge_count();
+    set_edge_count(edge_count()-1);
+    set_edge_bytes(edge_bytes()-j);
 }
 
 void node_t::add_path_step(const uint64_t& path_id, const bool& is_rev,
@@ -106,9 +71,7 @@ void node_t::add_path_step(const uint64_t& path_id, const bool& is_rev,
 }
 
 void node_t::add_path_step(const node_t::step_t& step) {
-    layout_t layout = get_layout();
-    layout.set_path_count(layout.path_count()+1);
-    set_layout(layout);
+    set_path_count(path_count()+1);
     uint64_t step_bytes = sqvarint::length((uint64_t*)step.data, 5);
     uint64_t old_size = bytes.size();
     bytes.resize(old_size+step_bytes);
@@ -118,11 +81,10 @@ void node_t::add_path_step(const node_t::step_t& step) {
 }
 
 const std::vector<node_t::step_t> node_t::get_path_steps(void) const {
-    layout_t layout = get_layout();
-    if (layout.path_count() == 0) return {};
-    std::vector<node_t::step_t> steps(layout.path_count());
-    uint8_t* target = (uint8_t*)bytes.data()+layout.path_start();
-    for (uint64_t i = 0; i < layout.path_count(); ++i) {
+    if (path_count() == 0) return {};
+    std::vector<node_t::step_t> steps(path_count());
+    uint8_t* target = (uint8_t*)bytes.data()+path_start();
+    for (uint64_t i = 0; i < path_count(); ++i) {
         auto& step = steps[i];
         target = sqvarint::decode(&step.data[0], target, PATH_RECORD_LENGTH);
     }
@@ -130,17 +92,15 @@ const std::vector<node_t::step_t> node_t::get_path_steps(void) const {
 }
 
 const node_t::step_t node_t::get_path_step(const uint64_t& rank) const {
-    layout_t layout = get_layout();
     node_t::step_t step;
     sqvarint::decode(&step.data[0],
-                   sqvarint::seek((uint8_t*)bytes.data() + layout.path_start(), PATH_RECORD_LENGTH*rank),
+                   sqvarint::seek((uint8_t*)bytes.data() + path_start(), PATH_RECORD_LENGTH*rank),
                    PATH_RECORD_LENGTH);
     return step;
 }
 
 void node_t::set_path_step(const uint64_t& rank, const step_t& step) {
-    layout_t layout = get_layout();
-    uint64_t offset = layout.path_start()+sqvarint::bytes(bytes.data() + layout.path_start(), PATH_RECORD_LENGTH*rank);
+    uint64_t offset = path_start()+sqvarint::bytes(bytes.data() + path_start(), PATH_RECORD_LENGTH*rank);
     uint8_t* target = bytes.data()+offset;
     uint64_t old_size = sqvarint::bytes(target, PATH_RECORD_LENGTH);
     uint64_t new_size = sqvarint::length(step.data, PATH_RECORD_LENGTH);
@@ -157,11 +117,10 @@ void node_t::set_path_step(const uint64_t& rank, const step_t& step) {
 void node_t::flip_paths(const uint64_t& start_marker, const uint64_t& end_marker) {
     const std::vector<node_t::step_t> steps = get_path_steps();
     // remove all path steps
-    node_t::layout_t layout = get_layout();
     uint64_t old_size = bytes.size();
-    bytes.erase(bytes.begin()+layout.path_start(), bytes.end());
+    bytes.erase(bytes.begin()+path_start(), bytes.end());
     bytes.resize(old_size);
-    uint8_t* target = bytes.data()+layout.path_start();
+    uint8_t* target = bytes.data()+path_start();
     // flip them and replace
     for (auto& step : steps) {
         // flip the step
@@ -173,34 +132,36 @@ void node_t::flip_paths(const uint64_t& start_marker, const uint64_t& end_marker
 }
 
 void node_t::remove_path_step(const uint64_t& rank) {
-    node_t::layout_t layout = get_layout();
-    if (rank > layout.path_count()) assert(false);
-    uint8_t* i = sqvarint::seek(bytes.data()+layout.path_start(), PATH_RECORD_LENGTH*rank);
+    if (rank > path_count()) assert(false);
+    uint8_t* i = sqvarint::seek(bytes.data()+path_start(), PATH_RECORD_LENGTH*rank);
     uint8_t* j = sqvarint::seek(i, PATH_RECORD_LENGTH);
     bytes.erase(bytes.begin() + (i - bytes.data()),
                 bytes.begin() + (j - bytes.data()));
-    layout.set_path_count(layout.path_count()-1);
-    set_layout(layout);
+    set_path_count(path_count()-1);
 }
 
 void node_t::clear(void) {
-    bytes = { 5, 0, 0, 0, 0 };
+    _seq_bytes = 0;
+    _edge_bytes = 0;
+    _edge_count = 0;
+    _path_bytes = 0;
+    _path_count = 0;
+    bytes.clear();
 }
 
 void node_t::clear_path_steps(void) {
-    node_t::layout_t layout = get_layout();
-    bytes.erase(bytes.begin()+layout.path_start(), bytes.end());
-    layout.set_path_count(0);
-    set_layout(layout);
-}
-
-uint64_t node_t::path_count(void) const {
-    layout_t layout = get_layout();
-    return layout.path_count();
+    bytes.erase(bytes.begin()+path_start(), bytes.end());
+    set_path_count(0);
 }
 
 uint64_t node_t::serialize(std::ostream& out) const {
     uint64_t written = 0;
+    out.write((char*)&_seq_bytes, sizeof(uint32_t));
+    out.write((char*)&_edge_bytes, sizeof(uint32_t));
+    out.write((char*)&_edge_count, sizeof(uint32_t));
+    out.write((char*)&_path_bytes, sizeof(uint32_t));
+    out.write((char*)&_path_count, sizeof(uint32_t));
+    written += sizeof(uint32_t)*5;
     uint64_t node_size = bytes.size();
     out.write((char*)&node_size, sizeof(node_size));
     written += sizeof(uint64_t);
@@ -210,6 +171,11 @@ uint64_t node_t::serialize(std::ostream& out) const {
 }
 
 void node_t::load(std::istream& in) {
+    in.read((char*)&_seq_bytes, sizeof(uint32_t));
+    in.read((char*)&_edge_bytes, sizeof(uint32_t));
+    in.read((char*)&_edge_count, sizeof(uint32_t));
+    in.read((char*)&_path_bytes, sizeof(uint32_t));
+    in.read((char*)&_path_count, sizeof(uint32_t));
     uint64_t node_size = 0;
     in.read((char*)&node_size, sizeof(node_size));
     bytes.resize(node_size);
@@ -217,16 +183,14 @@ void node_t::load(std::istream& in) {
 }
 
 void node_t::display(void) const {
-    layout_t layout = get_layout();
     std::cerr << "self_bytes " << bytes.size() << " "
-              << "layout_bytes " << layout.layout_bytes() << " "
-              << "seq_bytes " << layout.seq_bytes() << " "
+              << "seq_bytes " << seq_bytes() << " "
               << "seq " << sequence() << " "
-              << "edge_start " << layout.edge_start() << " "
-              << "edge_count " << layout.edge_count() << " "
-              << "edge_bytes " << layout.edge_bytes() << " "
-              << "path_start " << layout.path_start() << " "
-              << "path_count " << layout.path_count() << " | ";
+              << "edge_start " << edge_start() << " "
+              << "edge_count " << edge_count() << " "
+              << "edge_bytes " << edge_bytes() << " "
+              << "path_start " << path_start() << " "
+              << "path_count " << path_count() << " | ";
     for (auto i : bytes) {
         std::cerr << (int) i << " ";
     }

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -71,16 +71,16 @@ void node_t::add_path_step(const uint64_t& path_id, const bool& is_rev,
 }
 
 void node_t::add_path_step(const node_t::step_t& step) {
-    set_path_count(path_count()+1);
     for (uint8_t i = 0; i < PATH_RECORD_LENGTH; ++i) {
         path_steps.push_back(step.data[i]);
     }
 }
 
 const std::vector<node_t::step_t> node_t::get_path_steps(void) const {
-    if (path_count() == 0) return {};
-    std::vector<node_t::step_t> steps(path_count());
-    for (uint64_t i = 0; i < path_count(); ++i) {
+    uint64_t n_paths = path_count();
+    if (n_paths == 0) return {};
+    std::vector<node_t::step_t> steps(n_paths);
+    for (uint64_t i = 0; i < n_paths; ++i) {
         steps[i] = get_path_step(i);
     }
     return steps;
@@ -138,22 +138,19 @@ void node_t::remove_path_step(const uint64_t& rank) {
     for (uint8_t i = 0; i < PATH_RECORD_LENGTH; ++i) {
         path_steps.remove(offset);
     }
-    set_path_count(path_count()-1);
 }
 
 void node_t::clear(void) {
     set_seq_bytes(0);
     set_edge_bytes(0);
     set_edge_count(0);
-    set_path_count(0);
     bytes.clear();
     clear_path_steps();
 }
 
 void node_t::clear_path_steps(void) {
-    dyn::lciv<dyn::hacked_vector,256,1> null_iv;
+    lciv_iv null_iv;
     path_steps = null_iv;
-    set_path_count(0);
 }
 
 uint64_t node_t::serialize(std::ostream& out) const {
@@ -161,7 +158,6 @@ uint64_t node_t::serialize(std::ostream& out) const {
     out.write((char*)&_seq_bytes, sizeof(uint32_t));
     out.write((char*)&_edge_bytes, sizeof(uint32_t));
     out.write((char*)&_edge_count, sizeof(uint32_t));
-    out.write((char*)&_path_count, sizeof(uint32_t));
     written += sizeof(uint32_t)*4 + sizeof(uint8_t);
     uint64_t node_size = bytes.size();
     out.write((char*)&node_size, sizeof(node_size));
@@ -176,7 +172,6 @@ void node_t::load(std::istream& in) {
     in.read((char*)&_seq_bytes, sizeof(uint32_t));
     in.read((char*)&_edge_bytes, sizeof(uint32_t));
     in.read((char*)&_edge_count, sizeof(uint32_t));
-    in.read((char*)&_path_count, sizeof(uint32_t));
     uint64_t node_size = 0;
     in.read((char*)&node_size, sizeof(node_size));
     bytes.resize(node_size);

--- a/src/node.cpp
+++ b/src/node.cpp
@@ -119,6 +119,7 @@ void node_t::set_path_step(const uint64_t& rank, const step_t& step) {
     }
     target = bytes.data() + offset; // recalculate target, as it may have moved due to resize!
     sqvarint::encode(step.data, target, 5);
+    if (rank == path_count()-1) set_path_last_bytes(new_size);
 }
 
 std::pair<std::map<uint64_t, std::pair<uint64_t, bool>>, // path fronts
@@ -194,7 +195,7 @@ uint64_t node_t::serialize(std::ostream& out) const {
     out.write((char*)&_edge_count, sizeof(uint32_t));
     out.write((char*)&_path_count, sizeof(uint32_t));
     out.write((char*)&_path_last_bytes, sizeof(uint8_t));
-    written += sizeof(uint32_t)*5;
+    written += sizeof(uint32_t)*4 + sizeof(uint8_t);
     uint64_t node_size = bytes.size();
     out.write((char*)&node_size, sizeof(node_size));
     written += sizeof(uint64_t);

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -22,8 +22,8 @@ class node_t {
     uint32_t _seq_bytes = 0;
     uint32_t _edge_bytes = 0;
     uint32_t _edge_count = 0;
-    uint32_t _path_bytes = 0;
     uint32_t _path_count = 0;
+    uint8_t _path_last_bytes = 0;
 public:
     inline const uint64_t seq_start(void) const { return 0; }
     inline const uint64_t seq_bytes(void) const { return _seq_bytes; }
@@ -32,10 +32,12 @@ public:
     inline const uint64_t edge_bytes(void) const { return _edge_bytes; }
     inline const uint64_t path_start(void) const { return _seq_bytes+_edge_bytes; }
     inline const uint64_t path_count(void) const { return _path_count; }
+    inline const uint64_t path_last_bytes(void) const { return _path_last_bytes; }
     inline void set_seq_bytes(const uint64_t& i) { _seq_bytes = i; }
     inline void set_edge_count(const uint64_t& i) { _edge_count = i; }
     inline void set_edge_bytes(const uint64_t& i) { _edge_bytes = i; }
     inline void set_path_count(const uint64_t& i) { _path_count = i; }
+    inline void set_path_last_bytes(const uint8_t& i) { _path_last_bytes = i; }
     struct step_t {
         uint64_t data[5] = { 0, 0, 0, 0, 0 }; // PATH_RECORD_LENGTH
         step_t(void) { }
@@ -83,6 +85,7 @@ public:
     const std::vector<node_t::step_t> get_path_steps(void) const;
     const step_t get_path_step(const uint64_t& rank) const;
     void remove_path_step(const uint64_t& rank);
+    void update_path_last_bytes(void);
     void clear(void);
     void clear_path_steps(void);
     uint64_t serialize(std::ostream& out) const;

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -1,5 +1,4 @@
-#ifndef dgraph_node_hpp
-#define dgraph_node_hpp
+#pragma once
 
 #include <iostream>
 #include <cstdint>
@@ -9,6 +8,7 @@
 #include <map>
 #include <utility>
 #include <cstring>
+#include "dynamic.hpp"
 #include "varint.hpp"
 
 namespace odgi {
@@ -21,25 +21,24 @@ const uint8_t PATH_RECORD_LENGTH = 5;
 /// A node object with the sequence, its edge lists, and paths
 class node_t {
     std::vector<uint8_t> bytes;
+    //dyn::lciv<dyn::packed_vector,256,1> path_alphabet;
+    dyn::lciv<dyn::hacked_vector,256,1> path_steps;
     uint32_t _seq_bytes = 0;
     uint32_t _edge_bytes = 0;
     uint32_t _edge_count = 0;
     uint32_t _path_count = 0;
-    uint8_t _path_last_bytes = 0;
 public:
     inline const uint64_t seq_start(void) const { return 0; }
     inline const uint64_t seq_bytes(void) const { return _seq_bytes; }
     inline const uint64_t edge_start(void) const { return _seq_bytes; }
     inline const uint64_t edge_count(void) const { return _edge_count; }
     inline const uint64_t edge_bytes(void) const { return _edge_bytes; }
-    inline const uint64_t path_start(void) const { return _seq_bytes+_edge_bytes; }
     inline const uint64_t path_count(void) const { return _path_count; }
-    inline const uint64_t path_last_bytes(void) const { return _path_last_bytes; }
     inline void set_seq_bytes(const uint64_t& i) { _seq_bytes = i; }
     inline void set_edge_count(const uint64_t& i) { _edge_count = i; }
     inline void set_edge_bytes(const uint64_t& i) { _edge_bytes = i; }
     inline void set_path_count(const uint64_t& i) { _path_count = i; }
-    inline void set_path_last_bytes(const uint8_t& i) { _path_last_bytes = i; }
+    //inline void set_path_last_bytes(const uint8_t& i) { _path_last_bytes = i; }
     struct step_t {
         uint64_t data[5] = { 0, 0, 0, 0, 0 }; // PATH_RECORD_LENGTH
         step_t(void) { }
@@ -111,5 +110,3 @@ public:
 };
 
 }
-
-#endif

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <handlegraph/util.hpp>
 #include <vector>
+#include <map>
+#include <utility>
 #include <cstring>
 #include "varint.hpp"
 
@@ -81,7 +83,9 @@ public:
                        const uint64_t& prev_id, const uint64_t& prev_rank,
                        const uint64_t& next_id, const uint64_t& next_rank);
     void set_path_step(const uint64_t& rank, const step_t& step);
-    void flip_paths(const uint64_t& start_marker, const uint64_t& end_marker);
+    std::pair<std::map<uint64_t, std::pair<uint64_t, bool>>, // path fronts
+              std::map<uint64_t, std::pair<uint64_t, bool>>> // path backs
+         flip_paths(const uint64_t& start_marker, const uint64_t& end_marker);
     const std::vector<node_t::step_t> get_path_steps(void) const;
     const step_t get_path_step(const uint64_t& rank) const;
     void remove_path_step(const uint64_t& rank);

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -18,24 +18,24 @@ const uint8_t PATH_RECORD_LENGTH = 5;
 
 /// A node object with the sequence, its edge lists, and paths
 class node_t {
-    std::vector<uint8_t> bytes{ 5, 0, 0, 0, 0 };
+    std::vector<uint8_t> bytes;
+    uint32_t _seq_bytes = 0;
+    uint32_t _edge_bytes = 0;
+    uint32_t _edge_count = 0;
+    uint32_t _path_bytes = 0;
+    uint32_t _path_count = 0;
 public:
-    struct layout_t {
-        uint64_t data[5] = { 0, 0, 0, 0, 0 };
-        inline const uint64_t layout_bytes(void) const { return data[0]; }
-        inline const uint64_t seq_start(void) const { return data[0]; }
-        inline const uint64_t seq_bytes(void) const { return data[1]; }
-        inline const uint64_t edge_start(void) const { return layout_bytes()+seq_bytes(); }
-        inline const uint64_t edge_count(void) const { return data[2]; }
-        inline const uint64_t edge_bytes(void) const { return data[3]; }
-        inline const uint64_t path_start(void) const { return layout_bytes()+seq_bytes()+edge_bytes(); }
-        inline const uint64_t path_count(void) const { return data[4]; }
-        inline void set_layout_bytes(const uint64_t& i) { data[0] = i; }
-        inline void set_seq_bytes(const uint64_t& i) { data[1] = i; }
-        inline void set_edge_count(const uint64_t& i) { data[2] = i; }
-        inline void set_edge_bytes(const uint64_t& i) { data[3] = i; }
-        inline void set_path_count(const uint64_t& i) { data[4] = i; }
-    };
+    inline const uint64_t seq_start(void) const { return 0; }
+    inline const uint64_t seq_bytes(void) const { return _seq_bytes; }
+    inline const uint64_t edge_start(void) const { return _seq_bytes; }
+    inline const uint64_t edge_count(void) const { return _edge_count; }
+    inline const uint64_t edge_bytes(void) const { return _edge_bytes; }
+    inline const uint64_t path_start(void) const { return _seq_bytes+_edge_bytes; }
+    inline const uint64_t path_count(void) const { return _path_count; }
+    inline void set_seq_bytes(const uint64_t& i) { _seq_bytes = i; }
+    inline void set_edge_count(const uint64_t& i) { _edge_count = i; }
+    inline void set_edge_bytes(const uint64_t& i) { _edge_bytes = i; }
+    inline void set_path_count(const uint64_t& i) { _path_count = i; }
     struct step_t {
         uint64_t data[5] = { 0, 0, 0, 0, 0 }; // PATH_RECORD_LENGTH
         step_t(void) { }
@@ -65,18 +65,12 @@ public:
         inline void set_next_id(const uint64_t& i) { data[3] = i; }
         inline void set_next_rank(const uint64_t& i) { data[4] = i; }
     };
-    layout_t get_layout(void) const;
-    layout_t set_layout(layout_t layout);
     uint64_t sequence_size(void) const;
     const std::string sequence(void) const;
     void set_sequence(const std::string& seq);
-    uint64_t edge_count_offset(void) const;
-    uint64_t edge_count(void) const;
-    uint64_t edge_offset(void) const;
     std::vector<uint64_t> edges(void) const;
     void add_edge(const uint64_t& relative_id, const uint64_t& edge_type);
     void remove_edge(const uint64_t& rank);
-    void set_edge_count(const uint64_t& count, const layout_t& layout);
     void add_path_step(const uint64_t& path_id, const bool& is_rev,
                        const uint64_t& prev_id, const uint64_t& prev_rank,
                        const uint64_t& next_id, const uint64_t& next_rank);
@@ -91,7 +85,6 @@ public:
     void remove_path_step(const uint64_t& rank);
     void clear(void);
     void clear_path_steps(void);
-    uint64_t path_count(void) const;
     uint64_t serialize(std::ostream& out) const;
     void load(std::istream& in);
     void display(void) const;

--- a/src/node.hpp
+++ b/src/node.hpp
@@ -9,6 +9,7 @@
 #include <utility>
 #include <cstring>
 #include "dynamic.hpp"
+#include "dynamic_types.hpp"
 #include "varint.hpp"
 
 namespace odgi {
@@ -21,24 +22,20 @@ const uint8_t PATH_RECORD_LENGTH = 5;
 /// A node object with the sequence, its edge lists, and paths
 class node_t {
     std::vector<uint8_t> bytes;
-    //dyn::lciv<dyn::packed_vector,256,1> path_alphabet;
-    dyn::lciv<dyn::hacked_vector,256,1> path_steps;
+    lciv_iv path_steps;
     uint32_t _seq_bytes = 0;
     uint32_t _edge_bytes = 0;
     uint32_t _edge_count = 0;
-    uint32_t _path_count = 0;
 public:
     inline const uint64_t seq_start(void) const { return 0; }
     inline const uint64_t seq_bytes(void) const { return _seq_bytes; }
     inline const uint64_t edge_start(void) const { return _seq_bytes; }
     inline const uint64_t edge_count(void) const { return _edge_count; }
     inline const uint64_t edge_bytes(void) const { return _edge_bytes; }
-    inline const uint64_t path_count(void) const { return _path_count; }
+    inline const uint64_t path_count(void) const { return path_steps.size()/PATH_RECORD_LENGTH; }
     inline void set_seq_bytes(const uint64_t& i) { _seq_bytes = i; }
     inline void set_edge_count(const uint64_t& i) { _edge_count = i; }
     inline void set_edge_bytes(const uint64_t& i) { _edge_bytes = i; }
-    inline void set_path_count(const uint64_t& i) { _path_count = i; }
-    //inline void set_path_last_bytes(const uint8_t& i) { _path_last_bytes = i; }
     struct step_t {
         uint64_t data[5] = { 0, 0, 0, 0, 0 }; // PATH_RECORD_LENGTH
         step_t(void) { }

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -67,8 +67,8 @@ int main_prune(int argc, char** argv) {
         omp_set_num_threads(args::get(threads));
     }
     if (args::get(max_degree)) {
-        algorithms::remove_high_degree_nodes(graph, args::get(max_degree));
         graph.clear_paths();
+        algorithms::remove_high_degree_nodes(graph, args::get(max_degree));
     }
     if (args::get(max_furcations)) {
         std::vector<edge_t> to_prune = algorithms::find_edges_to_prune(graph, args::get(kmer_length), args::get(max_furcations));
@@ -81,13 +81,13 @@ int main_prune(int argc, char** argv) {
     }
     if (args::get(min_coverage) || args::get(max_coverage)) {
         std::vector<handle_t> to_drop = algorithms::find_handles_exceeding_coverage_limits(graph, args::get(min_coverage), args::get(max_coverage));
+        // remove the paths, because it's likely we have damaged some
+        // and at present, we have no mechanism to reconstruct them
+        graph.clear_paths();
         //std::cerr << "got " << to_drop.size() << " handles to drop" << std::endl;
         for (auto& handle : to_drop) {
             graph.destroy_handle(handle);
         }
-        // remove the paths, because it's likely we have damaged some
-        // and at present, we have no mechanism to reconstruct them
-        graph.clear_paths();
     }
     if (args::get(drop_paths)) {
         graph.clear_paths();

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -68,6 +68,7 @@ int main_prune(int argc, char** argv) {
     }
     if (args::get(max_degree)) {
         algorithms::remove_high_degree_nodes(graph, args::get(max_degree));
+        graph.clear_paths();
     }
     if (args::get(max_furcations)) {
         std::vector<edge_t> to_prune = algorithms::find_edges_to_prune(graph, args::get(kmer_length), args::get(max_furcations));
@@ -75,6 +76,7 @@ int main_prune(int argc, char** argv) {
         for (auto& edge : to_prune) {
             graph.destroy_edge(edge);
         }
+        // we're just removing edges, so paths shouldn't be damaged
         std::cerr << "done prune" << std::endl;
     }
     if (args::get(min_coverage) || args::get(max_coverage)) {
@@ -83,6 +85,9 @@ int main_prune(int argc, char** argv) {
         for (auto& handle : to_drop) {
             graph.destroy_handle(handle);
         }
+        // remove the paths, because it's likely we have damaged some
+        // and at present, we have no mechanism to reconstruct them
+        graph.clear_paths();
     }
     if (args::get(drop_paths)) {
         graph.clear_paths();

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -28,6 +28,7 @@ int main_sort(int argc, char** argv) {
     args::Flag cycle_breaking(parser, "cycle_breaking", "use a cycle breaking sort", {'b', "cycle-breaking"});
     args::Flag eades(parser, "eades", "use eades algorithm", {'e', "eades"});
     args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
+    args::Flag two(parser, "two", "use two-way (max of head-first and tail-first) topological algorithm", {'w', "two-way"});
     args::Flag paths_by_min_node_id(parser, "paths-min", "sort paths by their lowest contained node id", {'P', "paths-min"});
     args::Flag paths_by_max_node_id(parser, "paths-max", "sort paths by their highest contained node id", {'M', "paths-max"});
     try {
@@ -69,6 +70,8 @@ int main_sort(int argc, char** argv) {
             graph.apply_ordering(algorithms::eades_algorithm(&graph), true);
         } else if (args::get(lazy)) {
             graph.apply_ordering(algorithms::lazy_topological_order(&graph), true);
+        } else if (args::get(two)) {
+            graph.apply_ordering(algorithms::two_way_topological_order(&graph), true);
         } else {
             graph.apply_ordering(algorithms::topological_order(&graph), true);
         }

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -27,6 +27,7 @@ int main_sort(int argc, char** argv) {
     args::Flag show_sort(parser, "show", "write the sort order mapping", {'S', "show"});
     args::Flag cycle_breaking(parser, "cycle_breaking", "use a cycle breaking sort", {'b', "cycle-breaking"});
     args::Flag eades(parser, "eades", "use eades algorithm", {'e', "eades"});
+    args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
     args::Flag paths_by_min_node_id(parser, "paths-min", "sort paths by their lowest contained node id", {'P', "paths-min"});
     args::Flag paths_by_max_node_id(parser, "paths-max", "sort paths by their highest contained node id", {'M', "paths-max"});
     try {
@@ -57,7 +58,7 @@ int main_sort(int argc, char** argv) {
         }
     }
     if (args::get(show_sort)) {
-        vector<handle_t> order = algorithms::topological_order(&graph);
+        vector<handle_t> order = (args::get(lazy) ? algorithms::lazy_topological_order(&graph) : algorithms::topological_order(&graph));
         for (auto& handle : order) {
             std::cout << graph.get_id(handle) << std::endl;
         }
@@ -66,6 +67,8 @@ int main_sort(int argc, char** argv) {
     if (outfile.size()) {
         if (args::get(eades)) {
             graph.apply_ordering(algorithms::eades_algorithm(&graph), true);
+        } else if (args::get(lazy)) {
+            graph.apply_ordering(algorithms::lazy_topological_order(&graph), true);
         } else {
             graph.apply_ordering(algorithms::topological_order(&graph), true);
         }

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -20,7 +20,7 @@ int main_sort(int argc, char** argv) {
     argv[0] = (char*)prog_name.c_str();
     --argc;
     
-    args::ArgumentParser parser("metrics describing variation graphs");
+    args::ArgumentParser parser("variation graph sorts");
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph in this file", {'o', "out"});
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -172,8 +172,8 @@ int main_viz(int argc, char** argv) {
     };
 
     auto add_edge = [&](const handle_t& h, const handle_t& o) {
-        auto& _a = position_map[number_bool_packing::unpack_number(h) + !number_bool_packing::unpack_bit(h)];
-        auto& _b = position_map[number_bool_packing::unpack_number(o) + !number_bool_packing::unpack_bit(o)];
+        uint64_t _a = position_map[number_bool_packing::unpack_number(h) + !number_bool_packing::unpack_bit(h)];
+        uint64_t _b = position_map[number_bool_packing::unpack_number(o) + number_bool_packing::unpack_bit(o)];
         uint64_t a = std::min(_a, _b);
         uint64_t b = std::max(_a, _b);
         uint64_t dist = b - a;
@@ -181,7 +181,7 @@ int main_viz(int argc, char** argv) {
         for ( ; i < dist; i+=1/scale_y) {
             add_point(a, i, 0, 0, 0);
         }
-        while (a < b) {
+        while (a <= b) {
             add_point(a, i, 0, 0, 0);
             a += 1/scale_x;
         }

--- a/src/unittest/handle.cpp
+++ b/src/unittest/handle.cpp
@@ -2038,6 +2038,7 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
                 if (i == 0) {
                     occ = graph.path_begin(p);
                 }
+
                 REQUIRE(graph.get_path_handle_of_step(occ) == p);
                 REQUIRE(graph.get_handle_of_step(occ) == occs[i]);
                 REQUIRE(graph.has_previous_step(occ) == (i > 0));
@@ -2047,7 +2048,7 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
                     occ = graph.get_next_step(occ);
                 }
             }
-            
+
             for (int i = occs.size() - 1; i >= 0; i--){
                 if (i == occs.size() - 1) {
                     occ = graph.path_end(p);
@@ -2130,6 +2131,7 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
         graph.append_step(p2, h1);
         graph.append_step(p2, graph.flip(h2));
         graph.append_step(p2, h3);
+
         check_path(p2, {h1, graph.flip(h2), h3});
         
         // graph can query steps of a node on paths
@@ -2152,7 +2154,6 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
         REQUIRE(found1);
         REQUIRE(found2);
         found1 = found2 = false;
-        
         occs = graph.steps_of_handle(h1, true);
         for (auto& occ : occs) {
             if (graph.get_path_handle_of_step(occ) == p1 &&
@@ -2167,6 +2168,7 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
                 REQUIRE(false);
             }
         }
+
         REQUIRE(found1);
         REQUIRE(found2);
         found1 = found2 = false;
@@ -2186,6 +2188,7 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
                 REQUIRE(false);
             }
         }
+
         occs = graph.steps_of_handle(graph.flip(h2), true);
         for (auto& occ : occs) {
             if (graph.get_path_handle_of_step(occ) == p2 &&
@@ -2200,7 +2203,7 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
         REQUIRE(found2);
         found1 = found2 = false;
         vector<handle_t> segments = graph.divide_handle(h2, {size_t(2), size_t(4)});
-        
+
         // graph preserves paths when dividing nodes
 
         check_path(p1, {h1, segments[0], segments[1], segments[2], h3});
@@ -2214,7 +2217,7 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
         REQUIRE(graph.get_path_count() == 3);
         
         // graph can destroy paths
-        
+
         graph.destroy_path(p3);
 
         REQUIRE(!graph.has_path("3"));
@@ -2239,7 +2242,6 @@ TEST_CASE("Deletable handle graphs with mutable paths work", "[handle][packed][h
         REQUIRE(found1);
         REQUIRE(found2);
         REQUIRE(!found3);
-
         // check flips to see if membership records are still functional
         check_flips(p1, {h1, segments[0], segments[1], segments[2], h3});
         check_flips(p2, {h1, graph.flip(segments[2]), graph.flip(segments[1]), graph.flip(segments[0]), h3});


### PR DESCRIPTION
When our path set gets large enough, we can no longer fit each node_t in cache. When this happens, the variable length integer encoding starts to become extremely expensive. It's costly to jump into the middle of the path step set because we have to decode the entire set of path steps up to the one we're interested in.

A solution is to use a packed integer vector from DYNAMIC. Actually, I used the "hacked" integer vector that I developed, which only offers a kind of chunked encoding of the whole vector. This really helps construction and manipulation time for graphs with high path coverage.

The next thing I'm going to test is a small codebook to reduce required space when we have repetitive next and previous steps in the paths, which is pretty much the standard situation. This will be similar to GBWT. Again, there will be a significant overhead to keeping the codebook around, but it should keep things much smaller when the path depth on the graph gets large enough.