### PR TITLE
implement path coverage binning in odgi bin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ add_executable(odgi
   ${CMAKE_SOURCE_DIR}/src/subcommand/prune_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/simplify_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/subset_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/bin_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp
@@ -280,6 +281,7 @@ add_executable(odgi
   ${CMAKE_SOURCE_DIR}/src/algorithms/find_shortest_paths.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/id_ordered_paths.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/simple_components.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/bin_path_info.cpp
   )
 add_dependencies(odgi sdsl-lite)
 add_dependencies(odgi dynamic)

--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -76,9 +76,6 @@ void bin_path_info(const PathHandleGraph& graph,
             v.mean_inv /= (v.mean_cov ? v.mean_cov : 1);
             v.mean_cov /= bp_per_bin;
             v.mean_pos /= bp_per_bin * plen * v.mean_cov;
-            //v.mean_pos /= plen;
-            //v.mean_pos /= v.mean_cov;
-            //if (v.mean_pos > 1) v.mean_pos = 1; // repeats can make this go over 1
         }
     }
 }

--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -1,0 +1,74 @@
+#include "bin_path_info.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+void bin_path_coverage(const PathHandleGraph& graph,
+                       const std::string& prefix_delimiter,
+                       const uint64_t& num_bins,
+                       std::vector<std::pair<std::string, std::vector<double>>>& table) {
+    // the graph must be compacted for this to work
+    std::vector<uint64_t> position_map(graph.get_node_count()+1);
+    std::vector<std::pair<uint64_t, uint64_t>> contacts;
+    uint64_t len = 0;
+    graph.for_each_handle([&](const handle_t& h) {
+            position_map[number_bool_packing::unpack_number(h)] = len;
+            uint64_t hl = graph.get_length(h);
+            len += hl;
+        });
+    position_map[position_map.size()-1] = len;
+    // find the prefix order based on existing set
+    std::unordered_set<std::string> seen_prefixes;
+    std::unordered_map<std::string, uint64_t> path_prefix_rank;
+    auto get_path_prefix = [&](const path_handle_t& p) -> std::string {
+        std::string path_name = graph.get_path_name(p);
+        if (prefix_delimiter.empty()) {
+            return path_name;
+        } else {
+            return path_name.substr(0, path_name.find(prefix_delimiter));
+        }
+    };
+    graph.for_each_path_handle([&](const path_handle_t& p) {
+            std::string path_prefix = get_path_prefix(p);
+            if (!seen_prefixes.count(path_prefix)) {
+                path_prefix_rank[path_prefix] = seen_prefixes.size();
+                seen_prefixes.insert(path_prefix);
+            }
+        });
+    std::vector<std::string> path_prefix_order(seen_prefixes.size());
+    for (auto& p : path_prefix_rank) {
+        path_prefix_order[p.second] = p.first;
+    }
+    // resize the aggregation matrix
+    table.resize(path_prefix_rank.size());
+    auto path_prefix_order_itr = path_prefix_order.begin();
+    for (auto& row : table) {
+        row.first = *path_prefix_order_itr++;
+        row.second.resize(num_bins);
+    }
+    graph.for_each_path_handle([&](const path_handle_t& path) {
+            auto& path_rank = path_prefix_rank[get_path_prefix(path)];
+            auto& row = table[path_rank].second;
+            // walk the path and aggregate
+            graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
+                    handle_t h = graph.get_handle_of_step(occ);
+                    uint64_t p = position_map[number_bool_packing::unpack_number(h)];
+                    uint64_t hl = graph.get_length(h);
+                    // make contects for the bases in the node
+                    //std::cerr << p << std::endl;
+                    for (uint64_t k = 0; k < hl; ++k) {
+                        double x = std::floor((double)(p+k)/(double)len * num_bins);
+                        ++row[x];
+                    }
+                });
+        });
+    double bp_per_bin = (double)len / (double)num_bins;
+    for (auto& row : table) {
+        for (auto& v : row.second) {
+            v /= bp_per_bin;
+        }
+    }
+}
+
+}
+}

--- a/src/algorithms/bin_path_info.hpp
+++ b/src/algorithms/bin_path_info.hpp
@@ -18,10 +18,16 @@ namespace algorithms {
 using namespace std;
 using namespace handlegraph;
 
-void bin_path_coverage(const PathHandleGraph& graph,
-                       const std::string& prefix_delimiter,
-                       const uint64_t& num_bins,
-                       std::vector<std::pair<std::string, std::vector<double>>>& table);
+struct pathinfo_t {
+    double mean_cov;
+    double mean_inv;
+    double mean_pos;
+};
+
+void bin_path_info(const PathHandleGraph& graph,
+                   const std::string& prefix_delimiter,
+                   const uint64_t& num_bins,
+                   std::vector<std::pair<std::string, std::vector<pathinfo_t>>>& table);
 
 }
 }

--- a/src/algorithms/bin_path_info.hpp
+++ b/src/algorithms/bin_path_info.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <vector>
+#include <utility>
+#include <algorithm>
+#include <limits>
+#include <cmath>
+#include <iostream>
+#include <unordered_set>
+#include <unordered_map>
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/util.hpp>
+#include <handlegraph/path_handle_graph.hpp>
+
+namespace odgi {
+namespace algorithms {
+
+using namespace std;
+using namespace handlegraph;
+
+void bin_path_coverage(const PathHandleGraph& graph,
+                       const std::string& prefix_delimiter,
+                       const uint64_t& num_bins,
+                       std::vector<std::pair<std::string, std::vector<double>>>& table);
+
+}
+}

