### PR TITLE
Chopp the graph nodes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ add_executable(odgi
   ${CMAKE_SOURCE_DIR}/src/subcommand/subset_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/bin_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/matrix_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/chop_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -1230,6 +1230,8 @@ std::pair<step_handle_t, step_handle_t> graph_t::rewrite_segment(const step_hand
     // verify that we're making a valid rewrite    
     assert(old_seq == new_seq);
     // find the before and after steps, which we'll link into
+    bool is_begin = !has_previous_step(segment_begin);
+    bool is_end = !has_next_step(segment_begin);
     step_handle_t before = get_previous_step(segment_begin);
     step_handle_t after = get_next_step(segment_begin);
     // get the path metadata
@@ -1251,12 +1253,12 @@ std::pair<step_handle_t, step_handle_t> graph_t::rewrite_segment(const step_hand
     for (uint64_t i = 0; i < new_steps.size()-1; ++i) {
         link_steps(new_steps[i], new_steps[i+1]);
     }
-    if (before != path_front_end(path)) {
+    if (!is_begin) {
         link_steps(before, new_steps.front());
     } else {
         path_meta.first = new_steps.front();
     }
-    if (after != path_end(path)) {
+    if (!is_end) {
         link_steps(new_steps.back(), after);
     } else {
         path_meta.last = new_steps.back();

--- a/src/subcommand/chop_main.cpp
+++ b/src/subcommand/chop_main.cpp
@@ -66,9 +66,7 @@ int main_chop(int argc, char** argv) {
         // get divide points
         uint64_t length = graph.get_length(handle);
         std::vector<size_t> offsets;
-        std::cerr << "node " << graph.get_id(handle) << " " << graph.get_length(handle) << std::endl;
         for (uint64_t i = max_node_length; i < length; i+=max_node_length) {
-            std::cerr << "cutting at " << i << std::endl;
             offsets.push_back(i);
         }
         graph.divide_handle(handle, offsets);

--- a/src/subcommand/chop_main.cpp
+++ b/src/subcommand/chop_main.cpp
@@ -1,0 +1,94 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include "threads.hpp"
+#include "algorithms/simple_components.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_chop(int argc, char** argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc-1; ++i) {
+        argv[i] = argv[i+1];
+    }
+    std::string prog_name = "odgi chop";
+    argv[0] = (char*)prog_name.c_str();
+    --argc;
+    
+    args::ArgumentParser parser("merge unbranching linear components into single nodes (drops paths)");
+    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+    args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+    args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});
+    args::ValueFlag<uint64_t> chop_to(parser, "N", "divide nodes to be shorter than this length", {'c', "chop-to"});
+    args::Flag debug(parser, "debug", "print information about the components", {'d', "debug"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc==1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    graph_t graph;
+    assert(argc > 0);
+    assert(args::get(kmer_length));
+    std::string infile = args::get(dg_in_file);
+    if (infile.size()) {
+        if (infile == "-") {
+            graph.load(std::cin);
+        } else {
+            ifstream f(infile.c_str());
+            graph.load(f);
+            f.close();
+        }
+    }
+
+    uint64_t max_node_length = args::get(chop_to);
+    std::vector<handle_t> to_chop;
+    graph.for_each_handle([&](const handle_t& handle) {
+            if (graph.get_length(handle) > max_node_length) {
+                to_chop.push_back(handle);
+            }
+        });
+
+    for (auto& handle : to_chop) {
+        // get divide points
+        uint64_t length = graph.get_length(handle);
+        std::vector<size_t> offsets;
+        std::cerr << "node " << graph.get_id(handle) << " " << graph.get_length(handle) << std::endl;
+        for (uint64_t i = max_node_length; i < length; i+=max_node_length) {
+            std::cerr << "cutting at " << i << std::endl;
+            offsets.push_back(i);
+        }
+        graph.divide_handle(handle, offsets);
+    }
+    
+    std::string outfile = args::get(dg_out_file);
+    if (outfile.size()) {
+        if (outfile == "-") {
+            graph.serialize(std::cout);
+        } else {
+            ofstream f(outfile.c_str());
+            graph.serialize(f);
+            f.close();
+        }
+    }
+    return 0;
+}
+
+static Subcommand odgi_chop("chop", "chop long nodes into short ones while preserving topology",
+                            PIPELINE, 3, main_chop);
+
+
+}

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -28,7 +28,7 @@ int main_stats(int argc, char** argv) {
     args::Flag path_coverage(parser, "coverage", "provide a histogram of path coverage over bases in the graph", {'C', "coverage"});
     args::Flag path_setcov(parser, "setcov", "provide a histogram of coverage over unique sets of paths", {'V', "set-coverage"});
     args::Flag path_multicov(parser, "multicov", "provide a histogram of coverage over unique multisets of paths", {'M', "multi-coverage"});
-    args::ValueFlag<std::string> path_bedmulticov(parser, "BED", "for each BED entry, provide a histogram of coverage over unique multisets of paths", {'B', "bed-multicov"});
+    args::ValueFlag<std::string> path_bedmulticov(parser, "BED", "for each BED entry, provide a table of path coverage over unique multisets of paths in the graph. Each unique multiset of paths overlapping a given BED interval is described in terms of its length relative to the total interval, the number of path traversals, and unique paths involved in these traversals.", {'B', "bed-multicov"});
     args::ValueFlag<uint64_t> threads(parser, "N", "number of threads to use", {'t', "threads"});
 
     try {
@@ -173,14 +173,14 @@ int main_stats(int argc, char** argv) {
         // the header
         std::cout << "path.name" << "\t"
                   << "bed.name" << "\t"
-                  << "ival.start" << "\t"
-                  << "ival.stop" << "\t"
-                  << "ival.len" << "\t"
-                  << "state.len" << "\t"
-                  << "frac" << "\t"
-                  << "paths.size" << "\t"
-                  << "uniq.size" << "\t"
-                  << "paths" << std::endl;
+                  << "bed.start" << "\t"
+                  << "bed.stop" << "\t"
+                  << "bed.len" << "\t"
+                  << "path.set.state.len" << "\t"
+                  << "path.set.frac" << "\t"
+                  << "path.traversals" << "\t"
+                  << "uniq.paths.in.state" << "\t"
+                  << "path.multiset" << std::endl;
 
 #pragma omp parallel for
         for (uint64_t k = 0; k < path_names.size(); ++k) {


### PR DESCRIPTION
This replicates `vg mod -X` in `odgi chop`.

Working on a vg-free graph processing pipeline. The goal is to make xg indexes that we can index with `vg index` for the GCSA2, and then do mapping without ever loading the graph into vg::VG.

While working on this I remembered that one problem we have for vg map are nodes with very high degree. We can remove them during the kmer indexing, but they still hurt the alignment. I should implement a fix in vg map that doesn't require removing nodes from the base graph that we use as reference because this will disrupt paths that are needed for positional indexing.