### PR TITLE
more improvements to sorting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,17 @@ ExternalProject_Add(picosha256
 ExternalProject_Get_property(picosha256 SOURCE_DIR)
 set(picosha256_INCLUDE "${SOURCE_DIR}")
 
+# SGD based graph layout
+ExternalProject_Add(sgd2
+  GIT_REPOSITORY "https://github.com/ekg/sgd2.git"
+  GIT_TAG "3cb6ffe65dc14bf580866519e62d9b52964bdcae"
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND ""
+  CONFIGURE_COMMAND "")
+ExternalProject_Get_property(sgd2 SOURCE_DIR)
+set(sgd2_INCLUDE "${SOURCE_DIR}/src")
+
 # pybind11
 #ExternalProject_Add(pybind11
 #    GIT_REPOSITORY https://github.com/pybind/pybind11.git 
@@ -304,7 +315,8 @@ set(odgi_DEPS
     lodepng
     structures
     sonlib
-    picosha256)
+    picosha256
+    sgd2)
 add_dependencies(odgi_objs ${odgi_DEPS})
 
 set(odgi_INCLUDES
@@ -326,7 +338,8 @@ set(odgi_INCLUDES
   "${structures_INCLUDE}"
   "${sonLib_lib_INCLUDE}"
   "${sonLib_inc_INCLUDE}"
-  "${picosha256_INCLUDE}")
+  "${picosha256_INCLUDE}"
+  "${sgd2_INCLUDE}")
 
 set(odgi_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,8 +254,8 @@ set(mondriaan_LIB "${SOURCE_DIR}/lib")
 #set(pybind11_DIR ${SOURCE_DIR})
 #add_subdirectory(${pybind11_DIR})
 
-set(CMAKE_BUILD_TYPE Release)
-#set(CMAKE_BUILD_TYPE Debug)
+#set(CMAKE_BUILD_TYPE Release)
+set(CMAKE_BUILD_TYPE Debug)
 
 # set up our target executable and specify its dependencies and includes
 add_library(odgi_objs OBJECT
@@ -301,6 +301,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/cycle_breaking_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/eades_algorithm.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/dagify.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/split_strands.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/strongly_connected_components.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/weakly_connected_components.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/dfs.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,7 @@ set(gfakluge_LIB "${INSTALL_DIR}/src/gfakluge")
 # libhandlegraph (full build using its cmake config)
 ExternalProject_Add(handlegraph
   GIT_REPOSITORY "https://github.com/vgteam/libhandlegraph.git"
-  GIT_TAG "5756a2cd1819917559b2a421d5bb99ff30c9b061"
+  GIT_TAG "47791b556bb963d7f1922548cf512749e59dab86"
   CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_DIR}
   UPDATE_COMMAND ""
   INSTALL_COMMAND "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/prune.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/coverage.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/cycle_breaking_sort.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/random_order.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/eades_algorithm.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/dagify.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/split_strands.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,15 @@ ExternalProject_Add(sgd2
 ExternalProject_Get_property(sgd2 SOURCE_DIR)
 set(sgd2_INCLUDE "${SOURCE_DIR}/src")
 
+ExternalProject_Add(mondriaan
+  GIT_REPOSITORY "https://github.com/ekg/mondriaan.git"
+  GIT_TAG "7d840484ec49b31c99d5ab5c72a737596d82aa4e"
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND "")
+ExternalProject_Get_property(mondriaan SOURCE_DIR)
+set(mondriaan_INCLUDE "${SOURCE_DIR}/src")
+set(mondriaan_LIB "${SOURCE_DIR}/lib")
+
 # pybind11
 #ExternalProject_Add(pybind11
 #    GIT_REPOSITORY https://github.com/pybind/pybind11.git 
@@ -300,6 +309,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/simple_components.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/bin_path_info.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/sgd_layout.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/mondriaan_sort.cpp
   )
 
 set(odgi_DEPS 
@@ -318,7 +328,8 @@ set(odgi_DEPS
     structures
     sonlib
     picosha256
-    sgd2)
+    sgd2
+    mondriaan)
 add_dependencies(odgi_objs ${odgi_DEPS})
 
 set(odgi_INCLUDES
@@ -341,7 +352,8 @@ set(odgi_INCLUDES
   "${sonLib_lib_INCLUDE}"
   "${sonLib_inc_INCLUDE}"
   "${picosha256_INCLUDE}"
-  "${sgd2_INCLUDE}")
+  "${sgd2_INCLUDE}"
+  "${mondriaan_INCLUDE}")
 
 set(odgi_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"
@@ -352,6 +364,7 @@ set(odgi_LIBS
   "${sonLib_LIB}/stPinchesAndCacti.a"
   "${sonLib_LIB}/3EdgeConnected.a"
   "${sonLib_LIB}/sonLib.a"
+  "${mondriaan_LIB}/libmondriaan.a"
   "-ldl")
 
 target_include_directories(odgi_objs PUBLIC ${odgi_INCLUDES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,8 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/bin_path_info.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/sgd_layout.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/mondriaan_sort.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/matrix_writer.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/temp_file.cpp
   )
 
 set(odgi_DEPS 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/random_order.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/eades_algorithm.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/dagify.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/dagify_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/split_strands.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/strongly_connected_components.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/weakly_connected_components.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/bin_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/matrix_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/chop_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/layout_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp
@@ -298,6 +299,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/id_ordered_paths.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/simple_components.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/bin_path_info.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/sgd_layout.cpp
   )
 
 set(odgi_DEPS 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,16 +121,6 @@ ExternalProject_Add(tayweeargs
 ExternalProject_Get_property(tayweeargs SOURCE_DIR)
 set(tayweeargs_INCLUDE "${SOURCE_DIR}")
 
-# parallel bsort (header-only, so here we just check if we can build it)
-ExternalProject_Add(bsort
-  GIT_REPOSITORY "https://github.com/ekg/bsort.git"
-  GIT_TAG "c3ab0d3308424030e0a000645a26d2c10a59a124"
-  UPDATE_COMMAND ""
-  INSTALL_COMMAND "")
-ExternalProject_Get_property(bsort SOURCE_DIR)
-set(bsort_INCLUDE "${SOURCE_DIR}/src")
-set(bsort_LIB "${SOURCE_DIR}/lib")
-
 # BBHash perfect hasher
 ExternalProject_Add(bbhash
   GIT_REPOSITORY "https://github.com/vgteam/BBHash.git"
@@ -311,7 +301,6 @@ set(odgi_DEPS
     sparsepp
     ska
     intervaltree
-    bsort
     lodepng
     structures
     sonlib
@@ -334,7 +323,6 @@ set(odgi_INCLUDES
   "${intervaltree_INCLUDE}"
   "${lodepng_INCLUDE}"
   "${bbhash_INCLUDE}"
-  "${bsort_INCLUDE}"
   "${structures_INCLUDE}"
   "${sonLib_lib_INCLUDE}"
   "${sonLib_inc_INCLUDE}"

--- a/src/algorithms/dagify.cpp
+++ b/src/algorithms/dagify.cpp
@@ -9,116 +9,114 @@ namespace algorithms {
 using namespace handlegraph;
 
 
-    ska::flat_hash_map<handlegraph::nid_t, handlegraph::nid_t> dagify(const HandleGraph* graph, MutableHandleGraph* into,
-                                                               size_t min_preserved_path_length) {
+ska::flat_hash_map<handlegraph::nid_t, handlegraph::nid_t> dagify(const HandleGraph* graph, MutableHandleGraph* into,
+                                                                  size_t min_preserved_path_length) {
         
-        // initialize the translator from the dagified graph back to the original graph
-        ska::flat_hash_map<handlegraph::nid_t, handlegraph::nid_t> translator;
+    // initialize the translator from the dagified graph back to the original graph
+    ska::flat_hash_map<handlegraph::nid_t, handlegraph::nid_t> translator;
         
-        // generate a canonical orientation across the graph
-        std::vector<handle_t> orientation = single_stranded_orientation(graph);
+    // generate a canonical orientation across the graph
+    std::vector<handle_t> orientation = single_stranded_orientation(graph);
 
-        /*
-        if (orientation.size() < graph->get_node_count()) {
-            cerr << "error:[dagify] Dagify algorithm only valid on graphs with a single stranded orientation, consider using split_strands first" << endl;
-            exit(1);
-        }
-        */
-        
+    if (orientation.size() < graph->get_node_count()) {
+        cerr << "error:[dagify] Dagify algorithm only valid on graphs with a single stranded orientation, consider using split_strands first" << endl;
+        exit(1);
+    }
+
 #ifdef debug_dagify
-        cerr << "got canonical orientation:" << endl;
-        for (const handle_t& h : orientation) {
+    cerr << "got canonical orientation:" << endl;
+    for (const handle_t& h : orientation) {
+        cerr << "\t" << graph->get_id(h) << (graph->get_is_reverse(h) ? "-" : "+") << endl;
+    }
+#endif
+
+    // mark the ones that whose canonical orientation is reversed
+    ska::flat_hash_set<handlegraph::nid_t> reversed_nodes;
+    for (size_t i = 0; i < orientation.size(); i++) {
+        if (graph->get_is_reverse(orientation[i])) {
+            reversed_nodes.insert(graph->get_id(orientation[i]));
+        }
+    }
+
+    // find the strongly connected components of the original graph
+    std::vector<ska::flat_hash_set<handlegraph::nid_t>> strong_components = strongly_connected_components(graph);
+
+#ifdef debug_dagify
+    cerr << "got strongly connected components:" << endl;
+    for (size_t i = 0; i < strong_components.size(); i++) {
+        cerr << "\tcomponent " << i << endl;
+        for (handlegraph::nid_t nid : strong_components[i]) {
+            cerr << "\t\t" << nid << endl;
+        }
+    }
+#endif
+        
+    // duplicate strongly connected components into the dagified graph in such a way
+    // that paths are preserved
+        
+    // a tracker for which SCC a node belongs to
+    ska::flat_hash_map<handlegraph::nid_t, size_t> component_of;
+    // a map from a node in the original graph to all its copies (in order) in the
+    // dagified graph
+    ska::flat_hash_map<handle_t, std::vector<handle_t>> injector;
+    for (size_t i = 0; i < strong_components.size(); i++) {
+            
+#ifdef debug_dagify
+        cerr << "handling component " << i << endl;
+#endif
+            
+        // keep track of which nodes are in which component (for later)
+        auto& component = strong_components[i];
+        for (handlegraph::nid_t node_id : component) {
+            component_of[node_id] = i;
+        }
+            
+        // figure out how many times we need to copy this SCC
+            
+        // wrap the SCC in a handle graph
+        SubHandleGraph subgraph(graph);
+        for (const handlegraph::nid_t& node_id : component) {
+            subgraph.add_handle(graph->get_handle(node_id));
+        }
+
+        // get a layout with a low FAS, generic to any kind of graph
+        std::vector<handle_t> layout;
+        // but only if it's large enough to justify our dynamic data structure costs
+        if (subgraph.get_node_count() > 1000) {
+            layout = topological_order(&subgraph, false, false); // sort without heads or tails
+        } else {
+            subgraph.for_each_handle([&](const handle_t& handle) { layout.push_back(handle); });
+        }
+
+        // make sure the layout matches the canonical orientation of the graph
+        if (graph->get_is_reverse(layout.front()) != reversed_nodes.count(graph->get_id(layout.front()))) {
+            for (int64_t i = 0, j = layout.size() - 1; i < j; i++, j--) {
+                auto tmp = layout[i];
+                layout[i] = subgraph.flip(layout[j]);
+                layout[j] = subgraph.flip(tmp);
+            }
+            if (layout.size() % 2) {
+                layout[layout.size() / 2] = subgraph.flip(layout[layout.size() / 2]);
+            }
+        }
+            
+#ifdef debug_dagify
+        cerr << "layout for component:" << endl;
+        for (const handle_t& h : layout) {
             cerr << "\t" << graph->get_id(h) << (graph->get_is_reverse(h) ? "-" : "+") << endl;
         }
 #endif
-        
-        // mark the ones that whose canonical orientation is reversed
-        ska::flat_hash_set<handlegraph::nid_t> reversed_nodes;
-        for (size_t i = 0; i < orientation.size(); i++) {
-            if (graph->get_is_reverse(orientation[i])) {
-                reversed_nodes.insert(graph->get_id(orientation[i]));
-            }
+
+        // record the ordering of the layout so we can identify backward edges
+        ska::flat_hash_map<handle_t, size_t> ordering;
+        for (size_t i = 0; i < layout.size(); i++) {
+            ordering[layout[i]] = i;
         }
-        
-        // find the strongly connected components of the original graph
-        std::vector<ska::flat_hash_set<handlegraph::nid_t>> strong_components = strongly_connected_components(graph);
-        
-#ifdef debug_dagify
-        cerr << "got strongly connected components:" << endl;
-        for (size_t i = 0; i < strong_components.size(); i++) {
-            cerr << "\tcomponent " << i << endl;
-            for (handlegraph::nid_t nid : strong_components[i]) {
-                cerr << "\t\t" << nid << endl;
-            }
-        }
-#endif
-        
-        // duplicate strongly connected components into the dagified graph in such a way
-        // that paths are preserved
-        
-        // a tracker for which SCC a node belongs to
-        ska::flat_hash_map<handlegraph::nid_t, size_t> component_of;
-        // a map from a node in the original graph to all its copies (in order) in the
-        // dagified graph
-        ska::flat_hash_map<handle_t, std::vector<handle_t>> injector;
-        for (size_t i = 0; i < strong_components.size(); i++) {
-            
-#ifdef debug_dagify
-            cerr << "handling component " << i << endl;
-#endif
-            
-            // keep track of which nodes are in which component (for later)
-            auto& component = strong_components[i];
-            for (handlegraph::nid_t node_id : component) {
-                component_of[node_id] = i;
-            }
-            
-            // figure out how many times we need to copy this SCC
-            
-            // wrap the SCC in a handle graph
-            SubHandleGraph subgraph(graph);
-            for (const handlegraph::nid_t& node_id : component) {
-                subgraph.add_handle(graph->get_handle(node_id));
-            }
-            
-            // get a layout with a low FAS, generic to any kind of graph
-            std::vector<handle_t> layout;
-            // but only if it's large enough to justify our dynamic data structure costs
-            if (subgraph.get_node_count() > 1000) {
-                layout = topological_order(&subgraph, false, false); // sort without heads or tails
-            } else {
-                subgraph.for_each_handle([&](const handle_t& handle) { layout.push_back(handle); });
-            }
-            
-            // make sure the layout matches the canonical orientation of the graph
-            if (graph->get_is_reverse(layout.front()) != reversed_nodes.count(graph->get_id(layout.front()))) {
-                for (int64_t i = 0, j = layout.size() - 1; i < j; i++, j--) {
-                    auto tmp = layout[i];
-                    layout[i] = subgraph.flip(layout[j]);
-                    layout[j] = subgraph.flip(tmp);
-                }
-                if (layout.size() % 2) {
-                    layout[layout.size() / 2] = subgraph.flip(layout[layout.size() / 2]);
-                }
-            }
-            
-#ifdef debug_dagify
-            cerr << "layout for component:" << endl;
-            for (const handle_t& h : layout) {
-                cerr << "\t" << graph->get_id(h) << (graph->get_is_reverse(h) ? "-" : "+") << endl;
-            }
-#endif
-            
-            // record the ordering of the layout so we can identify backward edges
-            ska::flat_hash_map<handle_t, size_t> ordering;
-            for (size_t i = 0; i < layout.size(); i++) {
-                ordering[layout[i]] = i;
-            }
-            
-            // mark the edges as either forward or backward relative to the layout
-            std::vector<std::vector<size_t>> forward_edges(layout.size());
-            std::vector<pair<size_t, size_t>> backward_edges;
-            subgraph.for_each_edge([&](const edge_t& edge) {
+
+        // mark the edges as either forward or backward relative to the layout
+        std::vector<std::vector<size_t>> forward_edges(layout.size());
+        std::vector<std::pair<size_t, size_t>> backward_edges;
+        subgraph.for_each_edge([&](const edge_t& edge) {
                 // get the indices of the edge in the layout, making sure to match
                 // the canonical orientation
                 size_t i, j;
@@ -144,138 +142,138 @@ using namespace handlegraph;
                 return true;
             });
             
-            // check for each node whether we've duplicated the component enough times
-            // to preserve its cycles
+        // check for each node whether we've duplicated the component enough times
+        // to preserve its cycles
             
-            // dynamic progamming structures that represent distances within the current
-            // copy of the SCC and the next copy
-            std::vector<int64_t> distances(layout.size(), numeric_limits<int64_t>::max());
-            std::vector<int64_t> next_distances(layout.size(), numeric_limits<int64_t>::max());
+        // dynamic progamming structures that represent distances within the current
+        // copy of the SCC and the next copy
+        std::vector<int64_t> distances(layout.size(), numeric_limits<int64_t>::max());
+        std::vector<int64_t> next_distances(layout.size(), numeric_limits<int64_t>::max());
             
-            // init the distances so that we are measuring from the end of the heads of
-            // backward edges (which cross to the next copy of the SCC)
-            for (const pair<size_t, size_t>& bwd_edge : backward_edges) {
-                handle_t handle = layout[bwd_edge.first];
-                distances[ordering[handle]] = -subgraph.get_length(handle);
-            }
+        // init the distances so that we are measuring from the end of the heads of
+        // backward edges (which cross to the next copy of the SCC)
+        for (const pair<size_t, size_t>& bwd_edge : backward_edges) {
+            handle_t handle = layout[bwd_edge.first];
+            distances[ordering[handle]] = -subgraph.get_length(handle);
+        }
             
-            // init the tracker that we use for the bail-out condition
-            int64_t min_relaxed_dist = -1;
+        // init the tracker that we use for the bail-out condition
+        int64_t min_relaxed_dist = -1;
             
-            // add copies until the minimum distance to the new copy is longer than the distance we're
-            // trying to preserve
-            for (size_t copy_num = 0; min_relaxed_dist < int64_t(min_preserved_path_length); copy_num++) {
+        // add copies until the minimum distance to the new copy is longer than the distance we're
+        // trying to preserven
+        for (size_t copy_num = 0; min_relaxed_dist < int64_t(min_preserved_path_length); copy_num++) {
                 
 #ifdef debug_dagify
-                cerr << "copy number " << copy_num << endl;
+            cerr << "copy number " << copy_num << endl;
 #endif
                 
-                // do we need a new copy of this SCC to preserve paths?
-                if (copy_num == injector[layout.front()].size()) {
-                    // we haven't added this copy of the connected component yet
+            // do we need a new copy of this SCC to preserve paths?
+            if (copy_num == injector[layout.front()].size()) {
+                // we haven't added this copy of the connected component yet
                     
 #ifdef debug_dagify
-                    cerr << "adding nodes for this copy" << endl;
+                cerr << "adding nodes for this copy" << endl;
 #endif
                     
-                    // add the nodes
-                    for (const handle_t& original_handle : layout) {
-                        // create the node in the same foward orientation as the original
-                        handle_t new_handle = into->create_handle(graph->get_sequence(graph->forward(original_handle)));
-                        // use the handle locally in the same orientation as it is in the layout
-                        if (graph->get_is_reverse(original_handle)) {
-                            new_handle = into->flip(new_handle);
-                        }
+                // add the nodes
+                for (const handle_t& original_handle : layout) {
+                    // create the node in the same foward orientation as the original
+                    handle_t new_handle = into->create_handle(graph->get_sequence(graph->forward(original_handle)));
+                    // use the handle locally in the same orientation as it is in the layout
+                    if (graph->get_is_reverse(original_handle)) {
+                        new_handle = into->flip(new_handle);
+                    }
 #ifdef debug_dagify
-                        cerr << "\t" << graph->get_id(original_handle) << " duplicated to " << into->get_id(new_handle) << endl;
+                    cerr << "\t" << graph->get_id(original_handle) << " duplicated to " << into->get_id(new_handle) << endl;
 #endif
                         
-                        // record the translation between the graphs
-                        translator[into->get_id(new_handle)] = graph->get_id(original_handle);
-                        injector[original_handle].push_back(new_handle);
-                    }
-                    
-                    // add the forward edges within this copy
-                    for (size_t i = 0; i < forward_edges.size(); i++) {
-                        handle_t from = injector[layout[i]].back();
-                        for (const size_t& j : forward_edges[i]) {
-                            into->create_edge(from, injector[layout[j]].back());
-#ifdef debug_dagify
-                            cerr << "\t\tfwd edge " << into->get_id(from) << (into->get_is_reverse(from) ? "-" : "+") << " -> " << into->get_id(injector[layout[j]].back()) << (into->get_is_reverse(injector[layout[j]].back()) ? "-" : "+") << endl;
-#endif
-                        }
-                    }
-                    
-                    // is there a previous copy?
-                    if (copy_num > 0) {
-                        // add the backward edges between the copies
-                        for (const pair<size_t, size_t>& bwd_edge : backward_edges) {
-                            const auto& from_copies = injector[layout[bwd_edge.first]];
-                            into->create_edge(from_copies[from_copies.size() - 2],
-                                              injector[layout[bwd_edge.second]].back());
-#ifdef debug_dagify
-                            cerr << "\t\tbwd edge " << into->get_id(from_copies[from_copies.size() - 2]) << (into->get_is_reverse(from_copies[from_copies.size() - 2]) ? "-" : "+") << " -> " << into->get_id(injector[layout[bwd_edge.second]].back()) << (into->get_is_reverse(injector[layout[bwd_edge.second]].back()) ? "-" : "+") << endl;
-#endif
-                        }
-                    }
+                    // record the translation between the graphs
+                    translator[into->get_id(new_handle)] = graph->get_id(original_handle);
+                    injector[original_handle].push_back(new_handle);
                 }
-                
-                // we've finished adding the copy of the SCC that corresponds to this iteration
-                // now we will do the dynamic programming to bound the distance to the next SCC
-                
-                // find the shortest path to the nodes, staying within this copy of the SCC
-                for (size_t i = 0; i < distances.size(); i++) {
-                    // skip infinity to avoid overflow
-                    if (distances[i] == numeric_limits<int64_t>::max()) {
-                        continue;
-                    }
                     
-                    int64_t dist_thru = distances[i] + subgraph.get_length(layout[i]);
+                // add the forward edges within this copy
+                for (size_t i = 0; i < forward_edges.size(); i++) {
+                    handle_t from = injector[layout[i]].back();
                     for (const size_t& j : forward_edges[i]) {
-                        distances[j] = min(distances[j], dist_thru);
+                        into->create_edge(from, injector[layout[j]].back());
+#ifdef debug_dagify
+                        cerr << "\t\tfwd edge " << into->get_id(from) << (into->get_is_reverse(from) ? "-" : "+") << " -> " << into->get_id(injector[layout[j]].back()) << (into->get_is_reverse(injector[layout[j]].back()) ? "-" : "+") << endl;
+#endif
                     }
                 }
-                
-                // now find the minimum distance to nodes in the next copy of the SCC (which
-                // may not yet be created in the graph)
-                min_relaxed_dist = numeric_limits<int64_t>::max();
-                for (const pair<size_t, size_t>& bwd_edge : backward_edges) {
-                    // skip infinity to avoid overflow
-                    if (distances[bwd_edge.first] == numeric_limits<int64_t>::max()) {
-                        continue;
-                    }
                     
-                    int64_t dist_thru = distances[bwd_edge.first] + subgraph.get_length(layout[bwd_edge.first]);
-                    if (dist_thru < next_distances[bwd_edge.second]) {
-                        next_distances[bwd_edge.second] = dist_thru;
-                        // keep track of the shortest distance to the next copy
-                        min_relaxed_dist = min(min_relaxed_dist, dist_thru);
+                // is there a previous copy?
+                if (copy_num > 0) {
+                    // add the backward edges between the copies
+                    for (const pair<size_t, size_t>& bwd_edge : backward_edges) {
+                        const auto& from_copies = injector[layout[bwd_edge.first]];
+                        into->create_edge(from_copies[from_copies.size() - 2],
+                                          injector[layout[bwd_edge.second]].back());
+#ifdef debug_dagify
+                        cerr << "\t\tbwd edge " << into->get_id(from_copies[from_copies.size() - 2]) << (into->get_is_reverse(from_copies[from_copies.size() - 2]) ? "-" : "+") << " -> " << into->get_id(injector[layout[bwd_edge.second]].back()) << (into->get_is_reverse(injector[layout[bwd_edge.second]].back()) ? "-" : "+") << endl;
+#endif
                     }
                 }
+            }
+                
+            // we've finished adding the copy of the SCC that corresponds to this iteration
+            // now we will do the dynamic programming to bound the distance to the next SCC
+                
+            // find the shortest path to the nodes, staying within this copy of the SCC
+            for (size_t i = 0; i < distances.size(); i++) {
+                // skip infinity to avoid overflow
+                if (distances[i] == numeric_limits<int64_t>::max()) {
+                    continue;
+                }
+                    
+                int64_t dist_thru = distances[i] + subgraph.get_length(layout[i]);
+                for (const size_t& j : forward_edges[i]) {
+                    distances[j] = min(distances[j], dist_thru);
+                }
+            }
+                
+            // now find the minimum distance to nodes in the next copy of the SCC (which
+            // may not yet be created in the graph)
+            min_relaxed_dist = numeric_limits<int64_t>::max();
+            for (const pair<size_t, size_t>& bwd_edge : backward_edges) {
+                // skip infinity to avoid overflow
+                if (distances[bwd_edge.first] == numeric_limits<int64_t>::max()) {
+                    continue;
+                }
+                    
+                int64_t dist_thru = distances[bwd_edge.first] + subgraph.get_length(layout[bwd_edge.first]);
+                if (dist_thru < next_distances[bwd_edge.second]) {
+                    next_distances[bwd_edge.second] = dist_thru;
+                    // keep track of the shortest distance to the next copy
+                    min_relaxed_dist = min(min_relaxed_dist, dist_thru);
+                }
+            }
                 
 #ifdef debug_dagify
-                cerr << "distances within component" << endl;
-                for (size_t i = 0; i < distances.size(); i++) {
-                    cerr << "\t" << graph->get_id(layout[i]) << (graph->get_is_reverse(layout[i]) ? "-" : "+") << " " << distances[i] << endl;
-                }
-                cerr << "distances to next component" << endl;
-                for (size_t i = 0; i < next_distances.size(); i++) {
-                    cerr << "\t" << graph->get_id(layout[i]) << (graph->get_is_reverse(layout[i]) ? "-" : "+") << " " << next_distances[i] << endl;
-                }
+            cerr << "distances within component" << endl;
+            for (size_t i = 0; i < distances.size(); i++) {
+                cerr << "\t" << graph->get_id(layout[i]) << (graph->get_is_reverse(layout[i]) ? "-" : "+") << " " << distances[i] << endl;
+            }
+            cerr << "distances to next component" << endl;
+            for (size_t i = 0; i < next_distances.size(); i++) {
+                cerr << "\t" << graph->get_id(layout[i]) << (graph->get_is_reverse(layout[i]) ? "-" : "+") << " " << next_distances[i] << endl;
+            }
 #endif
                 
-                // initialize the DP structures for the next iteration
-                distances = move(next_distances);
-                next_distances.assign(distances.size(), numeric_limits<int64_t>::max());
-            }
+            // initialize the DP structures for the next iteration
+            distances = move(next_distances);
+            next_distances.assign(distances.size(), numeric_limits<int64_t>::max());
         }
+    }
         
 #ifdef debug_dagify
-        cerr << "adding edges between SCCs" << endl;
+    cerr << "adding edges between SCCs" << endl;
 #endif
 
-        // add edges between the strongly connected components
-        graph->for_each_edge([&](const edge_t& canonical_edge) {
+    // add edges between the strongly connected components
+    graph->for_each_edge([&](const edge_t& canonical_edge) {
             if (component_of[graph->get_id(canonical_edge.first)] != component_of[graph->get_id(canonical_edge.second)]) {
                 // this edge is between SCCs
                 
@@ -302,9 +300,9 @@ using namespace handlegraph;
             return true;
         });
         
-        // return the ID translator
-        return translator;
-    }
+    // return the ID translator
+    return translator;
+}
 }
 }
 

--- a/src/algorithms/dagify.cpp
+++ b/src/algorithms/dagify.cpp
@@ -83,8 +83,9 @@ using namespace handlegraph;
             
             // get a layout with a low FAS, generic to any kind of graph
             std::vector<handle_t> layout;
+            // but only if it's large enough to justify our dynamic data structure costs
             if (subgraph.get_node_count() > 1000) {
-                layout = topological_order(&subgraph);
+                layout = topological_order(&subgraph, false, false); // sort without heads or tails
             } else {
                 subgraph.for_each_handle([&](const handle_t& handle) { layout.push_back(handle); });
             }

--- a/src/algorithms/dagify.hpp
+++ b/src/algorithms/dagify.hpp
@@ -8,6 +8,7 @@
 #include "eades_algorithm.hpp"
 #include "strongly_connected_components.hpp"
 #include "is_single_stranded.hpp"
+#include "topological_sort.hpp"
 //#include <unordered_map>
 
 namespace odgi {

--- a/src/algorithms/dagify_sort.cpp
+++ b/src/algorithms/dagify_sort.cpp
@@ -4,18 +4,19 @@ namespace odgi {
 namespace algorithms {
 
 std::vector<handle_t> dagify_sort(const HandleGraph& base, MutableHandleGraph& split, MutableHandleGraph& into) {
-    //auto split_to_orig = algorithms::split_strands(&base, &split);
-    auto dagified_to_base = algorithms::dagify(&base, &into, 1);
+    auto split_to_orig = algorithms::split_strands(&base, &split);
+    auto dagified_to_split = algorithms::dagify(&split, &into, 1);
     auto dagified_to_orig = [&](handlegraph::nid_t id) {
-        //return split_to_orig[dagified_to_split[id]];
-        return dagified_to_base[id];
+        return split_to_orig[dagified_to_split[id]];
     };
     auto order = algorithms::topological_order(&into, true, false);
     // find the mean position in the order for each original handle
     ska::flat_hash_map<handlegraph::nid_t, std::pair<uint64_t, uint64_t>> pos_accum;
     for (uint64_t i = 0; i < order.size(); ++i) {
         auto& handle = order[i];
-        handlegraph::nid_t id = dagified_to_orig(into.get_id(handle));
+        auto e = dagified_to_orig(into.get_id(handle));
+        if (e.second) continue;
+        handlegraph::nid_t id = e.first;
         pos_accum[id].first += i;
         ++pos_accum[id].second;
     }

--- a/src/algorithms/dagify_sort.cpp
+++ b/src/algorithms/dagify_sort.cpp
@@ -1,0 +1,33 @@
+#include "dagify_sort.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+std::vector<handle_t> dagify_sort(const HandleGraph& base, MutableHandleGraph& split, MutableHandleGraph& into) {
+    auto split_to_orig = algorithms::split_strands(&base, &split);
+    auto dagified_to_split = algorithms::dagify(&split, &into, 1);
+    auto dagified_to_orig = [&](handlegraph::nid_t id) {
+        return split_to_orig[dagified_to_split[id]];
+    };
+    auto order = algorithms::topological_order(&into, true, false);
+    // translate the order
+    std::reverse(order.begin(), order.end());
+    ska::flat_hash_set<handlegraph::nid_t> seen;
+    std::vector<handle_t> translated_order;
+    for (auto& handle : order) {
+        //assert(dagified_to_orig.find(into.get_id(handle)) != dagified_to_orig.end());
+        auto vs_orig = dagified_to_orig(into.get_id(handle));
+        handlegraph::nid_t id = vs_orig.first;
+        //assert(id > 0);
+        if (!seen.count(id)) {
+            translated_order.push_back(base.get_handle(id));
+            seen.insert(id);
+        }
+    }
+    std::reverse(translated_order.begin(), translated_order.end());
+    assert(translated_order.size() == base.get_node_count());
+    return translated_order;
+}
+
+}
+}

--- a/src/algorithms/dagify_sort.hpp
+++ b/src/algorithms/dagify_sort.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_handle_graph.hpp>
+#include "hash_map.hpp"
+#include "topological_sort.hpp"
+#include "split_strands.hpp"
+#include "dagify.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+std::vector<handle_t> dagify_sort(const HandleGraph& base, MutableHandleGraph& split, MutableHandleGraph& into);
+
+}
+}

--- a/src/algorithms/eades_algorithm.cpp
+++ b/src/algorithms/eades_algorithm.cpp
@@ -42,7 +42,7 @@ using namespace handlegraph;
         auto assign_bucket = [&](const int64_t& in_degree, const int64_t& out_degree) {
             return out_degree - in_degree + int64_t(canonical_orientation.size()) - 2;
         };
-        vector<list<handle_t>> delta_buckets(canonical_orientation.size() > 1 ? 2 * canonical_orientation.size() - 3 : 0);
+        map<int64_t, list<handle_t>> delta_buckets; //(canonical_orientation.size() > 1 ? 2 * canonical_orientation.size() - 3 : 0);
         
         
         vector<handle_t> sources;
@@ -224,7 +224,7 @@ using namespace handlegraph;
                 cerr << "adding node " << graph->get_id(next) << (graph->get_is_reverse(next) ? "-" : "+") << " from delta bucket " << max_delta_bucket << endl;
 #endif
                 
-                bucket.pop_back();
+                if (bucket.size()) bucket.pop_back();
                 degree_info.erase(next);
                 
                 // add it to the layout

--- a/src/algorithms/eades_algorithm.hpp
+++ b/src/algorithms/eades_algorithm.hpp
@@ -12,6 +12,7 @@
 
 #include <vector>
 #include <list>
+#include <map>
 #include <unordered_map>
 
 namespace odgi {

--- a/src/algorithms/matrix_writer.cpp
+++ b/src/algorithms/matrix_writer.cpp
@@ -1,0 +1,45 @@
+#include "matrix_writer.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+void write_as_sparse_matrix(std::ostream& out, const PathHandleGraph& graph, bool weight_by_edge_depth, bool weight_by_edge_delta) {
+    uint64_t edge_count = 0;
+    graph.for_each_edge([&](const edge_t& edge) {
+            ++edge_count;
+        });
+    out << graph.max_node_id() << " " << graph.max_node_id() << " " << edge_count*2 << std::endl;
+    graph.for_each_edge([&](const edge_t& edge) {
+            // how many paths cross the edge?
+            double weight = 0;
+            if (weight_by_edge_depth) {
+                graph.for_each_step_on_handle(edge.first, [&](const step_handle_t& step) {
+                        if (graph.get_handle_of_step(step) == edge.first
+                            && graph.has_next_step(step)) {
+                            handle_t next = graph.get_handle_of_step(graph.get_next_step(step));
+                            if (next == edge.second) {
+                                ++weight;
+                            }
+                        } else if (graph.get_handle_of_step(step) == graph.flip(edge.first)
+                                   && graph.has_previous_step(step)) {
+                            handle_t prev = graph.get_handle_of_step(graph.get_previous_step(step));
+                            if (prev == graph.flip(edge.second)) {
+                                ++weight;
+                            }
+                        }
+                    });
+            } else {
+                weight = 1;
+            }
+            if (weight_by_edge_delta) {
+                double delta = std::abs(graph.get_id(edge.first) - graph.get_id(edge.second));
+                if (delta == 0) delta = 1;
+                weight = 1 / delta;
+            }
+            out << graph.get_id(edge.first) << " " << graph.get_id(edge.second) << " " << weight << std::endl;
+            out << graph.get_id(edge.second) << " " << graph.get_id(edge.first) << " " << weight << std::endl;
+        });
+}
+
+}
+}

--- a/src/algorithms/matrix_writer.hpp
+++ b/src/algorithms/matrix_writer.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+/**
+ * \file matrix_writer.hpp
+ *
+ * Defines a function to write a graph as a sparse matrix
+ */
+
+#include <iostream>
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/path_handle_graph.hpp>
+#include <handlegraph/util.hpp>
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+void write_as_sparse_matrix(std::ostream& out, const PathHandleGraph& graph, bool weight_by_edge_depth, bool weight_by_edge_delta);
+
+}
+}

--- a/src/algorithms/mondriaan_sort.cpp
+++ b/src/algorithms/mondriaan_sort.cpp
@@ -1,0 +1,915 @@
+#include "mondriaan_sort.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+
+void mondriaan_main(int argc, char **argv) {
+
+    /* This function is the main function, called mondriaan. It partitions
+       a sparse matrix, a dense input vector, and a dense output vector
+       for the purpose of parallel sparse matrix-vector multiplication u = A*v.
+
+       The function tries to minimise the total communication volume
+       by suitably partitioning the matrix, while keeping the computation
+       load imbalance within a user-specified fraction epsilon.
+       For the resulting communication volume, it tries to balance
+       the communication work among the processors by suitably
+       partitioning the vectors. The partitioning of the input and output
+       vectors can either be done independently, or by imposing
+       distr(u) = distr(v).
+
+       The sparse matrix is read from file using the Matrix Market (MM) format.
+       Its partitioning is written to file using a variant of the MM format,
+       where all nonzeros belonging to the same processor are listed together.
+
+       If the input file is called
+           pi.mtx
+       and 4 processors are required, the following output files are produced:
+           pi.mtx-P4 containing the matrix distribution
+           pi.mtx-v4                input vector distribution
+           pi.mtx-u4                output vector distribution
+           pi.mtx-C4                Cartesian submatrices corresponding
+                                    to the matrix distribution
+       Furthermore, useful information on the partitioning process
+       and the result, such as the load imbalance and communication
+       volume obtained, is written to standard output.
+
+       The sparse matrix partitioner can also be used for partitioning
+       hypergraphs. To do this, Mondriaan must be used in 1D column mode. 
+       Matrix columns then represent hypergraph vertices; they can be given
+       integer weights. Matrix rows then represent hyperedges; they cannot
+       be given weights.
+
+       The following additional operations are carried out by the main program:
+           - timing the matrix and vector partitionings
+           - removing duplicate nonzeros
+           - (optionally) checking whether the matrix is structurally symmetric
+           - (optionally) expanding a symmetric matrix stored in lower
+             triangular format to a fully stored matrix
+           - (optionally) adding diagonal dummy nonzeros to a square matrix
+             to make the diagonal completely nonzero (thereby facilitating
+             the vector distribution with distr(u) = distr(v)).
+
+       All partitioning options and parameters can be set using
+       the file mondriaan.defaults (provided the main function is compiled
+       with the name mondriaan.) If no such file exists, it is created with
+       sensible defaults.
+
+       If the input matrix has already been partitioned, it will be
+       partitioned again, from scratch.
+ */
+
+    struct opts Options; /* The Mondriaan options */
+    struct sparsematrix A; /* The Matrix;-) */
+
+    long MinNrNzElts, MaxNrNzElts; /* minimum, maximum number of nonzero elements 
+                                       per processor */
+
+    long MinWeight, MaxWeight; /* minimum, maximum column weight */
+    long weight, i, j;
+    unsigned long int ui;
+    long int *temp;
+    long ComU, ComV; /* communication cost for vectors u, v  */
+    long q, nzq;     /* processor number and its corresponding number of nonzeros */
+    int weighted, symmetric; /* boolean registering whether the input matrix
+                                 was weighted, symmetric */
+
+    long int *u_proc, *v_proc;   /* vector distribution for u, v */
+    char output[MAX_WORD_LENGTH]; /* filename of the output */
+    char EMMcomment[2000]; /* Comments in EMM one-file output */
+    char EMMcomment_buffer[2000]; /* For string concatenation */
+    
+    long int **row_perms = NULL, **col_perms = NULL; /* Will store local to global index info */
+
+    /* Below is used for Extended Matrix-Market one-file output */
+    long int *inv_count, **row_local2proc, **row_local2index, **col_local2proc, **col_local2index;
+
+    FILE *File = NULL;
+    char stdinName[] = "stdin";
+    
+    /* Timing variables */
+#ifdef TIME
+    clock_t starttime, endtime;
+    double cputime;
+#endif
+#ifdef UNIX
+    struct timeval starttime1, endtime1;
+#endif
+#ifdef INFO
+    double AvgNrNzElts;  /* average number of nonzero matrix elements per processor */
+    double AvgWeight;    /* average column weight */
+    long TotWeight;      /* total column weight */
+#endif
+
+    /* Get the parameters from the command line and initialise Options */
+    SetDefaultOptions(&Options);
+    
+    if (!SetOptionsFromFile(&Options, "Mondriaan.defaults")) {
+        fprintf(stderr, "main(): warning, cannot set options from 'Mondriaan.defaults', using default options and creating standard 'Mondriaan.defaults'!\n");
+        
+        File = fopen("Mondriaan.defaults", "w");
+        
+        if (File != NULL) {
+            ExportDefaultOptions(File);
+            SetDefaultOptions(&Options);
+            fclose(File);
+        }
+        else {
+            fprintf(stderr, "main(): Unable to create 'Mondriaan.defaults'!\n");
+        }
+    }
+    
+    if (!GetParameters(&Options, argc, argv)) {
+        fprintf(stderr, "main(): invalid command line parameters!\n");
+        exit(-1);
+    }
+    
+    if (!ApplyOptions(&Options)) {
+        fprintf(stderr, "main(): could not apply given options!\n");
+        exit(-1);
+    }
+    
+    /* Read matrix file from disk or standard input. */
+    if (!strcmp(Options.matrix, "-") || !strcmp(Options.matrix, "stdin")) {
+        if (!MMReadSparseMatrix(stdin, &A)) {
+            fprintf(stderr, "main(): Could not read matrix from standard input!\n");
+            exit(-1);
+        }
+        
+        Options.matrix = stdinName;
+    }
+    else {
+        File = fopen(Options.matrix, "r");
+    
+        if (!File) {
+            fprintf(stderr, "main(): Unable to open '%s' for reading!\n", Options.matrix);
+            exit(-1);
+        }
+        
+        if (!MMReadSparseMatrix(File, &A)) {
+            fprintf(stderr, "main(): Could not read matrix!\n");
+            exit(-1);
+        }
+        
+        fclose(File);
+    }
+  
+#ifdef INFO
+    printf("\nUsing Mondriaan version %s.\n\n", MONDRIAANVERSION);
+    printf("\n**************************************************************\n");
+    printf("Problem statistics:\n");
+    printf("  Matrix:           : %s\n",Options.matrix);
+    printf("  %s %s %s %s %s\n", A.Banner,A.Object,A.Format,A.Field,A.Symmetry);
+    printf("  m = Nr rows       : %ld\n", A.m); 
+    printf("  n = Nr columns    : %ld\n", A.n); 
+    printf("  nz = Nr nonzeros  : %ld\n", A.NrNzElts);
+  
+    /* Check if matrix A is structurally symmetric */
+    if (SparseMatrixStructurallySymmetric(&A))
+        printf("  Matrix is structurally symmetric\n\n");
+    else
+        printf("  Matrix is structurally unsymmetric\n\n");
+#endif
+
+    /* Remove duplicate nonzeros by adding them */
+    if (!SparseMatrixRemoveDuplicates(&A)) {
+        fprintf(stderr, "main(): Unable to remove duplicates!\n");
+        exit(-1);
+    }
+
+    /* Check if matrix A is already distributed */
+    if (A.MMTypeCode[0] == 'D') {
+        /* Matrix will be partitioned again */
+        fprintf(stderr, "Warning: Matrix '%s' already distributed !\n", 
+                Options.matrix);
+        fprintf(stderr, "         (Ignoring current partitions)\n"); 
+        
+        A.NrProcs = 0;
+        if (A.Pstart != NULL)
+            free(A.Pstart);
+        A.Pstart = NULL;
+    }
+   
+    /* Check if matrix is weighted (thus representing a hypergraph).
+       In that case, it must have n column weights (representing vertex weights), 
+       0 row weights and the split strategy must be onedimcol */
+
+    if (A.MMTypeCode[0] == 'W' && A.NrColWeights != A.n) {
+        fprintf(stderr, "main(): Weighted matrix with NrColWeights != n!\n");
+        exit(-1);
+    }
+
+    if (A.MMTypeCode[0] == 'W' && A.NrRowWeights != 0) {
+        fprintf(stderr, "Warning: Matrix '%s' has row weights!\n",
+                Options.matrix);
+        fprintf(stderr, "         Row-weighted column partitioning not yet implemented\n");
+        fprintf(stderr, "         (Ignoring row weights)\n");
+                
+        A.NrRowWeights = 0;
+        if (A.RowWeights != NULL)
+            free(A.RowWeights);
+        A.RowWeights = NULL;
+    }
+
+    if (A.MMTypeCode[0] == 'W' && Options.SplitStrategy != opts::OneDimCol) {
+        fprintf(stderr, "Warning: Matrix '%s' is a weighted matrix!\n", Options.matrix);
+        fprintf(stderr, "         must be partitioned by onedimcol strategy\n");
+        fprintf(stderr, "         (Ignoring requested split strategy)\n");
+        Options.SplitStrategy = opts::OneDimCol;
+    }
+
+    /* Register whether the input matrix was weighted, since the object type code will
+       be changed by the partitioning procedure to the code 'D' for a distributed matrix */
+    if (A.MMTypeCode[0] == 'W')
+        weighted = TRUE;
+    else
+        weighted = FALSE;
+  
+    /* Register whether the input matrix was symmetric, since the symmetry type code will
+       be changed by the conversion to full, to the code 'G' for a general matrix */
+    if (A.m == A.n && 
+         (A.MMTypeCode[3]=='S' || A.MMTypeCode[3]=='K' || A.MMTypeCode[3]=='H')) {
+        symmetric = TRUE; 
+    } else {
+        symmetric = FALSE;
+        if (Options.SplitStrategy == opts::SFineGrain) {
+            fprintf(stderr, "Error: Symmetric finegrain can only be used on symmetric input matrices!\n");
+            exit(-1);
+        }
+    }
+    
+    if (symmetric) {
+        if (Options.SymmetricMatrix_UseSingleEntry == opts::SingleEntNo)
+            SparseMatrixSymmetric2Full(&A); 
+        else if (Options.SplitStrategy == opts::SFineGrain)
+            SparseMatrixSymmetricRandom2Lower(&A);
+        else if (Options.SymmetricMatrix_SingleEntryType == opts::ETypeRandom)
+            SparseMatrixSymmetricLower2Random(&A);
+    }
+
+    if (Options.SplitStrategy == opts::SFineGrain && Options.SymmetricMatrix_SingleEntryType == opts::ETypeRandom)
+        printf("Warning: Symmetric finegrain requires lower-triangular format of symmetric matrix;\n         Random single entry type option is overridden.\n");
+  
+    /* If the matrix is square, add the dummies if requested.
+       This may lead to an enhanced vector distribution in the case of
+       an equal distribution of the input and output vectors.  */
+    if (A.m == A.n && 
+        Options.SquareMatrix_DistributeVectorsEqual == opts::EqVecYes &&
+        Options.SquareMatrix_DistributeVectorsEqual_AddDummies == opts::DumYes)
+        AddDummiesToSparseMatrix(&A);
+  
+    /* Set the number of processors */
+    A.NrProcs = Options.P;
+    
+#ifdef INFO
+    printf("  P = Nr processors : %d\n", A.NrProcs);
+    printf("  Nr dummies added  : %ld\n", A.NrDummies);
+    printf("  allowed imbalance : %g %c\n", 100*Options.eps, '%');
+    printf("\n****** Mondriaan matrix distribution ******\n\n");
+#endif
+
+    /* Initialise Pstart with all nonzeros in processor 0 */
+    A.Pstart = (long *) malloc((A.NrProcs+1) * sizeof(long));
+    if (A.Pstart == NULL) {
+        fprintf(stderr, "main(): Not enough memory for Pstart!\n");
+        exit(-1);
+    }
+    
+    A.Pstart[0] = 0;
+    for (q = 1; q <= A.NrProcs; q++)
+        A.Pstart[q] = A.NrNzElts;
+  
+    /**** Distribute the matrix (and time it) ****/
+#ifdef TIME
+    starttime = clock();
+#endif
+#ifdef UNIX
+    gettimeofday(&starttime1, NULL);
+#endif
+  
+    if (!DistributeMatrixMondriaan(&A, A.NrProcs, Options.eps, &Options, 0)) {
+        fprintf(stderr, "main(): Unable to distribute matrix!\n");
+        exit(-1);
+    }
+    
+#ifdef UNIX
+    gettimeofday(&endtime1, NULL);
+#endif
+  
+#ifdef TIME
+    endtime = clock();
+    cputime = ((double) (endtime - starttime)) / CLOCKS_PER_SEC;
+    printf("  matrix distribution CPU-time    : %f seconds\n", cputime); 
+#ifdef UNIX 
+    printf("  matrix distribution elapsed time: %f seconds\n",
+             (endtime1.tv_sec - starttime1.tv_sec) +
+             (endtime1.tv_usec - starttime1.tv_usec) / 1000000.0); 
+#endif
+    fflush(stdout);
+#endif 
+  
+    /* Remove the dummies */
+    if (A.m == A.n &&
+        Options.SquareMatrix_DistributeVectorsEqual == opts::EqVecYes && 
+        Options.SquareMatrix_DistributeVectorsEqual_AddDummies == opts::DumYes)
+        RemoveDummiesFromSparseMatrix(&A);
+  
+    /* Print information about the number of matrix elements */
+    MinNrNzElts = LONG_MAX;
+    MaxNrNzElts = LONG_MIN;
+    for (q = 0; q < A.NrProcs; q++) {
+        nzq = A.Pstart[q+1] - A.Pstart[q];
+        if (nzq < MinNrNzElts)
+            MinNrNzElts = nzq;
+        if (nzq > MaxNrNzElts)
+            MaxNrNzElts = nzq;
+    }
+
+#ifdef INFO
+    AvgNrNzElts = (double) A.NrNzElts / A.NrProcs;
+    printf("  Nr nonzero matrix elements:\n");
+    printf("    tot         : %ld \n", A.NrNzElts);
+    printf("    avg = tot/P : %g  \n", AvgNrNzElts);
+    printf("    max         : %ld \n", MaxNrNzElts);
+    printf("    min         : %ld \n", MinNrNzElts);
+    printf("    imbalance   : %g %c\n",
+                100 * (MaxNrNzElts/AvgNrNzElts - 1.0), '%');
+#endif
+
+    if (weighted){
+        A.MMTypeCode[0] = 'W'; /* temporarily, needed for computing weights */
+        MinWeight = LONG_MAX;
+        MaxWeight = LONG_MIN;
+        for (q = 0; q < A.NrProcs; q++) {
+            weight = ComputeWeight(&A, A.Pstart[q], A.Pstart[q+1]-1, NULL, &Options);
+            if (weight < MinWeight)
+                MinWeight = weight;
+            if (weight > MaxWeight)
+                MaxWeight = weight;
+        }
+        A.MMTypeCode[0] = 'D'; /* back to distributed matrix */
+
+#ifdef INFO
+        TotWeight = ComputeWeight(&A, 0, A.NrNzElts-1, NULL, &Options);
+        AvgWeight = (double) TotWeight / A.NrProcs;
+        printf("  Vertex (column) weight:\n");
+        printf("    tot         : %ld \n", TotWeight);
+        printf("    avg = tot/P : %g  \n", AvgWeight);
+        printf("    max         : %ld \n", MaxWeight);
+        printf("    min         : %ld \n", MinWeight);
+        printf("    imbalance   : %g %c\n",
+                    100 * (MaxWeight/AvgWeight - 1.0), '%');
+#endif
+    }
+
+    /* Convert randomly represented symmetric matrix to standard
+       lower triangular form */
+    if (symmetric &&
+        Options.SymmetricMatrix_UseSingleEntry == opts::SingleEntYes &&
+        Options.SymmetricMatrix_SingleEntryType == opts::ETypeRandom)
+              SparseMatrixSymmetricRandom2Lower(&A);
+ 
+    /* Writing (distributed) matrix info */
+    if( Options.OutputMode == opts::MultipleFiles ) {
+ 
+        /* Write the distributed matrix to file */
+        sprintf(output, "%s-P%d", Options.matrix, A.NrProcs);
+        File = fopen(output, "w");
+        if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        else {
+            MMWriteSparseMatrix(&A, File, NULL, &Options);
+            fclose(File);
+        }
+
+        /* Commit to permutation */
+        if (A.row_perm_inv != NULL && A.col_perm_inv != NULL) {
+            for( i=0; i<A.NrNzElts; i++ ) {
+                A.i[ i ] = A.row_perm_inv[ A.i[ i ] ];
+                A.j[ i ] = A.col_perm_inv[ A.j[ i ] ];
+            }
+        }
+ 
+        /* Write permuted matrix */
+        sprintf(output, "%s-reor-P%d", Options.matrix, A.NrProcs);
+        File = fopen(output, "w");
+        A.MMTypeCode[0] = 'M';
+        if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        else {
+            MMWriteSparseMatrix(&A, File, NULL, &Options);
+            fclose(File);
+        }
+        A.MMTypeCode[0] = 'D';
+
+        /* Write out block information */
+        if (A.rowBoundaries) {
+            if (remembrance_get( A.rowBoundaries )==NULL) {
+                fprintf(stderr, "main(): Error during read-out of row boundaries\n");
+                exit( -1 );
+            }
+            sprintf(output, "%s-rowblocks%d", Options.matrix, A.NrProcs);
+            File = fopen(output, "w");
+            if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+            else {
+                remembrance_write(A.rowBoundaries, File);
+                fclose(File);
+            }
+        }
+        if (Options.SplitStrategy != opts::SFineGrain)
+            if (A.colBoundaries) {
+                if (remembrance_get( A.colBoundaries )==NULL) {
+                    fprintf(stderr, "main(): Error during read-out of column boundaries\n");
+                    exit( -1 );
+                }
+                sprintf(output, "%s-colblocks%d", Options.matrix, A.NrProcs);
+                File = fopen(output, "w");
+                if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+                else {
+                   remembrance_write(A.colBoundaries, File);
+                   fclose(File);
+                }
+            }
+        
+
+        /* Undo commit to permutation */
+        if (A.row_perm_inv != NULL && A.col_perm_inv != NULL) {
+            for( i=0; i<A.NrNzElts; i++ ) {
+                A.i[ i ] = A.row_perm[ A.i[ i ] ];
+                A.j[ i ] = A.col_perm[ A.j[ i ] ];
+            }
+        }
+
+        /* Write out local matrix format */
+        row_perms = (long int**)malloc( (A.NrProcs+1) * sizeof( long int * ) );
+        col_perms = (long int**)malloc( (A.NrProcs+1) * sizeof( long int * ) );
+        if( !row_perms || !col_perms || 
+            !SparseMatrixOriginal2Local(&A, row_perms, col_perms) ) {
+            fprintf(stderr, "main(): Unable to transform to local view!");
+            exit(-1);
+        }
+        sprintf(output, "%s-local%d", Options.matrix, A.NrProcs);
+        File = fopen(output, "w");
+        if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        else {
+            MMWriteSparseMatrix(&A, File, NULL, &Options);
+            fclose(File);
+        }
+
+        /* Transform matrix back */
+        for( i=0; i<A.NrProcs; i++ )
+            for(j=A.Pstart[i]; j<A.Pstart[i+1]; j++ ) {
+                A.i[j] = row_perms[i][ A.i[j] ];
+                A.j[j] = col_perms[i][ A.j[j] ];
+            }
+        A.ViewType = ViewTypeOriginal;
+
+        /* Write out matrix the entries of which are processor indices. */
+        if (!MMInsertProcessorIndices(&A)) {
+            fprintf(stderr, "main(): Unable to write processor indices!\n");
+            exit(-1);
+        }
+    
+        A.MMTypeCode[0] = 'M';
+        sprintf(output, "%s-I%d", Options.matrix, A.NrProcs);
+    
+        File = fopen(output, "w");
+    
+        if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        else {
+            MMWriteSparseMatrix(&A, File, NULL, &Options);
+            fclose(File);
+        }
+        A.MMTypeCode[0] = 'D';
+ 
+        /* Write out permutations. */
+        if (A.col_perm != NULL) {
+            sprintf(output, "%s-col%d", Options.matrix, A.NrProcs);
+            File = fopen(output, "w");
+            if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+            else {
+                WriteVector(A.col_perm, 0, NULL, A.n, 0, File, &Options);
+               fclose(File);
+            }
+        }
+    
+        if (A.row_perm != NULL) {
+            sprintf(output, "%s-row%d", Options.matrix, A.NrProcs);
+            File = fopen(output, "w");
+            if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+            else {
+                WriteVector(A.row_perm, 0, NULL, A.m, 0, File, &Options);
+                fclose(File);
+            }
+        }
+
+        /* Free local to global index */
+        for( i=0; i<A.NrProcs+1; i++ ) {
+            free( row_perms[i] );
+            free( col_perms[i] );
+        }
+        free( row_perms ); free( col_perms );
+    } else if (Options.OutputMode == opts::OneFile) {
+        /* Extended MatrixMarket output */
+        if (Options.OutputFormat != opts::OutputEMM) {
+            fprintf(stderr, "main(): Single-file output requires EMM format!\n");
+            fprintf(stderr, "        overriding output format to EMM.\n");
+            Options.OutputFormat = opts::OutputEMM;
+        }
+        sprintf(EMMcomment, "%% File generated by running Mondriaan on A=%s with p=%d and \\epsilon=%f\n", Options.matrix, A.NrProcs, Options.eps);
+        sprintf(EMMcomment_buffer, "%% Main matrix corresponds to the distributed version of A\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        if (A.row_perm_inv != NULL && A.col_perm_inv != NULL) {
+            switch( Options.OrderPermutation ) {
+            case opts::OrderPrefix:
+                sprintf(EMMcomment_buffer, "%% This is followed by the (not-distributed) reverse Bordered Block Diagonal permuted matrix 'PAQ',\n");
+                strcat(EMMcomment, EMMcomment_buffer);
+                break;
+            case opts::OrderPostfix:
+                sprintf(EMMcomment_buffer, "%% This is followed by the (not-distributed) Bordered Block Diagonal permuted matrix 'PAQ',\n");
+                strcat(EMMcomment, EMMcomment_buffer);
+                break;
+            default:
+                sprintf(EMMcomment_buffer, "%% This is followed by the (not-distributed) Separated Block Diagonal permuted matrix 'PAQ',\n");
+                strcat(EMMcomment, EMMcomment_buffer);
+            }
+            sprintf(EMMcomment_buffer, "%% followed by the row-block boundary vector 'Row-boundaries',\n");
+            strcat(EMMcomment, EMMcomment_buffer);
+            sprintf(EMMcomment_buffer, "%% followed by the row-block hierarchy vector 'Row-hierarchy',\n");
+            strcat(EMMcomment, EMMcomment_buffer);
+            sprintf(EMMcomment_buffer, "%% followed by the column-block boundary vector 'Column-boundaries',\n");
+            strcat(EMMcomment, EMMcomment_buffer);
+            sprintf(EMMcomment_buffer, "%% followed by the column-block hierarchy vector 'Column-hierarchy',\n");
+            strcat(EMMcomment, EMMcomment_buffer);
+        }
+        sprintf(EMMcomment_buffer, "%% followed by a local view of the distributed form of A 'Local-A',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by a mapping of local row indices to global row indices 'LocalRow2Global',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by a mapping of local column indices to global column indices 'LocalCol2Global',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        if (A.row_perm != NULL){
+            sprintf(EMMcomment_buffer, "%% followed by the row permutation vector corresponding to P in PAQ 'Row-permutation',\n");
+            strcat(EMMcomment, EMMcomment_buffer);
+        }
+        if (A.col_perm != NULL){
+            sprintf(EMMcomment_buffer, "%% followed by the column permutation vector corresponding to Q in PAQ 'Column-permutation',\n");
+            strcat(EMMcomment, EMMcomment_buffer);
+        }
+        sprintf(EMMcomment_buffer, "%% followed by the input vector distribution 'Input-vector',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by the output vector distribution 'Output-vector',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by the local lengths of the output vectors 'OutputVectorLengths',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by the matrix row index to output vector processor ID mapping 'LocalRow2Processor',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by the matrix row index to output vector index mapping 'LocalRow2Index',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by the matrix column index to input vector processor ID mapping 'LocalCol2Processor',\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        sprintf(EMMcomment_buffer, "%% followed by the matrix column index to input vector index mapping 'LocalCol2Index'.\n");
+        strcat(EMMcomment, EMMcomment_buffer);
+        A.comment = EMMcomment;
+        sprintf(output, "%s-P%d.emm", Options.matrix, A.NrProcs);
+        File = fopen(output, "w");
+        if (!File) {
+            fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+            exit( -1 );
+        }
+        MMWriteSparseMatrix(&A, File, NULL, &Options);
+
+        /* Commit to permutation */
+        if (A.row_perm_inv != NULL && A.col_perm_inv != NULL) {
+            for( i=0; i<A.NrNzElts; i++ ) {
+                A.i[ i ] = A.row_perm_inv[ A.i[ i ] ];
+                A.j[ i ] = A.col_perm_inv[ A.j[ i ] ];
+            }
+        }
+ 
+        /* Write permuted matrix */
+        A.MMTypeCode[0] = 'M';
+        MMWriteSparseMatrix(&A, File, "PAQ", &Options);
+        A.MMTypeCode[0] = 'D';
+
+        /* Write out block information */
+        if (A.rowBoundaries) {
+            if (remembrance_get( A.rowBoundaries )==NULL) {
+                fprintf(stderr, "main(): Error during read-out of row boundaries\n");
+                exit( -1 );
+            }
+            temp = (long int*)malloc(A.rowBoundaries->size * sizeof( long int ));
+            for(ui=0; ui<A.rowBoundaries->size; ui++)
+                temp[ ui ] = A.rowBoundaries->vector[ ui ].index;
+            WriteVector(temp, 0, "Row-boundaries", A.rowBoundaries->size, 0, File, &Options);
+            for(ui=0; ui<A.rowBoundaries->size-1; ui++ )
+                temp[ ui ] = A.rowBoundaries->vector[ ui ].parent == ULONG_MAX ? 0 : A.rowBoundaries->vector[ ui ].parent + 1;
+            WriteVector(temp, 1, "Row-hierarchy", A.rowBoundaries->size-1, 0, File, &Options);
+            free(temp);
+        }
+        if (Options.SplitStrategy != opts::SFineGrain) {
+            if (A.colBoundaries) {
+                if (remembrance_get( A.colBoundaries )==NULL) {
+                    fprintf(stderr, "main(): Error during read-out of column boundaries\n");
+                    exit( -1 );
+                }
+                temp = (long int*)malloc( A.colBoundaries->size * sizeof( long int ) );
+                for(ui=0; ui<A.colBoundaries->size; ui++)
+                    temp[ ui ] = A.colBoundaries->vector[ ui ].index;
+                WriteVector(temp, 0, "Col-boundaries", A.colBoundaries->size, 0, File, &Options);
+                for(ui=0; ui<A.colBoundaries->size-1; ui++ )
+                    temp[ ui ] = A.colBoundaries->vector[ ui ].parent == ULONG_MAX ? 0 : A.colBoundaries->vector[ ui ].parent + 1;
+                WriteVector(temp, 1, "Col-hierarchy", A.colBoundaries->size-1, 0, File, &Options);
+                free(temp);
+            }
+        }
+    
+        /* Write out local matrix format */
+        row_perms = (long int**)malloc( (A.NrProcs+1) * sizeof( long int * ) );
+        col_perms = (long int**)malloc( (A.NrProcs+1) * sizeof( long int * ) );
+        if( !row_perms || !col_perms || 
+            !SparseMatrixOriginal2Local(&A, row_perms, col_perms) ) {
+            fprintf(stderr, "main(): Unable to transform to local view!");
+            exit(-1);
+        }
+        MMWriteSparseMatrix(&A, File, "Local-A", &Options);
+
+        /* Transform matrix back from Local to global view */
+        for( i=0; i<A.NrProcs; i++ )
+            for(j=A.Pstart[i]; j<A.Pstart[i+1]; j++ ) {
+                A.i[j] = row_perms[i][ A.i[j] ];
+                A.j[j] = col_perms[i][ A.j[j] ];
+            }
+        A.ViewType = ViewTypeOriginal;
+
+        /* Permutate row_perms and col_perms so that they point
+         * to global indices (corresponding to A) instead of
+         * permuted indices (corresponding to PAQ). 
+        for( i=0; i<A.NrProcs; i++ ) {
+                for( j=0; j<row_perms[A.NrProcs][i]; j++ )
+                        row_perms[i][j] = row_perms[i][j]; 
+                for( j=0; j<col_perms[A.NrProcs][i]; j++ )
+                        col_perms[i][j] = col_perms[i][j];
+        } */
+
+        WriteVectorCollection(row_perms, "LocalRow2Global", A.NrProcs, row_perms[A.NrProcs], File);
+        WriteVectorCollection(col_perms, "LocalCol2Global", A.NrProcs, col_perms[A.NrProcs], File);
+
+        /* Write out matrix the entries of which are processor indices */
+        /*if (!MMInsertProcessorIndices(&A)) {
+            fprintf(stderr, "main(): Unable to write processor indices!\n");
+            exit(-1);
+        }
+        A.MMTypeCode[0] = 'M';
+        tempchar = A.MMTypeCode[2];
+        A.MMTypeCode[2] = 'I';
+        MMWriteSparseMatrix(&A, File, "Global-A", &Options);
+        A.MMTypeCode[0] = 'D';
+        A.MMTypeCode[2] = tempchar;*/
+ 
+        /* Write out permutations */
+        if (A.row_perm != NULL) {
+            WriteVector(A.row_perm, 0, "Row-permutation", A.m, 0, File, &Options);
+        }
+        if (A.col_perm != NULL) {
+            WriteVector(A.col_perm, 0, "Column-permutation", A.n, 0, File, &Options);
+        }
+    } else if (Options.OutputMode == opts::DIMACS) {
+        /* For DIMACS we only need the vector distribution. */
+    } else {
+        fprintf(stderr, "main(): Unknown output mode!\n" );
+        exit( -1 );
+    }
+
+    /* Convert symmetrically partitioned, symmetric matrix to full form 
+       for vector distribution */
+    if (symmetric &&
+        Options.SymmetricMatrix_UseSingleEntry == opts::SingleEntYes) {
+        /* Some of the above transformations can make A arbitrary symmetric
+           instead of lower-traingular */
+        SparseMatrixSymmetricRandom2Lower(&A);
+        SparseMatrixSymmetric2Full(&A); /* now A.MMTypeCode[3]='G' */
+        
+        /* Print information about the number of matrix elements */
+        MinNrNzElts = LONG_MAX;
+        MaxNrNzElts = LONG_MIN;
+        for (q = 0; q < A.NrProcs; q++) {
+             nzq = A.Pstart[q+1] - A.Pstart[q];
+             if (nzq < MinNrNzElts)
+                 MinNrNzElts = nzq;
+             if (nzq > MaxNrNzElts)
+                 MaxNrNzElts = nzq;
+        }
+
+#ifdef INFO
+        AvgNrNzElts = (double) A.NrNzElts / A.NrProcs;
+        printf("  After conversion of distributed symmetric matrix to"
+               "  distributed full matrix\n");
+        printf("  Nr matrix elements:\n");
+        printf("    tot         : %ld \n", A.NrNzElts);
+        printf("    avg = tot/P : %g  \n", AvgNrNzElts);
+        printf("    max         : %ld \n", MaxNrNzElts);
+        printf("    min         : %ld \n", MinNrNzElts);
+
+        printf("    imbalance   : %g %c\n", 
+                    100 * (MaxNrNzElts / AvgNrNzElts - 1.0), '%');
+        /* vertex weight information is not printed, since it is not
+           meaningful here */ 
+#endif   
+    }
+  
+#ifdef INFO
+    printf("\n****** Mondriaan vector distribution ******\n");
+#endif
+  
+    /* Allocate memory for processor numbers for the vector components, 
+       for u = A*v with A an m by n matrix */
+    u_proc = (long int *) malloc(A.m * sizeof(long int));
+    v_proc = (long int *) malloc(A.n * sizeof(long int));
+    if (u_proc == NULL || v_proc == NULL) {
+        fprintf(stderr, "main(): Not enough memory for vectors u_proc and v_proc!\n");
+        exit(-1);
+    }
+      
+    /**** Distribute the vector (and time it) ****/
+#ifdef TIME
+    starttime = clock();
+#endif
+#ifdef UNIX
+    gettimeofday(&starttime1, NULL);
+#endif
+   
+    if (A.m == A.n && Options.SquareMatrix_DistributeVectorsEqual == opts::EqVecYes) {
+        /* Distribute the vectors equally */
+        if (symmetric &&
+            Options.SymmetricMatrix_UseSingleEntry == opts::SingleEntYes) {
+             
+            /* Distribute v independently, and then use the same distribution for u */
+            ComV = DistributeVec(&A, v_proc, ROW, &Options);
+            
+            if (ComV < 0) {
+                fprintf(stderr, "main(): Unable to distribute vectors!\n");
+                exit(-1);
+            }
+            
+            for (i = 0; i < A.m; i++)
+                u_proc[i] = v_proc[i];
+            ComU = ComV;
+#ifdef INFO
+            printf("\nCommunication results for u are the same as for v\n");
+            printf("but with sends and receives reversed\n\n");
+#endif
+        } else {
+            /* Distribute u and v together */
+            ComU = DistributeVecOrigEq(&A, u_proc, v_proc, &Options);
+            
+            if (ComU < 0) {
+                fprintf(stderr, "main(): Unable to distribute vectors!\n");
+                exit(-1);
+            }
+            
+            ComV = 0;
+        }
+    } else {
+        /* Distribute the vectors independently */
+        ComV = DistributeVec(&A, v_proc, ROW, &Options);
+        if (ComV < 0) {
+            fprintf(stderr, "main(): Unable to distribute input vector!\n");
+            exit(-1);
+        }
+
+        ComU = DistributeVec(&A, u_proc, COL, &Options);
+        if (ComU < 0) {
+            fprintf(stderr, "main(): Unable to distribute output vector!\n");
+            exit(-1);
+        }
+    }
+  
+#ifdef UNIX
+    gettimeofday(&endtime1, NULL);
+#endif
+  
+#ifdef TIME
+    endtime = clock();
+    cputime = ((double) (endtime - starttime)) / CLOCKS_PER_SEC;
+    printf("  vector distribution CPU-time      : %f seconds\n", cputime);
+#ifdef UNIX  
+    printf("  vector distribution elapsed time  : %f seconds\n",
+             (endtime1.tv_sec - starttime1.tv_sec) +
+             (endtime1.tv_usec - starttime1.tv_usec) / 1000000.0); 
+#endif   
+    fflush(stdout);
+#endif  
+      
+#ifdef INFO
+    printf("\nCommunication cost for u = A v: %ld (%g) \n", ComU + ComV,
+           ((double) ComU / A.m  + (double) ComV / A.n) /2);  
+    fflush(stdout);
+#endif
+ 
+    /* Write vector info */
+    if (Options.OutputMode == opts::MultipleFiles) {
+        /* Write the vector distribution to file */
+        sprintf(output, "%s-u%d", Options.matrix, A.NrProcs);
+        File = fopen(output, "w");
+    
+        if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        else {
+            WriteVectorDistribution(u_proc, NULL, A.m, A.NrProcs, File, &Options);
+            fclose(File);
+        }
+  
+        sprintf(output, "%s-v%d", Options.matrix, A.NrProcs);    
+        File = fopen(output, "w");
+    
+        if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        else {
+            WriteVectorDistribution(v_proc, NULL, A.n, A.NrProcs, File, &Options);
+            fclose(File);
+        }
+    } else if (Options.OutputMode == opts::OneFile) {
+        /* Write the vector distribution to file */
+        WriteVectorDistribution(v_proc, "Input-vector", A.n, A.NrProcs, File, &Options);
+        WriteVectorDistribution(u_proc, "Output-vector", A.m, A.NrProcs, File, &Options);
+
+        /* LocalRow2Processor */
+        inv_count = NULL;
+        row_local2proc = row_local2index = col_local2proc = col_local2index = NULL;
+       if(!SparseMatrixLocal2Vector(&A, row_perms, u_proc, &inv_count, &row_local2proc, &row_local2index, 0)) {
+            fprintf(stderr, "Error during derivation of local index arrays for SpMV multiplication (row direction)\n");
+            exit(-1);
+        }
+        WriteVector(inv_count, 0, "OutputVectorLengths", A.NrProcs, 0, File, &Options);
+        WriteVectorCollection(row_local2proc, "LocalRow2Processor", A.NrProcs, row_perms[A.NrProcs], File);
+        WriteVectorCollection(row_local2index, "LocalRow2Index", A.NrProcs, row_perms[A.NrProcs], File);
+        for( i=0; i<A.NrProcs; i++ ) {
+            free( row_local2proc[i] );
+            free( row_local2index[i] );
+        }
+        free( row_local2proc ); free( row_local2index );
+        /* LocalCol2Processor */
+        free(inv_count);
+       if(!SparseMatrixLocal2Vector(&A, col_perms, v_proc, &inv_count, &col_local2proc, &col_local2index, 1)) {
+            fprintf(stderr, "Error during derivation of local index arrays for SpMV multiplication (column direction)\n");
+            exit(-1);
+        }
+        WriteVector(inv_count, 0, "InputVectorLengths", A.NrProcs, 0, File, &Options);
+        WriteVectorCollection(col_local2proc, "LocalCol2Processor", A.NrProcs, col_perms[A.NrProcs], File);
+        WriteVectorCollection(col_local2index, "LocalCol2Index", A.NrProcs, col_perms[A.NrProcs], File);
+        for( i=0; i<A.NrProcs; i++ ) {
+            free( col_local2proc[i] );
+            free( col_local2index[i] );
+        }
+        free( col_local2proc ); free( col_local2index );
+        free(inv_count);
+        /* Also free local to global index */
+        for( i=0; i<A.NrProcs+1; i++ ) {
+            free( row_perms[i] );
+            free( col_perms[i] );
+        }
+        free( row_perms ); free( col_perms );
+        fclose(File);
+    } else if (Options.OutputMode == opts::DIMACS) {
+        if (A.m != A.n || Options.SquareMatrix_DistributeVectorsEqual != opts::EqVecYes) {
+            fprintf(stderr, "main(): Unequal vector distributions in DIMACS mode!\n");
+        }
+        
+        /* Only write the vector distribution to disk. */
+        sprintf(output, "%s%d.part", Options.matrix, A.NrProcs);
+        File = fopen(output, "w");
+    
+        if (!File) {
+            fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        } else {
+            for (i = 0; i < A.m; i++) fprintf(File, "%ld\n", u_proc[i]);
+            fclose(File);
+        }
+    }
+  
+    if (Options.OutputMode == opts::MultipleFiles) {
+        /* Write the index sets of the Cartesian submatrices to file */
+        sprintf(output, "%s-C%d", Options.matrix, A.NrProcs);
+        File = fopen(output, "w");
+        if (!File) fprintf(stderr, "main(): Unable to open '%s' for writing!\n", output);
+        else {
+            MMWriteCartesianSubmatrices(&A, File);
+            fclose(File);
+        }
+    }
+
+    /* Free memory */
+    MMDeleteSparseMatrix(&A);  
+    free(v_proc);
+    free(u_proc);
+
+} /* end main */
+
+std::vector<handle_t> mondriaan_sort(const HandleGraph& graph) {
+    // set up input
+    // write to file
+    // set up mondriaan command line
+    // get the symmetric permutation of the matrix
+    // clean up temp files
+}
+
+}
+}

--- a/src/algorithms/mondriaan_sort.cpp
+++ b/src/algorithms/mondriaan_sort.cpp
@@ -898,13 +898,11 @@ std::vector<handle_t> mondriaan_sort(const PathHandleGraph& graph,
     //std::string tempname = std::tmpnam(nullptr);
     if (!n_parts) n_parts = 1; // force 1
     std::string tempname = temp_file::create();
-    std::cerr << "using tempname " << tempname << std::endl;
     std::string outmtx = tempname + ".mtx";
     std::ofstream out(outmtx.c_str());
     algorithms::write_as_sparse_matrix(out, graph, weight_by_edge_depth, weight_by_edge_delta);
     out.close();
     // set up mondriaan command line
-    //Mondriaan DRB1-3123.mtx 8 1 -Permute=SBD -EnforceSymmetricPermutation=yes -Coarsening_StopRatio=1 -SplitStrategy=finegrain -Iterative_Refinement=always -Coarsening_InprodScaling=max -VectorPartition_Step3=decrease -Coarsening_InprodMatchingOrder=incrwgt -Coarsening_NetScaling=no -Coarsening_MatchingStrategy=ata -Coarsening_MatchingATAMatcher=greedy -SquareMatrix_DistributeVectorsEqual_AddDummies=no -ImproveFreeNonzeros=no -LoadbalanceStrategy=increase
     std::vector<std::string> args = {
         "Mondriaan",
         outmtx,

--- a/src/algorithms/mondriaan_sort.cpp
+++ b/src/algorithms/mondriaan_sort.cpp
@@ -897,6 +897,7 @@ std::vector<handle_t> mondriaan_sort(const PathHandleGraph& graph,
     // write to file
     //std::string tempname = std::tmpnam(nullptr);
     if (!n_parts) n_parts = 1; // force 1
+    if (eps == 0) eps = 1.0;
     std::string tempname = temp_file::create();
     std::string outmtx = tempname + ".mtx";
     std::ofstream out(outmtx.c_str());
@@ -908,19 +909,20 @@ std::vector<handle_t> mondriaan_sort(const PathHandleGraph& graph,
         outmtx,
         std::to_string(n_parts),
         std::to_string(eps),
+        "-Permute=SBD",
         "-EnforceSymmetricPermutation=yes",
-        "-Coarsening_StopRatio=1",
-        "-SplitStrategy=finegrain",
-        "-Iterative_Refinement=always",
-        "-Coarsening_InprodScaling=max",
-        "-VectorPartition_Step3=decrease",
-        "-Coarsening_InprodMatchingOrder=incrwgt",
-        "-Coarsening_NetScaling=no",
+        //"-Coarsening_StopRatio=1",
+        //"-SplitStrategy=finegrain",
+        //"-Iterative_Refinement=always",
+        //"-Coarsening_InprodScaling=max",
+        //"-VectorPartition_Step3=decrease",
+        //"-Coarsening_InprodMatchingOrder=incrwgt",
+        //"-Coarsening_NetScaling=no",
         "-Coarsening_MatchingStrategy=ata",
         "-Coarsening_MatchingATAMatcher=greedy",
-        "-SquareMatrix_DistributeVectorsEqual_AddDummies=no",
-        "-ImproveFreeNonzeros=no",
-        "-LoadbalanceStrategy=increase"
+        //"-SquareMatrix_DistributeVectorsEqual_AddDummies=no",
+        //"-ImproveFreeNonzeros=no",
+        //"-LoadbalanceStrategy=increase"
     };
     char* argvec[args.size()];
     for (uint8_t i = 0; i < args.size(); ++i) {

--- a/src/algorithms/mondriaan_sort.cpp
+++ b/src/algorithms/mondriaan_sort.cpp
@@ -897,6 +897,7 @@ std::vector<handle_t> mondriaan_sort(const PathHandleGraph& graph,
     // write to file
     //std::string tempname = std::tmpnam(nullptr);
     if (!n_parts) n_parts = 1; // force 1
+    n_parts = std::min(n_parts, graph.get_node_count());
     if (eps == 0) eps = 1.0;
     std::string tempname = temp_file::create();
     std::string outmtx = tempname + ".mtx";

--- a/src/algorithms/mondriaan_sort.hpp
+++ b/src/algorithms/mondriaan_sort.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+/**
+ * \file sparse_sort.hpp
+ *
+ * Defines a sparse matrix sort of the graph based on Mondriaan
+ */
+
+#include <iostream>
+#include "../hash_map.hpp"
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/util.hpp>
+
+#define GAINBUCKET_ARRAY
+#define MONDRIAANVERSION "\"4.2.1\""
+// hack to allow mondriaan to use variables named "new"
+#define new mynew
+extern "C" {
+#include <Mondriaan.h>
+}
+#undef new
+
+//#include "dynamic.hpp"
+//#include "apply_bulk_modifications.hpp"
+//#include "is_single_stranded.hpp"
+
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+void mondriaan_main(int argc, char** argv);
+
+std::vector<handle_t> mondriaan_sort(const HandleGraph& graph);
+
+}
+}

--- a/src/algorithms/mondriaan_sort.hpp
+++ b/src/algorithms/mondriaan_sort.hpp
@@ -7,9 +7,12 @@
  */
 
 #include <iostream>
+#include <fstream>
 #include "../hash_map.hpp"
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/util.hpp>
+#include "matrix_writer.hpp"
+#include "temp_file.hpp"
 
 #define GAINBUCKET_ARRAY
 #define MONDRIAANVERSION "\"4.2.1\""
@@ -32,7 +35,10 @@ using namespace handlegraph;
 
 void mondriaan_main(int argc, char** argv);
 
-std::vector<handle_t> mondriaan_sort(const HandleGraph& graph);
+std::vector<handle_t> mondriaan_sort(const PathHandleGraph& graph,
+                                     uint64_t n_parts, double eps,
+                                     bool weight_by_edge_depth, bool weight_by_edge_delta);
+
 
 }
 }

--- a/src/algorithms/random_order.cpp
+++ b/src/algorithms/random_order.cpp
@@ -1,0 +1,19 @@
+#include "random_order.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+std::vector<handle_t> random_order(const HandleGraph& graph) {
+    std::vector<handle_t> order;
+    graph.for_each_handle([&order](const handle_t& handle) {
+            order.push_back(handle);
+        });
+    std::random_device dev;
+    std::mt19937 rng(dev());
+    std::shuffle(order.begin(), order.end(), rng);
+    return order;
+}
+
+}
+}

--- a/src/algorithms/random_order.hpp
+++ b/src/algorithms/random_order.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_handle_graph.hpp>
+#include <algorithm>
+#include <random>
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+// provide a randomized order for the graph
+std::vector<handle_t> random_order(const HandleGraph& graph);
+
+}
+}

--- a/src/algorithms/sgd_layout.cpp
+++ b/src/algorithms/sgd_layout.cpp
@@ -39,8 +39,11 @@ std::vector<double> sgd_layout(const HandleGraph& graph, uint64_t pivots, uint64
             X[i] = dist(rng);
         }
         // do layout
-        sgd2::layout_sparse_unweighted(n, X.data(), I.size(), I.data(), J.data(), pivots, t_max, eps);
-        //sgd2::layout_unweighted(n, X.data(), I.size(), I.data(), J.data(), t_max, eps);
+        if (pivots > 0) {
+            sgd2::layout_sparse_unweighted(n, X.data(), I.size(), I.data(), J.data(), pivots, t_max, eps);
+        } else {
+            sgd2::layout_unweighted(n, X.data(), I.size(), I.data(), J.data(), t_max, eps);
+        }
 
         for (uint64_t i = 0; i < 2*n; i+=2) {
             //std::cerr << "i = " << i << std::endl;

--- a/src/algorithms/sgd_layout.cpp
+++ b/src/algorithms/sgd_layout.cpp
@@ -1,0 +1,57 @@
+#include "sgd_layout.hpp"
+#include "sgd2.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+std::vector<double> sgd_layout(const HandleGraph& graph, uint64_t pivots, uint64_t t_max, double eps, double x_padding) {
+    std::vector<double> layout(graph.get_node_count()*2);
+    double max_x = 0;
+    auto weak_components = algorithms::weakly_connected_components(&graph);
+    for (auto& component : weak_components) {
+        std::vector<handlegraph::nid_t> component_ids;
+        ska::flat_hash_map<handlegraph::nid_t, uint64_t> local_id;
+        for (auto& id : component) {
+            local_id[id] = component_ids.size();
+            component_ids.push_back(id);
+        }
+        // convert to input format for SGD
+        std::vector<uint64_t> I, J;
+        graph.for_each_edge([&](const edge_t& e) {
+                if (component.count(graph.get_id(e.first))
+                    && component.count(graph.get_id(e.first))) {
+                    I.push_back(local_id[graph.get_id(e.first)]);
+                    J.push_back(local_id[graph.get_id(e.second)]);
+                }
+            });
+        uint64_t n = component.size();
+        std::vector<double> X(2*n);
+        std::random_device dev;
+        // todo, seed with graph topology/contents to get a stable result
+        std::mt19937 rng(dev());
+        std::uniform_real_distribution<double> dist(0,1);
+        for (uint64_t i = 0; i < 2*n; ++i) {
+            X[i] = dist(rng);
+        }
+        // do layout
+        sgd2::layout_sparse_unweighted(n, X.data(), I.size(), I.data(), J.data(), pivots, t_max, eps);
+        for (uint64_t i = 0; i < 2*n; i+=2) {
+            //std::cerr << "i = " << i << std::endl;
+            uint64_t j = component_ids[i/2]-1;
+            layout[j] = X[i] + max_x;
+            layout[j+1] = X[i+1];
+        }
+        // set new max_x
+        for (uint64_t i = 0; i < 2*n; i+=2) {
+            max_x = std::max(X[i], max_x);
+        }
+        max_x += x_padding;
+    }
+    // all the weakly connected component layouts have been merged here
+    return layout;
+}
+
+}
+}

--- a/src/algorithms/sgd_layout.cpp
+++ b/src/algorithms/sgd_layout.cpp
@@ -10,26 +10,29 @@ std::vector<double> sgd_layout(const HandleGraph& graph, uint64_t pivots, uint64
     std::vector<double> layout(graph.get_node_count()*2);
     double max_x = 0;
     auto weak_components = algorithms::weakly_connected_components(&graph);
-    for (auto& component : weak_components) {
+    for (auto& weak_component : weak_components) {
         std::vector<handlegraph::nid_t> component_ids;
         ska::flat_hash_map<handlegraph::nid_t, uint64_t> local_id;
-        for (auto& id : component) {
-            local_id[id] = component_ids.size();
+        for (auto& id : weak_component) {
             component_ids.push_back(id);
+        }
+        std::sort(component_ids.begin(), component_ids.end());
+        for (uint64_t i = 0; i < component_ids.size(); ++i) {
+            local_id[component_ids[i]] = i;
         }
         // convert to input format for SGD
         std::vector<uint64_t> I, J;
         graph.for_each_edge([&](const edge_t& e) {
-                if (component.count(graph.get_id(e.first))
-                    && component.count(graph.get_id(e.first))) {
+                if (weak_component.count(graph.get_id(e.first))
+                    && weak_component.count(graph.get_id(e.first))) {
                     I.push_back(local_id[graph.get_id(e.first)]);
                     J.push_back(local_id[graph.get_id(e.second)]);
                 }
             });
-        uint64_t n = component.size();
+        uint64_t n = weak_component.size();
         std::vector<double> X(2*n);
         std::random_device dev;
-        // todo, seed with graph topology/contents to get a stable result
+        // todo, seed with graph topology/contents to get a more stable result
         std::mt19937 rng(dev());
         std::uniform_real_distribution<double> dist(0,1);
         for (uint64_t i = 0; i < 2*n; ++i) {
@@ -37,11 +40,14 @@ std::vector<double> sgd_layout(const HandleGraph& graph, uint64_t pivots, uint64
         }
         // do layout
         sgd2::layout_sparse_unweighted(n, X.data(), I.size(), I.data(), J.data(), pivots, t_max, eps);
+        //sgd2::layout_unweighted(n, X.data(), I.size(), I.data(), J.data(), t_max, eps);
+
         for (uint64_t i = 0; i < 2*n; i+=2) {
             //std::cerr << "i = " << i << std::endl;
             uint64_t j = component_ids[i/2]-1;
-            layout[j] = X[i] + max_x;
-            layout[j+1] = X[i+1];
+            layout[j*2] = X[i] + max_x;
+            layout[j*2+1] = X[i+1];
+            //std::cerr << "layout " << j << " " << layout[j*2] << " " << layout[j*2+1] << std::endl;
         }
         // set new max_x
         for (uint64_t i = 0; i < 2*n; i+=2) {
@@ -50,6 +56,11 @@ std::vector<double> sgd_layout(const HandleGraph& graph, uint64_t pivots, uint64
         max_x += x_padding;
     }
     // all the weakly connected component layouts have been merged here
+    /*
+    for (uint64_t i = 0; i < layout.size(); i+=2) {
+        std::cerr << i/2 << " " << layout[i] << " " << layout[i+1] << std::endl;
+    }
+    */
     return layout;
 }
 

--- a/src/algorithms/sgd_layout.hpp
+++ b/src/algorithms/sgd_layout.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+/**
+ * \file sgd_layout.hpp
+ *
+ * Run SGD based graph layout
+ */
+
+#include <handlegraph/handle_graph.hpp>
+#include <vector>
+#include <random>
+#include "algorithms/weakly_connected_components.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+std::vector<double> sgd_layout(const HandleGraph& graph, uint64_t pivots, uint64_t t_max, double eps, double x_padding);
+
+}
+}
+
+
+

--- a/src/algorithms/split_strands.cpp
+++ b/src/algorithms/split_strands.cpp
@@ -1,26 +1,26 @@
 #include "split_strands.hpp"
 
-namespace vg {
+namespace odgi {
 namespace algorithms {
 
-using namespace std;
 using namespace handlegraph;
 
-    unordered_map<handlegraph::nid_t, pair<handlegraph::nid_t, bool>> split_strands(const HandleGraph* source, MutableHandleGraph* into) {
+
+ska::flat_hash_map<handlegraph::nid_t, std::pair<handlegraph::nid_t, bool>> split_strands(const HandleGraph* source, MutableHandleGraph* into) {
+
+    if (into->get_node_count()) {
+        std::cerr << "error:[algorithms] attempted to create strand-splitted graph in a non-empty graph" << std::endl;
+        exit(1);
+    }
         
-        if (into->node_size()) {
-            cerr << "error:[algorithms] attempted to create strand-splitted graph in a non-empty graph" << endl;
-            exit(1);
-        }
+    ska::flat_hash_map<handlegraph::nid_t, std::pair<handlegraph::nid_t, bool>> node_translation;
         
-        unordered_map<handlegraph::nid_t, pair<handlegraph::nid_t, bool>> node_translation;
+    ska::flat_hash_map<handle_t, handle_t> forward_node;
+    ska::flat_hash_map<handle_t, handle_t> reverse_node;
         
-        unordered_map<handle_t, handle_t> forward_node;
-        unordered_map<handle_t, handle_t> reverse_node;
-        
-        unordered_set<edge_t> edges;
-        
-        source->for_each_handle([&](const handle_t& handle) {            
+    ska::flat_hash_set<edge_t> edges;
+
+    source->for_each_handle([&](const handle_t& handle) {            
             // create and record forward and reverse versions of each node
             handle_t fwd_handle = into->create_handle(source->get_sequence(handle));
             handle_t rev_handle = into->create_handle(reverse_complement(source->get_sequence(handle)));
@@ -28,35 +28,36 @@ using namespace handlegraph;
             forward_node[handle] = fwd_handle;
             reverse_node[handle] = rev_handle;
             
-            node_translation[into->get_id(fwd_handle)] = make_pair(source->get_id(handle), false);
-            node_translation[into->get_id(rev_handle)] = make_pair(source->get_id(handle), true);
+            node_translation[into->get_id(fwd_handle)] = std::make_pair(source->get_id(handle), false);
+            node_translation[into->get_id(rev_handle)] = std::make_pair(source->get_id(handle), true);
             
             // collect all the edges
             source->follow_edges(handle, true, [&](const handle_t& prev) {
-                edges.insert(source->edge_handle(prev, handle));
-            });
+                    edges.insert(source->edge_handle(prev, handle));
+                });
             source->follow_edges(handle, false, [&](const handle_t& next) {
-                edges.insert(source->edge_handle(handle, next));
-            });
+                    edges.insert(source->edge_handle(handle, next));
+                });
         });
         
-        // translate each edge into two edges between forward-oriented nodes
-        for (edge_t edge : edges) {
-            handle_t fwd_prev = source->get_is_reverse(edge.first) ? reverse_node[source->flip(edge.first)]
-                                                                   : forward_node[edge.first];
-            handle_t fwd_next = source->get_is_reverse(edge.second) ? reverse_node[source->flip(edge.second)]
-                                                                    : forward_node[edge.second];
+    // translate each edge into two edges between forward-oriented nodes
+    for (edge_t edge : edges) {
+        handle_t fwd_prev = source->get_is_reverse(edge.first) ? reverse_node[source->flip(edge.first)]
+            : forward_node[edge.first];
+        handle_t fwd_next = source->get_is_reverse(edge.second) ? reverse_node[source->flip(edge.second)]
+            : forward_node[edge.second];
             
-            handle_t rev_prev = source->get_is_reverse(edge.second) ? forward_node[source->flip(edge.second)]
-                                                                    : reverse_node[edge.second];
-            handle_t rev_next = source->get_is_reverse(edge.first) ? forward_node[source->flip(edge.first)]
-                                                                   : reverse_node[edge.first];
+        handle_t rev_prev = source->get_is_reverse(edge.second) ? forward_node[source->flip(edge.second)]
+            : reverse_node[edge.second];
+        handle_t rev_next = source->get_is_reverse(edge.first) ? forward_node[source->flip(edge.first)]
+            : reverse_node[edge.first];
             
-            into->create_edge(fwd_prev, fwd_next);
-            into->create_edge(rev_prev, rev_next);
-        }
-        
-        return move(node_translation);
+        into->create_edge(fwd_prev, fwd_next);
+        into->create_edge(rev_prev, rev_next);
     }
+        
+    return move(node_translation);
+}
+
 }
 }

--- a/src/algorithms/split_strands.hpp
+++ b/src/algorithms/split_strands.hpp
@@ -1,5 +1,4 @@
-#ifndef VG_ALGORITHMS_SPLIT_STRANDS_HPP_INCLUDED
-#define VG_ALGORITHMS_SPLIT_STRANDS_HPP_INCLUDED
+#pragma once
 
 /**
  * \file split_strands.hpp
@@ -9,15 +8,16 @@
 
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/mutable_handle_graph.hpp>
-#include "../utility.hpp"
-
+//#include "../utility.hpp"
+#include "dna.hpp"
+#include "hash_map.hpp"
+#include <utility>
 #include <unordered_set>
 #include <unordered_map>
 
-namespace vg {
+namespace odgi {
 namespace algorithms {
 
-using namespace std;
 using namespace handlegraph;
 
     /// Fills a MutableHandleGraph 'into' with a graph that has the same sequence and path
@@ -26,10 +26,8 @@ using namespace handlegraph;
     /// complement sequence. Returns a map that translates node IDs from 'into' to their
     /// node ID and orientation in 'source'. Reports an error and exits if 'into' is not
     /// empty.
-    unordered_map<handlegraph::nid_t, pair<handlegraph::nid_t, bool>> split_strands(const HandleGraph* source,
-                                                                                  MutableHandleGraph* into);
+ska::flat_hash_map<handlegraph::nid_t, std::pair<handlegraph::nid_t, bool>> split_strands(const HandleGraph* source,
+                                                                                          MutableHandleGraph* into);
 
 }
 }
-
-#endif

--- a/src/algorithms/temp_file.cpp
+++ b/src/algorithms/temp_file.cpp
@@ -1,0 +1,113 @@
+#include "temp_file.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+namespace temp_file {
+
+// We use this to make the API thread-safe
+std::recursive_mutex monitor;
+
+std::string temp_dir;
+
+/// Because the names are in a static object, we can delete them when
+/// std::exit() is called.
+struct Handler {
+    std::set<std::string> filenames;
+    std::string parent_directory;
+    ~Handler() {
+        // No need to lock in static destructor
+        for (auto& filename : filenames) {
+            std::remove(filename.c_str());
+        }
+        if (!parent_directory.empty()) {
+            // There may be extraneous files in the directory still (like .fai files)
+            auto directory = opendir(parent_directory.c_str());
+            
+            dirent* dp;
+            while ((dp = readdir(directory)) != nullptr) {
+                // For every item still in it, delete it.
+                // TODO: Maybe eventually recursively delete?
+                std::remove((parent_directory + "/" + dp->d_name).c_str());
+            }
+            closedir(directory);
+            
+            // Delete the directory itself
+            std::remove(parent_directory.c_str());
+        }
+    }
+} handler;
+
+std::string create(const std::string& base) {
+    std::lock_guard<std::recursive_mutex> lock(monitor);
+
+    if (handler.parent_directory.empty()) {
+        // Make a parent directory for our temp files
+        std::string tmpdirname_cpp = get_dir() + "/odgi-XXXXXX";
+        char* tmpdirname = new char[tmpdirname_cpp.length() + 1];
+        strcpy(tmpdirname, tmpdirname_cpp.c_str());
+        auto got = mkdtemp(tmpdirname);
+        if (got != nullptr) {
+            // Save the directory we got
+            handler.parent_directory = got;
+        } else {
+            std::cerr << "[odgi]: couldn't create temp directory: " << tmpdirname << std::endl;
+            exit(1);
+        }
+        delete [] tmpdirname;
+    }
+
+    std::string tmpname = handler.parent_directory + "/" + base + "XXXXXX";
+    // hack to use mkstemp to get us a safe temporary file name
+    int fd = mkstemp(&tmpname[0]);
+    if(fd != -1) {
+        // we don't leave it open; we are assumed to open it again externally
+        close(fd);
+    } else {
+        std::cerr << "[odgi]: couldn't create temp file on base "
+                  << base << " : " << tmpname << std::endl;
+        exit(1);
+    }
+    handler.filenames.insert(tmpname);
+    return tmpname;
+}
+
+std::string create() {
+    // No need to lock as we call this thing that locks
+    return create("odgi-");
+}
+
+void remove(const std::string& filename) {
+    std::lock_guard<std::recursive_mutex> lock(monitor);
+    
+    std::remove(filename.c_str());
+    handler.filenames.erase(filename);
+}
+
+void set_dir(const std::string& new_temp_dir) {
+    std::lock_guard<std::recursive_mutex> lock(monitor);
+    
+    temp_dir = new_temp_dir;
+}
+
+std::string get_dir() {
+    std::lock_guard<std::recursive_mutex> lock(monitor);
+
+    // Get the default temp dir from environment variables.
+    if (temp_dir.empty()) {
+        const char* system_temp_dir = nullptr;
+        for(const char* var_name : {"TMPDIR", "TMP", "TEMP", "TEMPDIR", "USERPROFILE"}) {
+            if (system_temp_dir == nullptr) {
+                system_temp_dir = getenv(var_name);
+            }
+        }
+        temp_dir = (system_temp_dir == nullptr ? "/tmp" : system_temp_dir);
+    }
+
+    return temp_dir;
+}
+
+}
+
+}
+}

--- a/src/algorithms/temp_file.hpp
+++ b/src/algorithms/temp_file.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+/**
+ * \file temp_file.hpp
+ *
+ * Defines a static structure to handle temp files and clean them up at exit
+ */
+
+#include <iostream>
+#include <mutex>
+#include <string>
+#include <set>
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+#include <dirent.h>
+
+namespace odgi {
+namespace algorithms {
+
+/**
+ * Temporary files. Create with create() and remove with remove(). All
+ * temporary files will be deleted when the program exits normally or with
+ * std::exit(). The files will be created in a directory determined from
+ * environment variables, though this can be overridden with set_dir().
+ * The interface is thread-safe.
+ */
+namespace temp_file {
+
+/// Create a temporary file starting with the given base name
+std::string create(const std::string& base);
+
+/// Create a temporary file
+std::string create();
+
+/// Remove a temporary file
+void remove(const std::string& filename);
+
+/// Set a temp dir, overriding system defaults and environment variables.
+void set_dir(const std::string& new_temp_dir);
+
+/// Get the current temp dir
+std::string get_dir();
+
+} // namespace temp_file
+
+}
+}

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -133,6 +133,8 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bo
         for(const handle_t& tail : tail_nodes(g)) {
             s.set(number_bool_packing::unpack_number(tail), 1);
         }
+    } else {
+        s.set(0, 1);
     }
 
     // We will use an ordered map handles by ID for nodes we have not visited

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -126,6 +126,7 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bo
     // topological sort on DAGs. It mimics the effect we used to get when we
     // joined all the head nodes to a new root head node and seeded that. We
     // ignore tails since we only orient right from nodes we pick.
+    /*
     if (use_heads) {
         for(const handle_t& head : head_nodes(g)) {
             s.set(number_bool_packing::unpack_number(head), 1);
@@ -135,6 +136,7 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bo
             s.set(number_bool_packing::unpack_number(tail), 1);
         }
     }
+    */
 
     // We will use an ordered map handles by ID for nodes we have not visited
     // yet. This ensures a consistent sort order across systems.

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -133,8 +133,6 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bo
         for(const handle_t& tail : tail_nodes(g)) {
             s.set(number_bool_packing::unpack_number(tail), 1);
         }
-    } else {
-        s.set(0, 1);
     }
 
     // We will use an ordered map handles by ID for nodes we have not visited
@@ -332,6 +330,8 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bo
         uint64_t c = g->get_node_count();
         std::cerr << "topological sort " << i << " of " << c << " ~ " << "100.0000%" << std::endl;
     }
+
+    assert(sorted.size() == g->get_node_count());
 
     // Send away our sorted ordering.
     return sorted;

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -49,7 +49,7 @@ std::vector<handle_t> tail_nodes(const HandleGraph* g) {
     
 }
 
-std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bool progress_reporting) {
+std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bool use_tails, bool progress_reporting) {
 
     // Make a vector to hold the ordered and oriented nodes.
     std::vector<handle_t> sorted;
@@ -126,17 +126,15 @@ std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads, bo
     // topological sort on DAGs. It mimics the effect we used to get when we
     // joined all the head nodes to a new root head node and seeded that. We
     // ignore tails since we only orient right from nodes we pick.
-    /*
     if (use_heads) {
         for(const handle_t& head : head_nodes(g)) {
             s.set(number_bool_packing::unpack_number(head), 1);
         }
-    } else {
+    } else if (use_tails) {
         for(const handle_t& tail : tail_nodes(g)) {
             s.set(number_bool_packing::unpack_number(tail), 1);
         }
     }
-    */
 
     // We will use an ordered map handles by ID for nodes we have not visited
     // yet. This ensures a consistent sort order across systems.

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -58,7 +58,10 @@ std::vector<handle_t> tail_nodes(const HandleGraph* g);
  *                     (This helps start at natural entry points to cycles)
  *     return L (a topologically sorted order and orientation)
  */
-std::vector<handle_t> topological_order(const HandleGraph* g, bool use_heads = true, bool progress_reporting = false);
+std::vector<handle_t> topological_order(const HandleGraph* g,
+                                        bool use_heads = true,
+                                        bool use_tails = false,
+                                        bool progress_reporting = false);
 
 std::vector<handle_t> two_way_topological_order(const HandleGraph* g);
 

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -701,7 +701,6 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
         order = &order_in;
     }
     // nodes
-    //hash_map<nid_t, nid_t> ids;
     std::vector<nid_t> ids;
     uint64_t max_handle_rank = 0;
     uint64_t min_handle_rank = std::numeric_limits<uint64_t>::max();
@@ -732,6 +731,7 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
     }
     // edges
     for (auto& handle : *order) {
+        node_t& node = node_v.at(number_bool_packing::unpack_number(handle));        
         follow_edges(handle, false, [&](const handle_t& h) {
                 ordered.create_edge(ordered.get_handle(ids[number_bool_packing::unpack_number(handle) - min_handle_rank],
                                                        get_is_reverse(handle)),

--- a/src/subcommand/chop_main.cpp
+++ b/src/subcommand/chop_main.cpp
@@ -18,7 +18,7 @@ int main_chop(int argc, char** argv) {
     argv[0] = (char*)prog_name.c_str();
     --argc;
     
-    args::ArgumentParser parser("merge unbranching linear components into single nodes (drops paths)");
+    args::ArgumentParser parser("divide nodes into smaller pieces");
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -68,7 +68,7 @@ int main_layout(int argc, char** argv) {
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> svg_out_file(parser, "FILE", "write the SVG rendering to this file", {'o', "out"});
     args::ValueFlag<uint64_t> iter_max(parser, "N", "maximum number of iterations to run the layout (default 30)", {'m', "iter-max"});
-    args::ValueFlag<uint64_t> num_pivots(parser, "N", "number of pivots for sparse layout (default 200)", {'p', "n-pivots"});
+    args::ValueFlag<uint64_t> num_pivots(parser, "N", "number of pivots for sparse layout (default 0, non-sparse layout)", {'p', "n-pivots"});
     args::ValueFlag<double> eps_rate(parser, "N", "learning rate for SGD layout (default 0.01)", {'e', "eps"});
     args::ValueFlag<double> x_pad(parser, "N", "padding between connected component layouts (default 10.0)", {'x', "x-padding"});
     args::ValueFlag<double> render_scale(parser, "N", "SVG scaling (default 5.0)", {'R', "render-scale"});
@@ -90,7 +90,7 @@ int main_layout(int argc, char** argv) {
     }
 
     uint64_t t_max = !args::get(iter_max) ? 30 : args::get(iter_max);
-    uint64_t n_pivots = !args::get(num_pivots) ? 200 : args::get(num_pivots);
+    uint64_t n_pivots = !args::get(num_pivots) ? 0 : args::get(num_pivots);
     double eps = !args::get(eps_rate) ? 0.01 : args::get(eps_rate);
     double x_padding = !args::get(x_pad) ? 10.0 : args::get(x_pad);
     double svg_scale = !args::get(render_scale) ? 5.0 : args::get(render_scale);

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -10,8 +10,7 @@ namespace odgi {
 using namespace odgi::subcommand;
 
 
-void draw_svg(ostream& out, const std::vector<double>& X, const HandleGraph& graph) {
-    double scale = 5.0;
+void draw_svg(ostream& out, const std::vector<double>& X, const HandleGraph& graph, double scale) {
     double border = 10.0;
     double min_x = 0;
     double min_y = 0;
@@ -64,7 +63,7 @@ int main_layout(int argc, char** argv) {
     argv[0] = (char*)prog_name.c_str();
     --argc;
     
-    args::ArgumentParser parser("draw 2D layouts of the graph using stocastic gradient descent");
+    args::ArgumentParser parser("draw 2D layouts of the graph using stocastic gradient descent (the graph must be sorted and id-compacted)");
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> svg_out_file(parser, "FILE", "write the SVG rendering to this file", {'o', "out"});
@@ -72,6 +71,7 @@ int main_layout(int argc, char** argv) {
     args::ValueFlag<uint64_t> num_pivots(parser, "N", "number of pivots for sparse layout (default 200)", {'p', "n-pivots"});
     args::ValueFlag<double> eps_rate(parser, "N", "learning rate for SGD layout (default 0.01)", {'e', "eps"});
     args::ValueFlag<double> x_pad(parser, "N", "padding between connected component layouts (default 10.0)", {'x', "x-padding"});
+    args::ValueFlag<double> render_scale(parser, "N", "SVG scaling (default 5.0)", {'R', "render-scale"});
     args::Flag debug(parser, "debug", "print information about the layout", {'d', "debug"});
 
     try {
@@ -93,6 +93,7 @@ int main_layout(int argc, char** argv) {
     uint64_t n_pivots = !args::get(num_pivots) ? 200 : args::get(num_pivots);
     double eps = !args::get(eps_rate) ? 0.01 : args::get(eps_rate);
     double x_padding = !args::get(x_pad) ? 10.0 : args::get(x_pad);
+    double svg_scale = !args::get(render_scale) ? 5.0 : args::get(render_scale);
     
     graph_t graph;
     assert(argc > 0);
@@ -112,10 +113,10 @@ int main_layout(int argc, char** argv) {
     std::string outfile = args::get(svg_out_file);
     if (outfile.size()) {
         if (outfile == "-") {
-            draw_svg(std::cout, layout, graph);
+            draw_svg(std::cout, layout, graph, svg_scale);
         } else {
             ofstream f(outfile.c_str());
-            draw_svg(f, layout, graph);
+            draw_svg(f, layout, graph, svg_scale);
             f.close();
         }
     }

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -1,0 +1,129 @@
+#include "subcommand.hpp"
+#include <iostream>
+#include "odgi.hpp"
+#include "args.hxx"
+#include "threads.hpp"
+#include "algorithms/sgd_layout.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+
+void draw_svg(ostream& out, const std::vector<double>& X, const HandleGraph& graph) {
+    double scale = 5.0;
+    double border = 10.0;
+    double min_x = 0;
+    double min_y = 0;
+    double max_x = 0;
+    double max_y = 0;
+    // determine boundaries
+    uint64_t n = graph.get_node_count();
+    for (uint64_t i = 0; i < n; ++i) {
+        double x = X[i*2]*scale;
+        double y = X[i*2+1]*scale;
+        if (x < min_x) min_x = x;
+        if (x > max_x) max_x = x;
+        if (y < min_y) min_y = y;
+        if (y > max_y) max_y = y;
+    }
+    double width = max_x - min_x;
+    double height = max_y - min_y;
+    
+    out << "<svg width=\"" << width + border << "\" height=\"" << height + border << "\" "
+        << "viewBox=\"" << min_x - border/2<< " " << min_y - border/2 << " " << width + border << " " << height + border << "\" xmlns=\"http://www.w3.org/2000/svg\">"
+        << "<style type=\"text/css\">"
+        << "line{stroke:black;stroke-width:1.0;stroke-opacity:1.0;stroke-linecap:round;}"
+        //<< "circle{{r:" << 1.0 << ";fill:black;fill-opacity:" << 1.0 << "}}"
+        << "</style>"
+        << std::endl;
+
+    // iterate through graph edges
+    graph.for_each_edge([&](const edge_t& e) {
+            uint64_t a = graph.get_id(e.first)-1;
+            uint64_t b = graph.get_id(e.second)-1;
+            out << "<line x1=\"" << X[a*2]*scale << "\" x2=\"" << X[b*2]*scale
+                << "\" y1=\"" << X[a*2+1]*scale << "\" y2=\"" << X[b*2+1]*scale << "\"/>"
+                << std::endl;
+        });
+    /* // to draw nodes
+    for (uint64_t i = 0; i < n; ++i) {
+        std::cout << "<circle cx=\"" << X[i*2]*scale << "\" cy=\"" << X[i*2+1]*scale << "\" r=\"1.0\"/>" << std::endl;
+    }
+    */
+    out << "</svg>" << std::endl;
+}
+
+int main_layout(int argc, char** argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc-1; ++i) {
+        argv[i] = argv[i+1];
+    }
+    std::string prog_name = "odgi layout";
+    argv[0] = (char*)prog_name.c_str();
+    --argc;
+    
+    args::ArgumentParser parser("draw 2D layouts of the graph using stocastic gradient descent");
+    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+    args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+    args::ValueFlag<std::string> svg_out_file(parser, "FILE", "write the SVG rendering to this file", {'o', "out"});
+    args::ValueFlag<uint64_t> iter_max(parser, "N", "maximum number of iterations to run the layout (default 30)", {'m', "iter-max"});
+    args::ValueFlag<uint64_t> num_pivots(parser, "N", "number of pivots for sparse layout (default 200)", {'p', "n-pivots"});
+    args::ValueFlag<double> eps_rate(parser, "N", "learning rate for SGD layout (default 0.01)", {'e', "eps"});
+    args::ValueFlag<double> x_pad(parser, "N", "padding between connected component layouts (default 10.0)", {'x', "x-padding"});
+    args::Flag debug(parser, "debug", "print information about the layout", {'d', "debug"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc==1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    uint64_t t_max = !args::get(iter_max) ? 30 : args::get(iter_max);
+    uint64_t n_pivots = !args::get(num_pivots) ? 200 : args::get(num_pivots);
+    double eps = !args::get(eps_rate) ? 0.01 : args::get(eps_rate);
+    double x_padding = !args::get(x_pad) ? 10.0 : args::get(x_pad);
+    
+    graph_t graph;
+    assert(argc > 0);
+    std::string infile = args::get(dg_in_file);
+    if (infile.size()) {
+        if (infile == "-") {
+            graph.load(std::cin);
+        } else {
+            ifstream f(infile.c_str());
+            graph.load(f);
+            f.close();
+        }
+    }
+
+    std::vector<double> layout = algorithms::sgd_layout(graph, n_pivots, t_max, eps, x_padding);
+
+    std::string outfile = args::get(svg_out_file);
+    if (outfile.size()) {
+        if (outfile == "-") {
+            draw_svg(std::cout, layout, graph);
+        } else {
+            ofstream f(outfile.c_str());
+            draw_svg(f, layout, graph);
+            f.close();
+        }
+    }
+    return 0;
+}
+
+static Subcommand odgi_layout("layout", "use SGD to make 2D layouts of the graph",
+                              PIPELINE, 3, main_layout);
+
+
+}

--- a/src/subcommand/matrix_main.cpp
+++ b/src/subcommand/matrix_main.cpp
@@ -1,7 +1,7 @@
 #include "subcommand.hpp"
 #include "odgi.hpp"
 #include "args.hxx"
-#include "algorithms/bin_path_info.hpp"
+#include "algorithms/matrix_writer.hpp"
 
 namespace odgi {
 
@@ -51,41 +51,7 @@ int main_matrix(int argc, char** argv) {
         }
     }
 
-    uint64_t edge_count = 0;
-    graph.for_each_edge([&](const edge_t& edge) {
-            ++edge_count;
-        });
-    std::cout << graph.max_node_id() << " " << graph.max_node_id() << " " << edge_count*2 << std::endl;
-    graph.for_each_edge([&](const edge_t& edge) {
-            // how many paths cross the edge?
-            double weight = 0;
-            if (args::get(weight_by_edge_depth)) {
-                graph.for_each_step_on_handle(edge.first, [&](const step_handle_t& step) {
-                        if (graph.get_handle_of_step(step) == edge.first
-                            && graph.has_next_step(step)) {
-                            handle_t next = graph.get_handle_of_step(graph.get_next_step(step));
-                            if (next == edge.second) {
-                                ++weight;
-                            }
-                        } else if (graph.get_handle_of_step(step) == graph.flip(edge.first)
-                                   && graph.has_previous_step(step)) {
-                            handle_t prev = graph.get_handle_of_step(graph.get_previous_step(step));
-                            if (prev == graph.flip(edge.second)) {
-                                ++weight;
-                            }
-                        }
-                    });
-            } else {
-                weight = 1;
-            }
-            if (args::get(weight_by_edge_delta)) {
-                double delta = std::abs(graph.get_id(edge.first) - graph.get_id(edge.second));
-                if (delta == 0) delta = 1;
-                weight = 1 / delta;
-            }
-            std::cout << graph.get_id(edge.first) << " " << graph.get_id(edge.second) << " " << weight << std::endl;
-            std::cout << graph.get_id(edge.second) << " " << graph.get_id(edge.first) << " " << weight << std::endl;
-        });
+    algorithms::write_as_sparse_matrix(std::cout, graph, args::get(weight_by_edge_depth), args::get(weight_by_edge_delta));
 
     return 0;
 }

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -147,6 +147,13 @@ int main_sort(int argc, char** argv) {
                 case 'r':
                     order = algorithms::random_order(graph);
                     break;
+                case 'f':
+                    order.clear();
+                    graph.for_each_handle([&order](const handle_t& handle) {
+                            order.push_back(handle);
+                        });
+                    std::reverse(order.begin(), order.end());
+                    break;
                 case 'm':
                     order = algorithms::mondriaan_sort(graph, args::get(mondriaan_n_parts), 1.0, false, false);
                     break;

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -7,6 +7,7 @@
 #include "algorithms/id_ordered_paths.hpp"
 #include "algorithms/dagify.hpp"
 #include "algorithms/split_strands.hpp"
+#include "algorithms/random_order.hpp"
 #include "algorithms/mondriaan_sort.hpp"
 
 namespace odgi {
@@ -34,10 +35,11 @@ int main_sort(int argc, char** argv) {
     args::Flag eades(parser, "eades", "use eades algorithm", {'e', "eades"});
     args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
     args::Flag two(parser, "two", "use two-way (max of head-first and tail-first) topological algorithm", {'w', "two-way"});
+    args::Flag randomize(parser, "random", "randomly sort the graph", {'r', "random"});
     args::Flag no_seeds(parser, "no-seeds", "don't use heads or tails to seed topological sort", {'n', "no-seeds"});
     args::Flag mondriaan(parser, "mondriaan", "use sparse matrix diagonalization to sort the graph", {'m', "mondriaan"});
     args::ValueFlag<uint64_t> mondriaan_n_parts(parser, "N", "number of partitions for mondriaan", {'N', "mondriaan-n-parts"});
-    
+    args::ValueFlag<double> mondriaan_epsilon(parser, "N", "epsilon parameter to mondriaan", {'E', "mondriaan-epsilon"});
     args::ValueFlag<std::string> pipeline(parser, "STRING", "apply a series of sorts, based on single-character command line arguments to this command, with 's' the default sort", {'p', "pipeline"});
     args::Flag paths_by_min_node_id(parser, "paths-min", "sort paths by their lowest contained node id", {'L', "paths-min"});
     args::Flag paths_by_max_node_id(parser, "paths-max", "sort paths by their highest contained node id", {'M', "paths-max"});
@@ -132,7 +134,9 @@ int main_sort(int argc, char** argv) {
         } else if (args::get(no_seeds)) {
             graph.apply_ordering(algorithms::topological_order(&graph, false, false, args::get(progress)), true);
         } else if (args::get(mondriaan)) {
-            graph.apply_ordering(algorithms::mondriaan_sort(graph, args::get(mondriaan_n_parts), 1.0, false, false), true);
+            graph.apply_ordering(algorithms::mondriaan_sort(graph, args::get(mondriaan_n_parts), args::get(mondriaan_epsilon), false, false), true);
+        } else if (args::get(randomize)) {
+            graph.apply_ordering(algorithms::random_order(graph), true);
         } else if (!args::get(pipeline).empty()) {
             // for each sort type, apply it to the graph
             std::vector<handle_t> order;
@@ -158,6 +162,9 @@ int main_sort(int argc, char** argv) {
                     break;
                 case 'w':
                     order = algorithms::two_way_topological_order(&graph);
+                    break;
+                case 'r':
+                    order = algorithms::random_order(graph);
                     break;
                 case 'm':
                     order = algorithms::mondriaan_sort(graph, args::get(mondriaan_n_parts), 1.0, false, false);

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -6,6 +6,7 @@
 #include "algorithms/cycle_breaking_sort.hpp"
 #include "algorithms/id_ordered_paths.hpp"
 #include "algorithms/dagify.hpp"
+#include "algorithms/mondriaan_sort.hpp"
 
 namespace odgi {
 
@@ -32,6 +33,8 @@ int main_sort(int argc, char** argv) {
     args::Flag eades(parser, "eades", "use eades algorithm", {'e', "eades"});
     args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
     args::Flag two(parser, "two", "use two-way (max of head-first and tail-first) topological algorithm", {'w', "two-way"});
+    args::Flag mondriaan(parser, "mondriaan", "use sparse matrix diagonalization to sort the graph", {'m', "mondriaan"});
+    args::ValueFlag<uint64_t> mondriaan_n_parts(parser, "mondriaan-n-parts", "number of partitions for mondriaan", {'N', "mondriaan-n-parts"});
     args::Flag no_seeds(parser, "no-seeds", "don't use heads or tails to seed topological sort", {'n', "no-seeds"});
     args::Flag paths_by_min_node_id(parser, "paths-min", "sort paths by their lowest contained node id", {'P', "paths-min"});
     args::Flag paths_by_max_node_id(parser, "paths-max", "sort paths by their highest contained node id", {'M', "paths-max"});
@@ -111,6 +114,8 @@ int main_sort(int argc, char** argv) {
             graph.apply_ordering(algorithms::cycle_breaking_sort(graph), true);
         } else if (args::get(no_seeds)) {
             graph.apply_ordering(algorithms::topological_order(&graph, false, false, args::get(progress)), true);
+        } else if (args::get(mondriaan)) {
+            graph.apply_ordering(algorithms::mondriaan_sort(graph, args::get(mondriaan_n_parts), 1.0, false, false), true);
         } else {
             graph.apply_ordering(algorithms::topological_order(&graph, true, false, args::get(progress)), true);
         }


### PR DESCRIPTION
Thus far, this branch implements a new kind of sort which I'm calling "dagified sort". In this, we dagify the graph and use the sort positions we get there to order the nodes in the original graph. This deals with the somewhat pathological problem that our pseudo topological sorter often pushes cyclic components very far in the sort order from their actual topological position. There might be better solutions.

In this branch I'll also be pulling in a bunch of changes that let us sort the graph using sparse matrix diagonalization techniques. The idea is that these are used for neighborhood detection in graphs, and these should still be applicable to genome graphs despite the relative sparsity of the edge matrix. For instance, we hope that a chromosome or SV cluster would tend to form a neighborhood in such a representation, without being affected by cycles or inversions as much as the methods we have available are.

These methods are great for getting the large scale order of the graph into a more meaningful shape, but aren't so good when dealing with local structures. I've discovered that I get great performance out of a series of sorts (eades, DFS, DAGified, topo) after a sort based on a symmetric (row and column equivalent) permutation of the sparse matrix representing an undirected version of the graph. These are seeded with the order from the matrix permutation and that's then smoothed by the locally correct topology-respecting properties of these methods. Most of the graphs are in acyclic segments, and exact sorting of these does best.

So for this graph of DRB1-3123, which is slightly tangled when built with minimap2 and seqwish, I can get a sort that seems to respect the overall topology (as implied by Bandage's force directed layout):

![image](https://user-images.githubusercontent.com/145425/64488438-1a26c880-d240-11e9-98e7-de623c443f9c.png)

![image](https://user-images.githubusercontent.com/145425/64488406-8c4add80-d23f-11e9-9255-eee863e216d7.png)

To do this, I'm applying particular configurations of the [Mondriaan](https://git.science.uu.nl/R.H.Bisseling/mondriaan) package for sparse matrix partitioning. One tricky aspect of this is that the partitioning seems to require a fixed parameter for the number of partitions. There are also lots and lots of options about how this is done.

This approach appears to have very nice runtime behavior, and runs in about the same amount of time as the series of deterministic sort algorithms that I apply post-hoc to clean up the fine structure of the sorted order.

This might be of interest to @jeizenga, @adamnovak, and @haussler.

Here's a script that should roughly reproduce the test on DRB1-3123:

```
# build the graph
minimap2 -c -x asm20 -X -r 10 -t 4 DRB1-3123.fa DRB1-3123.fa | gzip >DRB1-3123.paf.gz && time seqwish -s DRB1-3123.fa -p DRB1-3123.paf.gz -b DRB1-3123.work -g DRB1-3123.gfa
# make the sparse matrix form of it
odgi build -g DRB1-3123.gfa >DRB1-3123.og
odgi matrix -i DRB1-3123.og > DRB1-3123.mtx
# use mondrian to derive a sort
Mondriaan DRB1-3123.mtx 8 1 -Permute=SBD -EnforceSymmetricPermutation=yes -Coarsening_StopRatio=1 -SplitStrategy=finegrain -Iterative_Refinement=always -Coarsening_InprodScaling=max -VectorPartition_Step3=decrease -Coarsening_InprodMatchingOrder=incrwgt -Coarsening_NetScaling=no -Coarsening_MatchingStrategy=ata -Coarsening_MatchingATAMatcher=greedy -SquareMatrix_DistributeVectorsEqual_AddDummies=no -ImproveFreeNonzeros=no -LoadbalanceStrategy=increase 
# apply the sort and clean it up
odgi sort -i DRB1-3123.og -s DRB1-3123.mtx-col8 -o - \
    | odgi sort -i - -o - -e \
    | odgi sort -i - -o - -b \
    | odgi sort -i - -o - -d \
    | odgi sort -i - -o - \
    | odgi viz -i - -o DRB1-3123.gfa.viz.png -x 2000 -R
```