--- a/src/subcommand/bin_main.cpp
+++ b/src/subcommand/bin_main.cpp
@@ -21,7 +21,8 @@ int main_bin(int argc, char** argv) {
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph in this file", {'o', "out"});
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
-    args::Flag coverage(parser, "coverage", "bin average path coverage across the graph", {'c', "coverage"});
+    // we now do both coverage and orientation
+    //args::Flag coverage(parser, "coverage", "bin average path coverage across the graph", {'c', "coverage"});
     args::ValueFlag<std::string> path_delim(parser, "path-delim", "sort paths in bins by their prefix up to this delemiter", {'D', "path-delim"});
     args::ValueFlag<uint64_t> num_bins(parser, "N", "number of bins", {'n', "num-bins"});
     try {
@@ -53,14 +54,16 @@ int main_bin(int argc, char** argv) {
     }
 
     // our aggregation matrix
-    std::vector<std::pair<std::string, std::vector<double>>> table;
-    if (args::get(coverage)) {
-        algorithms::bin_path_coverage(graph, args::get(path_delim), args::get(num_bins), table);
-    }
-    std::cout << "path.name" << "\t" << "bin" << "\t" << "mean.cov" << std::endl;
+    std::vector<std::pair<std::string, std::vector<algorithms::pathinfo_t>>> table;
+    algorithms::bin_path_info(graph, args::get(path_delim), args::get(num_bins), table);
+    std::cout << "path.name" << "\t" << "bin" << "\t" << "mean.cov" << "\t" << "mean.inv" << "\t" << "mean.pos" << std::endl;
     for (auto& row : table) {
         for (uint64_t i = 0; i < row.second.size(); ++i) {
-            std::cout << row.first << "\t" << i+1 << "\t" << row.second[i] << std::endl;
+            auto& info = row.second[i];
+            if (info.mean_cov) {
+                auto& name = row.first;
+                std::cout << name << "\t" << i+1 << "\t" << info.mean_cov << "\t" << info.mean_inv << "\t" << info.mean_pos << std::endl;
+            }
         }
     }
 

--- a/src/subcommand/bin_main.cpp
+++ b/src/subcommand/bin_main.cpp
@@ -1,0 +1,74 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include "algorithms/bin_path_info.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_bin(int argc, char** argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc-1; ++i) {
+        argv[i] = argv[i+1];
+    }
+    std::string prog_name = "odgi bin";
+    argv[0] = (char*)prog_name.c_str();
+    --argc;
+    
+    args::ArgumentParser parser("binning of path information in the graph");
+    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+    args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph in this file", {'o', "out"});
+    args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+    args::Flag coverage(parser, "coverage", "bin average path coverage across the graph", {'c', "coverage"});
+    args::ValueFlag<std::string> path_delim(parser, "path-delim", "sort paths in bins by their prefix up to this delemiter", {'D', "path-delim"});
+    args::ValueFlag<uint64_t> num_bins(parser, "N", "number of bins", {'n', "num-bins"});
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc==1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    graph_t graph;
+    assert(argc > 0);
+    std::string infile = args::get(dg_in_file);
+    if (infile.size()) {
+        if (infile == "-") {
+            graph.load(std::cin);
+        } else {
+            ifstream f(infile.c_str());
+            graph.load(f);
+            f.close();
+        }
+    }
+
+    // our aggregation matrix
+    std::vector<std::pair<std::string, std::vector<double>>> table;
+    if (args::get(coverage)) {
+        algorithms::bin_path_coverage(graph, args::get(path_delim), args::get(num_bins), table);
+    }
+    std::cout << "path.name" << "\t" << "bin" << "\t" << "mean.cov" << std::endl;
+    for (auto& row : table) {
+        for (uint64_t i = 0; i < row.second.size(); ++i) {
+            std::cout << row.first << "\t" << i+1 << "\t" << row.second[i] << std::endl;
+        }
+    }
+
+    return 0;
+}
+
+static Subcommand odgi_bin("bin", "bin path information across the graph",
+                              PIPELINE, 3, main_bin);
+
+
+}


### PR DESCRIPTION
Provides binning that you can use to do things like this:

```
odgi bin -i seqwish_yeast_l10k.dg -c -n 10000 >seqwish_yeast_l10k.dg.pathcov.tsv
```

In R:

```
require(ggplot2)
seqwish.yeast <- read.delim('seqwish_yeast_l10k.dg.pathcov.tsv')
ggplot(seqwish.yeast, aes(y=path.name, x=bin, color=mean.cov)) + geom_tile() + scale_color_gradientn(colors=c("white", "black", "blue", "green", "red")) + theme_bw() + theme(axis.ticks.y=element_blank())
```

Makes this plot:

![seqwish_yeast_l10k dg pathcov tsv](https://user-images.githubusercontent.com/145425/63979298-878b6a00-ca86-11e9-9eb8-2737de50e67d.png)
