### PR TITLE
low memory topological sort using dynamic succinct data structures

### DIFF
--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -49,7 +49,7 @@ std::vector<handle_t> tail_nodes(const HandleGraph* g) {
     
 }
 
-std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads) {
+std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bool progress_reporting) {
 
     // Make a vector to hold the ordered and oriented nodes.
     std::vector<handle_t> sorted;
@@ -197,6 +197,11 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads) {
             handle_t n = number_bool_packing::pack(i, false);
             // Emit it
             sorted.push_back(n);
+            if (progress_reporting && sorted.size() % 1000 == 0) {
+                uint64_t i = sorted.size();
+                uint64_t c = g->get_node_count();
+                std::cerr << "topological sort " << i << " of " << c << " ~ " << (float)i/(float)c * 100 << "%" << "\r";
+            }
 #ifdef debug
 #pragma omp critical (cerr)
             cerr << "Using oriented node " << g->get_id(n) << " orientation " << g->get_is_reverse(n) << endl;
@@ -320,6 +325,11 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads) {
                     }
                 });
         }
+    }
+    if (progress_reporting && sorted.size()) {
+        uint64_t i = sorted.size();
+        uint64_t c = g->get_node_count();
+        std::cerr << "topological sort " << i << " of " << c << " ~ " << "100.0000%" << std::endl;
     }
 
     // Send away our sorted ordering.

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -1,5 +1,4 @@
-#ifndef VG_ALGORITHMS_TOPOLOGICAL_SORT_HPP_INCLUDED
-#define VG_ALGORITHMS_TOPOLOGICAL_SORT_HPP_INCLUDED
+#pragma once
 
 /**
  * \file topological_sort.hpp
@@ -13,6 +12,8 @@
 #include <iostream>
 #include "../hash_map.hpp"
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/util.hpp>
+#include "dynamic.hpp"
 #include "apply_bulk_modifications.hpp"
 #include "is_single_stranded.hpp"
 
@@ -81,5 +82,3 @@ void topological_sort(MutableHandleGraph& g, bool compact_ids);
 
 }
 }
-
-#endif

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -58,7 +58,7 @@ std::vector<handle_t> tail_nodes(const HandleGraph* g);
  *                     (This helps start at natural entry points to cycles)
  *     return L (a topologically sorted order and orientation)
  */
-std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads = true);
+std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads = true, bool progress_reporting = false);
 
 std::vector<handle_t> two_way_topological_order(const HandleGraph* g);
 

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -686,32 +686,38 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
         order = &order_in;
     }
     // nodes
-    hash_map<nid_t, nid_t> ids;
-    ids.reserve(order->size());
+    //hash_map<nid_t, nid_t> ids;
+    std::vector<nid_t> ids;
+    uint64_t max_handle_rank = 0;
+    for_each_handle([&](const handle_t& handle) {
+            max_handle_rank = std::max(max_handle_rank,
+                                       number_bool_packing::unpack_number(handle));
+        });
+    ids.resize(max_handle_rank);
     // establish id mapping
     if (compact_ids) {
         for (uint64_t i = 0; i < order->size(); ++i) {
-            ids[get_id(order->at(i))] = i+1;
+            ids[number_bool_packing::unpack_number(order->at(i))] = i+1;
         }
     } else {
         for (uint64_t i = 0; i < order->size(); ++i) {
             auto& handle = order->at(i);
-            ids[get_id(handle)] = get_id(handle);
+            ids[number_bool_packing::unpack_number(handle)] = get_id(handle);
         }
     }
     // nodes
     for (auto& handle : *order) {
-        ordered.create_handle(get_sequence(handle), ids[get_id(handle)]);
+        ordered.create_handle(get_sequence(handle), ids[number_bool_packing::unpack_number(handle)]);
     }
     // edges
     for (auto& handle : *order) {
         follow_edges(handle, false, [&](const handle_t& h) {
-                ordered.create_edge(ordered.get_handle(ids[get_id(handle)], get_is_reverse(handle)),
-                                    ordered.get_handle(ids[get_id(h)], get_is_reverse(h)));
+                ordered.create_edge(ordered.get_handle(ids[number_bool_packing::unpack_number(handle)], get_is_reverse(handle)),
+                                    ordered.get_handle(ids[number_bool_packing::unpack_number(h)], get_is_reverse(h)));
             });
         follow_edges(handle, true, [&](const handle_t& h) {
-                ordered.create_edge(ordered.get_handle(ids[get_id(h)], get_is_reverse(h)),
-                                    ordered.get_handle(ids[get_id(handle)], get_is_reverse(handle)));
+                ordered.create_edge(ordered.get_handle(ids[number_bool_packing::unpack_number(h)], get_is_reverse(h)),
+                                    ordered.get_handle(ids[number_bool_packing::unpack_number(handle)], get_is_reverse(handle)));
             });
     }
     // paths
