### PR TITLE
Add a min id offset to apply_ordering to avoid a crash

### DIFF
--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -691,9 +691,11 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
     uint64_t max_handle_rank = 0;
     uint64_t min_handle_rank = std::numeric_limits<uint64_t>::max();
     for_each_handle([&](const handle_t& handle) {
-            max_handle_rank = std::max(max_handle_rank,
-                                       number_bool_packing::unpack_number(handle));
-        });
+        max_handle_rank = std::max(max_handle_rank,
+                                   number_bool_packing::unpack_number(handle));
+        min_handle_rank = std::min(min_handle_rank,
+                                   number_bool_packing::unpack_number(handle));
+    });
     if (max_handle_rank > 0) {
         ids.resize(max_handle_rank - min_handle_rank + 1);
     }


### PR DESCRIPTION
Ran into a crash (I think because of discontinguous IDs), which seems to have been fixed by adding this minimum offset to the ID conversion step in `apply_ordering` and making sure the vector is large enough.