@@ -719,7 +725,7 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
             path_handle_t new_path = ordered.create_path_handle(get_path_name(old_path));
             for_each_step_in_path(old_path, [&](const step_handle_t& step) {
                     handle_t old_handle = get_handle_of_step(step);
-                    handle_t new_handle = ordered.get_handle(ids[get_id(old_handle)], get_is_reverse(old_handle));
+                    handle_t new_handle = ordered.get_handle(ids[number_bool_packing::unpack_number(old_handle)], get_is_reverse(old_handle));
                     ordered.append_step(new_path, new_handle);
                 });
         });

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -6,8 +6,7 @@
 //  main dynamic compact graph definition
 //
 
-#ifndef dgraph_hpp
-#define dgraph_hpp
+#pragma once
 
 #include <cstdio>
 #include <cstdint>
@@ -471,13 +470,7 @@ private:
 
 };
 
-const static uint64_t path_begin_marker = 0; //std::numeric_limits<uint64_t>::max()-1;
-const static uint64_t path_end_marker = 1; // std::numeric_limits<uint64_t>::max();
-
-// avoid undefined reference error
-//const uint64_t graph_t::path_begin_marker;
-//const uint64_t graph_t::path_end_marker;
+const static uint64_t path_begin_marker = 0;
+const static uint64_t path_end_marker = 1;
 
 } // end dankness
-
-#endif /* dgraph_hpp */

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -31,6 +31,7 @@ int main_sort(int argc, char** argv) {
     args::Flag two(parser, "two", "use two-way (max of head-first and tail-first) topological algorithm", {'w', "two-way"});
     args::Flag paths_by_min_node_id(parser, "paths-min", "sort paths by their lowest contained node id", {'P', "paths-min"});
     args::Flag paths_by_max_node_id(parser, "paths-max", "sort paths by their highest contained node id", {'M', "paths-max"});
+    args::Flag progress(parser, "progress", "display progress of the sort", {'p', "progress"});
     try {
         parser.ParseCLI(argc, argv);
     } catch (args::Help) {
@@ -73,7 +74,7 @@ int main_sort(int argc, char** argv) {
         } else if (args::get(two)) {
             graph.apply_ordering(algorithms::two_way_topological_order(&graph), true);
         } else {
-            graph.apply_ordering(algorithms::topological_order(&graph), true);
+            graph.apply_ordering(algorithms::topological_order(&graph, true, args::get(progress)), true);
         }
         if (args::get(cycle_breaking)) {
             graph.apply_ordering(algorithms::cycle_breaking_sort(graph), true);


### PR DESCRIPTION
In this PR, I'm going to work up a series of changes to the topological sort to keep its memory usage moderate. The memory usage of `algorithms::topological_order` has been a bottleneck when working with large seqwish graphs. Sorting and id compaction are basically a requirement for "untangling" these pangenomes and virtually all downstream operations.