### PR TITLE
Use pybind11 to implement a python module and class for odgi::graph_t

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@
 *~
 build/
 bin/
+lib/
 test/
 .gdb_history

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/pybind11"]
+	path = deps/pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,7 @@ language: cpp
 compiler: gcc
 sudo: required
 dist: bionic
-python:
-    - 3.7
-#before_install:
-#install:
-#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:jonathonf/gcc-7.1; sudo apt-get update -qy; sudo apt-get install -qy gcc-7 g++-7; fi
-#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
+install:
+    sudo apt-get update -qy; sudo apt-get install -qy python-dev python3-dev
 script:
   - cmake -H. -Bbuild && cmake --build build -- -j 4 && echo Testing && bin/odgi test && cd lib && python -c 'import odgi; g = odgi.graph()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:jonathonf/gcc-7.1; sudo apt-get update -qy; sudo apt-get install -qy gcc-7 g++-7; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
 script:
-  - cmake -H. -Bbuild && cmake --build build -- -j 4 && echo Testing && bin/odgi test
+  - cmake -H. -Bbuild && cmake --build build -- -j 4 && echo Testing && bin/odgi test && cd lib && python -c 'import odgi; g = odgi.graph()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ compiler: gcc
 sudo: required
 dist: bionic
 install:
-    sudo apt-get update -qy; sudo apt-get install -qy python-dev python3-dev
+    sudo apt-get update -qy; sudo apt-get install -qy python-dev python3-dev python3.7-dev
 script:
   - cmake -H. -Bbuild && cmake --build build -- -j 4 && echo Testing && bin/odgi test && cd lib && python -c 'import odgi; g = odgi.graph()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 language: cpp
 compiler: gcc
 sudo: required
-dist: xenial
+dist: bionic
 #before_install:
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:jonathonf/gcc-7.1; sudo apt-get update -qy; sudo apt-get install -qy gcc-7 g++-7; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ dist: bionic
 install:
     sudo apt-get update -qy; sudo apt-get install -qy python-dev python3-dev python3.7-dev
 script:
-  - cmake -H. -Bbuild && cmake --build build -- -j 4 && echo Testing && bin/odgi test && cd lib && python -c 'import odgi; g = odgi.graph()'
+  - cmake -H. -Bbuild && cmake --build build -- -j 4 && echo Testing && bin/odgi test && cd lib && ls -l && python3.7 -c 'import odgi; g = odgi.graph()'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ language: cpp
 compiler: gcc
 sudo: required
 dist: bionic
+python:
+    - 3.7
 #before_install:
-install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:jonathonf/gcc-7.1; sudo apt-get update -qy; sudo apt-get install -qy gcc-7 g++-7; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
+#install:
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo add-apt-repository -y ppa:jonathonf/gcc-7.1; sudo apt-get update -qy; sudo apt-get install -qy gcc-7 g++-7; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 --slave /usr/bin/g++ g++ /usr/bin/g++-7; fi
 script:
   - cmake -H. -Bbuild && cmake --build build -- -j 4 && echo Testing && bin/odgi test && cd lib && python -c 'import odgi; g = odgi.graph()'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,18 +233,16 @@ ExternalProject_Get_property(picosha256 SOURCE_DIR)
 set(picosha256_INCLUDE "${SOURCE_DIR}")
 
 # pybind11
-
 #ExternalProject_Add(pybind11
 #    GIT_REPOSITORY https://github.com/pybind/pybind11.git 
 #    GIT_TAG v2.2.4
 #    CONFIGURE_COMMAND ""
 #    BUILD_COMMAND ""
-#    INSTALL_COMMAND ""
-#)
+#    INSTALL_COMMAND "")
 #ExternalProject_Get_Property(pybind11 SOURCE_DIR)
 #set(pybind11_INCLUDE_DIRS ${SOURCE_DIR}/include)
-#set(pybind11_DIR ${SOURCE_DIR}/pybind11/tools)
-#set(pybind11_DIR "${SOURCE_DIR}") # CACHE PATH "")
+#set(pybind11_DIR ${SOURCE_DIR})
+#add_subdirectory(${pybind11_DIR})
 
 set(CMAKE_BUILD_TYPE Release)
 #set(CMAKE_BUILD_TYPE Debug)
@@ -367,15 +365,16 @@ add_executable(odgi
 target_link_libraries(odgi ${odgi_LIBS})
 set_target_properties(odgi PROPERTIES OUTPUT_NAME "odgi")
 
-find_package(pybind11)
-if(pybind11_FOUND)
-  #message("system wide pybind11 installation found")
-  pybind11_add_module(odgi_pybind11 "${CMAKE_SOURCE_DIR}/src/pythonmodule.cpp")
-  add_dependencies(odgi_pybind11 ${odgi_DEPS} libodgi)
-  target_include_directories(odgi_pybind11 PUBLIC ${odgi_INCLUDES})
-  target_link_libraries(odgi_pybind11 PRIVATE "${CMAKE_SOURCE_DIR}/lib/libodgi.a" "${odgi_LIBS}")
-  set_target_properties(odgi_pybind11 PROPERTIES OUTPUT_NAME "odgi")
+if (NOT EXISTS ${CMAKE_SOURCE_DIR}/deps/pybind11/CMakeLists.txt)
+  execute_process(COMMAND git submodule update --init --recursive)
 endif()
+
+add_subdirectory(deps/pybind11)
+pybind11_add_module(odgi_pybind11 "${CMAKE_SOURCE_DIR}/src/pythonmodule.cpp")
+add_dependencies(odgi_pybind11 ${odgi_DEPS} libodgi)
+target_include_directories(odgi_pybind11 PUBLIC ${odgi_INCLUDES})
+target_link_libraries(odgi_pybind11 PRIVATE "${CMAKE_SOURCE_DIR}/lib/libodgi.a" "${odgi_LIBS}")
+set_target_properties(odgi_pybind11 PROPERTIES OUTPUT_NAME "odgi")
 
 if (APPLE)
 elseif (TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,9 +250,8 @@ set(CMAKE_BUILD_TYPE Release)
 #set(CMAKE_BUILD_TYPE Debug)
 
 # set up our target executable and specify its dependencies and includes
-add_executable(odgi
+add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/odgi.cpp
-  ${CMAKE_SOURCE_DIR}/src/main.cpp
   ${CMAKE_SOURCE_DIR}/src/crash.cpp
   ${CMAKE_SOURCE_DIR}/src/position.cpp
   ${CMAKE_SOURCE_DIR}/src/gfa_to_handle.cpp
@@ -319,8 +318,7 @@ set(odgi_DEPS
     structures
     sonlib
     picosha256)
-add_dependencies(odgi ${odgi_DEPS})
-
+add_dependencies(odgi_objs ${odgi_DEPS})
 
 set(odgi_INCLUDES
   "${CMAKE_SOURCE_DIR}/src"
@@ -353,19 +351,30 @@ set(odgi_LIBS
   "${sonLib_LIB}/stPinchesAndCacti.a"
   "${sonLib_LIB}/3EdgeConnected.a"
   "${sonLib_LIB}/sonLib.a"
-  "-ldl"
-  )
+  "-ldl")
 
-target_include_directories(odgi PUBLIC ${odgi_INCLUDES})
+target_include_directories(odgi_objs PUBLIC ${odgi_INCLUDES})
+set_target_properties(odgi_objs PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+
+add_library(libodgi STATIC $<TARGET_OBJECTS:odgi_objs>)
+set_target_properties(libodgi PROPERTIES OUTPUT_NAME "odgi")
+set_target_properties(libodgi PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+add_executable(odgi
+  $<TARGET_OBJECTS:odgi_objs>
+  ${CMAKE_SOURCE_DIR}/src/main.cpp)
 target_link_libraries(odgi ${odgi_LIBS})
+set_target_properties(odgi PROPERTIES OUTPUT_NAME "odgi")
 
 find_package(pybind11)
 if(pybind11_FOUND)
-  message("system wide pybind11 installation found\n")
+  #message("system wide pybind11 installation found")
   pybind11_add_module(odgi_pybind11 "${CMAKE_SOURCE_DIR}/src/pythonmodule.cpp")
-  add_dependencies(odgi_pybind11 ${odgi_DEPS})
+  add_dependencies(odgi_pybind11 ${odgi_DEPS} libodgi)
   target_include_directories(odgi_pybind11 PUBLIC ${odgi_INCLUDES})
-  target_link_libraries(odgi_pybind11 PRIVATE ${odgi_LIBS})
+  target_link_libraries(odgi_pybind11 PRIVATE "${CMAKE_SOURCE_DIR}/lib/libodgi.a" "${odgi_LIBS}")
+  set_target_properties(odgi_pybind11 PROPERTIES OUTPUT_NAME "odgi")
 endif()
 
 if (APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,20 @@ ExternalProject_Add(picosha256
 ExternalProject_Get_property(picosha256 SOURCE_DIR)
 set(picosha256_INCLUDE "${SOURCE_DIR}")
 
+# pybind11
+
+#ExternalProject_Add(pybind11
+#    GIT_REPOSITORY https://github.com/pybind/pybind11.git 
+#    GIT_TAG v2.2.4
+#    CONFIGURE_COMMAND ""
+#    BUILD_COMMAND ""
+#    INSTALL_COMMAND ""
+#)
+#ExternalProject_Get_Property(pybind11 SOURCE_DIR)
+#set(pybind11_INCLUDE_DIRS ${SOURCE_DIR}/include)
+#set(pybind11_DIR ${SOURCE_DIR}/pybind11/tools)
+#set(pybind11_DIR "${SOURCE_DIR}") # CACHE PATH "")
+
 set(CMAKE_BUILD_TYPE Release)
 #set(CMAKE_BUILD_TYPE Debug)
 
@@ -287,23 +301,28 @@ add_executable(odgi
   ${CMAKE_SOURCE_DIR}/src/algorithms/simple_components.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/bin_path_info.cpp
   )
-add_dependencies(odgi sdsl-lite)
-add_dependencies(odgi dynamic)
-add_dependencies(odgi hopscotch_map)
-add_dependencies(odgi backwardscpp)
-add_dependencies(odgi gfakluge)
-add_dependencies(odgi handlegraph)
-add_dependencies(odgi tayweeargs)
-add_dependencies(odgi bbhash)
-add_dependencies(odgi sparsepp)
-add_dependencies(odgi ska)
-add_dependencies(odgi intervaltree)
-add_dependencies(odgi bsort)
-add_dependencies(odgi lodepng)
-add_dependencies(odgi structures)
-add_dependencies(odgi sonlib)
-add_dependencies(odgi picosha256)
-target_include_directories(odgi PUBLIC
+
+set(odgi_DEPS 
+    sdsl-lite
+    dynamic
+    hopscotch_map
+    backwardscpp
+    gfakluge
+    handlegraph
+    tayweeargs
+    bbhash
+    sparsepp
+    ska
+    intervaltree
+    bsort
+    lodepng
+    structures
+    sonlib
+    picosha256)
+add_dependencies(odgi ${odgi_DEPS})
+
+
+set(odgi_INCLUDES
   "${CMAKE_SOURCE_DIR}/src"
   "${sdsl-lite_INCLUDE}"
   "${sdsl-lite-divsufsort_INCLUDE}"
@@ -324,7 +343,8 @@ target_include_directories(odgi PUBLIC
   "${sonLib_lib_INCLUDE}"
   "${sonLib_inc_INCLUDE}"
   "${picosha256_INCLUDE}")
-target_link_libraries(odgi
+
+set(odgi_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort.a"
   "${sdsl-lite-divsufsort_LIB}/libdivsufsort64.a"
@@ -335,6 +355,18 @@ target_link_libraries(odgi
   "${sonLib_LIB}/sonLib.a"
   "-ldl"
   )
+
+target_include_directories(odgi PUBLIC ${odgi_INCLUDES})
+target_link_libraries(odgi ${odgi_LIBS})
+
+find_package(pybind11)
+if(pybind11_FOUND)
+  message("system wide pybind11 installation found\n")
+  pybind11_add_module(odgi_pybind11 "${CMAKE_SOURCE_DIR}/src/pythonmodule.cpp")
+  add_dependencies(odgi_pybind11 ${odgi_DEPS})
+  target_include_directories(odgi_pybind11 PUBLIC ${odgi_INCLUDES})
+  target_link_libraries(odgi_pybind11 PRIVATE ${odgi_LIBS})
+endif()
 
 if (APPLE)
 elseif (TRUE)

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -82,6 +82,7 @@ protected:
     bool for_each_handle_impl(const std::function<bool(const handle_t&)>& iteratee, bool parallel = false) const;
     
 public:
+
     /// Return the number of nodes in the graph
     /// TODO: can't be node_count because XG has a field named node_count.
     size_t get_node_count(void) const;
@@ -346,7 +347,6 @@ public:
     /**
      * Insert a visit to a node to the given path between the given steps.
      * Returns a handle to the new step on the path which is appended.
-
      * Handles to prior steps on the path, and to other paths, must remain valid.
      */
     step_handle_t insert_step(const step_handle_t& before, const step_handle_t& after, const handle_t& to_insert);

--- a/src/pythonmodule.cpp
+++ b/src/pythonmodule.cpp
@@ -5,26 +5,23 @@
 // Pybind11
 #include <pybind11/pybind11.h>
 #include <pybind11/common.h>
-#include <pybind11/numpy.h>
-#include <pybind11/stl.h>
+//#include <pybind11/numpy.h>
+//#include <pybind11/stl.h>
 //using namespace pybind11 as py;
 namespace py = pybind11;
 
-
-PYBIND11_MODULE(odgi_pybind11, m)
+PYBIND11_MODULE(odgi, m)
 {
 
     // Expose class Graph to Python.
     py::class_<odgi::graph_t>(m, "graph", "the odgi graph type")
+        .def(py::init())
         .def("has_node",
               &odgi::graph_t::has_node,
-             "Return true if the given node is in the graph.",
-             py::arg("node_id"))
+             "Return true if the given node is in the graph.")
         .def("get_handle",
              &odgi::graph_t::get_handle,
-             "Return the handle for the given node id.",
-             py::arg("node_id"),
-             py::arg("is_reverse") = false)
+             "Return the handle for the given node id.")
         .def("get_id",
              &odgi::graph_t::get_id,
              "Return the id of the given handle.",

--- a/src/pythonmodule.cpp
+++ b/src/pythonmodule.cpp
@@ -135,7 +135,7 @@ PYBIND11_MODULE(odgi, m)
              "Return a step handle to a fictitious handle one past the end of the path.")
         .def("path_back",
              &odgi::graph_t::path_back,
-             "Return a step handle to the last step, which is arbitrary in the case of a circular path.")
+             "Return a step handle to the last step, which is arbitrary in the case\nof a circular path.")
         .def("path_front_end",
              &odgi::graph_t::path_front_end,
              "Return a step handle to a fictitious handle one past the start of the path.")
@@ -153,10 +153,10 @@ PYBIND11_MODULE(odgi, m)
              "Returns true if the step is not the first step on the path, else false.")
         .def("get_next_step",
              &odgi::graph_t::get_next_step,
-             "Returns a handle to the next step on the path. Calling on an end marker step returns the same end marker.")
+             "Returns a handle to the next step on the path. Calling on an end marker\nstep returns the same end marker.")
         .def("get_previous_step",
              &odgi::graph_t::get_previous_step,
-             "Returns a handle to the previous step on the path. Calling on a front end marker step returns the same end marker.")
+             "Returns a handle to the previous step on the path. Calling on a front\nend marker step returns the same end marker.")
         .def("get_path_handle_of_step",
              &odgi::graph_t::get_path_handle_of_step,
              "Returns a handle to the path that an step is on.")
@@ -183,10 +183,9 @@ PYBIND11_MODULE(odgi, m)
         .def("create_handle",
              [](odgi::graph_t& g, const std::string& sequence, const handlegraph::nid_t& id) { return g.create_handle(sequence, id); },
              "Create a new node with the given sequence and return the handle.")
-        //--
         .def("destroy_handle",
              &odgi::graph_t::destroy_handle,
-             "Remove the node belonging to the given handle and all of its edges. Does not update any stored paths. Invalidates the destroyed handle.")
+             "Remove the node belonging to the given handle and all of its edges.\nDoes not update any stored paths.\nInvalidates the destroyed handle.")
         .def("create_edge",
              [](odgi::graph_t& g, const handlegraph::handle_t& from, const handlegraph::handle_t& to) { return g.create_edge(from, to); },
              "Create an edge connecting the given handles in the given order and orientations.")
@@ -210,7 +209,7 @@ PYBIND11_MODULE(odgi, m)
              "Remove all stored paths.")
         .def("apply_ordering",
              &odgi::graph_t::apply_ordering,
-             "Reorder the graph's internal structure to match that given. Optionally compact the id space of the graph to match the ordering, from 1->|ordering|.",
+             "Reorder the graph's internal structure to match that given.\nOptionally compact the id space of the graph to match the ordering, from 1->|ordering|.",
              py::arg("order"),
              py::arg("compact_ids") = false)
         .def("optimize",
@@ -222,17 +221,17 @@ PYBIND11_MODULE(odgi, m)
              "Reorder the graph's paths as given.")
         .def("apply_orientation",
              &odgi::graph_t::apply_orientation,
-             "Alter the node that the given handle corresponds to so the orientation indicated by the handle becomes the node's local forward orientation. Updates all links and path steps to match the new orientation.")
+             "Alter the node that the given handle corresponds to so the orientation indicated\nby the handle becomes the node's local forward orientation.\nUpdates all links and path steps to match the new orientation.")
         .def("divide_handle",
              [](odgi::graph_t& g, const handlegraph::handle_t& handle, const std::vector<size_t>& offsets) {
                  return g.divide_handle(handle, offsets);
              },
-             "Split a handle's underlying node at the given offsets in the handle's orientation. Returns the handles to the new parts.")
+             "Split a handle's underlying node at the given offsets in the handle's orientation.\nReturns the handles to the new parts.")
         .def("divide_handle",
              [](odgi::graph_t& g, const handlegraph::handle_t& handle, size_t offset) {
                  return g.divide_handle(handle, offset);
              },
-             "Split a handle's underlying node at the given offset in the handle's orientation. Returns the handles to the new parts.")
+             "Split a handle's underlying node at the given offset in the handle's orientation.\nReturns the handles to the new parts.")
         .def("combine_handles",
              &odgi::graph_t::combine_handles,
              "Join handles into a new node, returning the handle of the new node.")
@@ -241,24 +240,24 @@ PYBIND11_MODULE(odgi, m)
              "Destroy the given path. Invalidates handles to the path and its node steps.")
         .def("create_path_handle",
              &odgi::graph_t::create_path_handle,
-             "Create a path with the given name. The caller must ensure that no path with the given name already exists.",
+             "Create a path with the given name. The caller must ensure that no path with the\ngiven name already exists.",
              py::arg("name"),
              py::arg("is_circular") = false)
         .def("prepend_step",
              &odgi::graph_t::prepend_step,
-             "Append a visit to a node to the given path. Returns a handle to the new final step on the path which is appended.")
+             "Append a visit to a node to the given path.\nReturns a handle to the new final step on the path which is appended.")
         .def("append_step",
              &odgi::graph_t::append_step,
-             "Append a visit to a node to the given path. Returns a handle to the new final step on the path which is appended.")
+             "Append a visit to a node to the given path.\nReturns a handle to the new final step\non the path which is appended.")
         .def("insert_step",
              &odgi::graph_t::insert_step,
-             "Insert a visit to a node to the given path between the given steps. Returns a handle to the new step on the path which is appended.")
+             "Insert a visit to a node to the given path between the given steps.\nReturns a handle to the new step on the path which is appended.")
         .def("set_step",
              &odgi::graph_t::set_step,
              "Set the step to the given handle, possibly re-linking and cleaning up if needed.")
         .def("rewrite_segment",
              &odgi::graph_t::rewrite_segment,
-             "Replace the path range with the new segment, returning the new start and end step handles for the segment.")
+             "Replace the path range with the new segment,\nreturning the new start and end step handles for the segment.")
         /*
         .def("display",
              &odgi::graph_t::display,

--- a/src/pythonmodule.cpp
+++ b/src/pythonmodule.cpp
@@ -4,24 +4,33 @@
 
 // Pybind11
 #include <pybind11/pybind11.h>
-#include <pybind11/common.h>
-//#include <pybind11/numpy.h>
-//#include <pybind11/stl.h>
-//using namespace pybind11 as py;
+#include <pybind11/functional.h>
+#include <pybind11/iostream.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+#include <pybind11/complex.h>
 namespace py = pybind11;
 
 PYBIND11_MODULE(odgi, m)
 {
+
+    py::class_<handlegraph::handle_t>(m, "handle", "the handle, which refers to oriented nodes");
+    py::class_<handlegraph::path_handle_t>(m, "path_handle", "the path handle type, which refers to paths");
+    py::class_<handlegraph::step_handle_t>(m, "step_handle", "the step handle type, which refers to path paths");
+    py::class_<handlegraph::edge_t>(m, "edge", "edges link two handles together");
 
     // Expose class Graph to Python.
     py::class_<odgi::graph_t>(m, "graph", "the odgi graph type")
         .def(py::init())
         .def("has_node",
               &odgi::graph_t::has_node,
-             "Return true if the given node is in the graph.")
+             "Return true if the given node is in the graph.",
+             py::arg("node_id"))
         .def("get_handle",
              &odgi::graph_t::get_handle,
-             "Return the handle for the given node id.")
+             "Return the handle for the given node id.",
+             py::arg("node_id"),
+             py::arg("is_reverse") = false)
         .def("get_id",
              &odgi::graph_t::get_id,
              "Return the id of the given handle.",
@@ -41,6 +50,18 @@ PYBIND11_MODULE(odgi, m)
         .def("get_sequence",
              &odgi::graph_t::get_sequence,
              py::arg("handle"))
+         .def("follow_edges",
+             [](const odgi::graph_t& g, const handlegraph::handle_t& handle, bool go_left, const std::function<bool(const handlegraph::handle_t&)>& iteratee) {
+                 return g.follow_edges(handle, go_left, iteratee);
+             },
+             "Follow edges starting at a given node.")
+        .def("for_each_handle",
+             [](const odgi::graph_t& g, const std::function<bool(const handlegraph::handle_t&)>& iteratee, bool parallel) {
+                 return g.for_each_handle(iteratee, parallel);
+             },
+             "Iterate over all the nodes in the graph.",
+             py::arg("iteratee"),
+             py::arg("parallel") = false)
         .def("get_node_count",
              &odgi::graph_t::get_node_count,
              "Return the number of nodes in the graph.")
@@ -50,6 +71,216 @@ PYBIND11_MODULE(odgi, m)
         .def("max_node_id",
              &odgi::graph_t::max_node_id,
              "Return the maximum node id in the graph.")
+        .def("set_id_increment ",
+             &odgi::graph_t::set_id_increment,
+             "Set a base increment for the node id space.")
+        .def("get_degree",
+             &odgi::graph_t::get_degree,
+             "Return the degree of the given node.")
+        .def("forward",
+             &odgi::graph_t::forward,
+             "Return the forward version of the handle.")
+        .def("edge_handle",
+             &odgi::graph_t::edge_handle,
+             "Return the edge handle for the given pair of handles.")
+        .def("has_path",
+             &odgi::graph_t::has_path,
+             "Return if a path with the givenv name exists in the graph.")
+        .def("get_path_handle",
+             &odgi::graph_t::get_path_handle,
+             "Return the path handle for the named path.")
+        .def("get_path_name",
+             &odgi::graph_t::get_path_name,
+             "Return the path name for a given path handle.")
+        .def("get_step_count",
+             [](const odgi::graph_t& g, const handlegraph::path_handle_t& path_handle) { return g.get_step_count(path_handle); },
+             "Return the step count of a given path.")
+        .def("get_path_count",
+             &odgi::graph_t::get_path_count,
+             "Return the path count of the graph")
+        .def("steps_of_handle",
+             &odgi::graph_t::steps_of_handle,
+             "Obtain the steps on a given handle.")
+        .def("for_each_path_handle",
+             [](const odgi::graph_t& g,
+                const std::function<bool(const handlegraph::path_handle_t&)>& iteratee) {
+                 return g.for_each_path_handle(iteratee);
+             },
+             "Invoke the callback for each path in the graph.")
+        .def("for_each_step_on_handle",
+             [](const odgi::graph_t& g,
+                const handlegraph::handle_t& handle,
+                const std::function<bool(const handlegraph::step_handle_t&)>& iteratee) {
+                 return g.for_each_step_on_handle(handle, iteratee);
+             },
+             "Invoke the callback for each of the steps on a given handle.")
+        .def("get_step_count",
+             [](const odgi::graph_t& g, const handlegraph::handle_t& handle) { return g.get_step_count(handle); },
+             "Return the number of steps on the given handle.")
+        .def("get_handle_of_step",
+             &odgi::graph_t::get_handle_of_step,
+             "Return the handle that a given step occurs on.")
+        .def("get_path",
+             &odgi::graph_t::get_path,
+             "Return the path of a given step handle.")
+        .def("path_begin",
+             &odgi::graph_t::path_begin,
+             "Return the step handle for the first step in the given path.")
+        .def("path_end",
+             &odgi::graph_t::path_end,
+             "Return a step handle to a fictitious handle one past the end of the path.")
+        .def("path_back",
+             &odgi::graph_t::path_back,
+             "Return a step handle to the last step, which is arbitrary in the case of a circular path.")
+        .def("path_front_end",
+             &odgi::graph_t::path_front_end,
+             "Return a step handle to a fictitious handle one past the start of the path.")
+        .def("is_path_front_end",
+             &odgi::graph_t::is_path_front_end,
+             "Returns true if the step handle is a front end magic handle.")
+        .def("is_path_end",
+             &odgi::graph_t::is_path_end,
+             "Returns true if the step handle is an end magic handle.")
+        .def("has_next_step",
+             &odgi::graph_t::has_next_step,
+             "Returns true if the step is not the last step on the path, else false.")
+        .def("has_previous_step",
+             &odgi::graph_t::has_previous_step,
+             "Returns true if the step is not the first step on the path, else false.")
+        .def("get_next_step",
+             &odgi::graph_t::get_next_step,
+             "Returns a handle to the next step on the path. Calling on an end marker step returns the same end marker.")
+        .def("get_previous_step",
+             &odgi::graph_t::get_previous_step,
+             "Returns a handle to the previous step on the path. Calling on a front end marker step returns the same end marker.")
+        .def("get_path_handle_of_step",
+             &odgi::graph_t::get_path_handle_of_step,
+             "Returns a handle to the path that an step is on.")
+        /*
+        .def("get_ordinal_rank_of_step",
+             &odgi::graph_t::get_ordinal_rank_of_step,
+             "Returns the 0-based ordinal rank of a step on a path. (warning: not implemented in odgi)")
+        */
+        .def("is_empty",
+             &odgi::graph_t::is_empty,
+             "Returns true if the given path is empty, and false otherwise.")
+        .def("for_each_step_in_path",
+             &odgi::graph_t::for_each_step_in_path,
+             "Invoke the callback for each step in a given path.")
+        .def("get_is_circular",
+             &odgi::graph_t::get_is_circular,
+             "Returns true if the path is circular.")
+        .def("set_circularity",
+             &odgi::graph_t::set_circularity,
+             "Set if the path is circular or not.")
+        .def("create_handle",
+             [](odgi::graph_t& g, const std::string& sequence) { return g.create_handle(sequence); },
+             "Create a new node with the given sequence and return the handle.")
+        .def("create_handle",
+             [](odgi::graph_t& g, const std::string& sequence, const handlegraph::nid_t& id) { return g.create_handle(sequence, id); },
+             "Create a new node with the given sequence and return the handle.")
+        //--
+        .def("destroy_handle",
+             &odgi::graph_t::destroy_handle,
+             "Remove the node belonging to the given handle and all of its edges. Does not update any stored paths. Invalidates the destroyed handle.")
+        .def("create_edge",
+             [](odgi::graph_t& g, const handlegraph::handle_t& from, const handlegraph::handle_t& to) { return g.create_edge(from, to); },
+             "Create an edge connecting the given handles in the given order and orientations.")
+        .def("create_edge",
+             [](odgi::graph_t& g, const handlegraph::edge_t& edge) { return g.create_edge(edge); },
+             "Create an edge connecting the given handles in the given order and orientations.")
+        .def("has_edge",
+             &odgi::graph_t::has_edge,
+             "Returns true if the given edge exists")
+        .def("destroy_edge",
+             [](odgi::graph_t& g, const handlegraph::edge_t& edge) { return g.destroy_edge(edge); },
+             "Remove the edge connecting the given handles in the given order and orientations.")
+        .def("destroy_edge",
+             [](odgi::graph_t& g, const handlegraph::handle_t& from, const handlegraph::handle_t& to) { return g.destroy_edge(from, to); },
+             "Remove the edge connecting the given handles in the given order and orientations.")
+        .def("clear",
+             &odgi::graph_t::clear,
+             "Remove all nodes and edges. Does not update any stored paths.")
+        .def("clear_paths",
+             &odgi::graph_t::clear_paths,
+             "Remove all stored paths.")
+        .def("apply_ordering",
+             &odgi::graph_t::apply_ordering,
+             "Reorder the graph's internal structure to match that given. Optionally compact the id space of the graph to match the ordering, from 1->|ordering|.",
+             py::arg("order"),
+             py::arg("compact_ids") = false)
+        .def("optimize",
+             &odgi::graph_t::optimize,
+             "Organize the graph for better performance and memory use.",
+             py::arg("allow_id_reassignment") = false)
+        .def("apply_path_ordering",
+             &odgi::graph_t::apply_path_ordering,
+             "Reorder the graph's paths as given.")
+        .def("apply_orientation",
+             &odgi::graph_t::apply_orientation,
+             "Alter the node that the given handle corresponds to so the orientation indicated by the handle becomes the node's local forward orientation. Updates all links and path steps to match the new orientation.")
+        .def("divide_handle",
+             [](odgi::graph_t& g, const handlegraph::handle_t& handle, const std::vector<size_t>& offsets) {
+                 return g.divide_handle(handle, offsets);
+             },
+             "Split a handle's underlying node at the given offsets in the handle's orientation. Returns the handles to the new parts.")
+        .def("divide_handle",
+             [](odgi::graph_t& g, const handlegraph::handle_t& handle, size_t offset) {
+                 return g.divide_handle(handle, offset);
+             },
+             "Split a handle's underlying node at the given offset in the handle's orientation. Returns the handles to the new parts.")
+        .def("combine_handles",
+             &odgi::graph_t::combine_handles,
+             "Join handles into a new node, returning the handle of the new node.")
+        .def("destroy_path",
+             &odgi::graph_t::destroy_path,
+             "Destroy the given path. Invalidates handles to the path and its node steps.")
+        .def("create_path_handle",
+             &odgi::graph_t::create_path_handle,
+             "Create a path with the given name. The caller must ensure that no path with the given name already exists.",
+             py::arg("name"),
+             py::arg("is_circular") = false)
+        .def("prepend_step",
+             &odgi::graph_t::prepend_step,
+             "Append a visit to a node to the given path. Returns a handle to the new final step on the path which is appended.")
+        .def("append_step",
+             &odgi::graph_t::append_step,
+             "Append a visit to a node to the given path. Returns a handle to the new final step on the path which is appended.")
+        .def("insert_step",
+             &odgi::graph_t::insert_step,
+             "Insert a visit to a node to the given path between the given steps. Returns a handle to the new step on the path which is appended.")
+        .def("set_step",
+             &odgi::graph_t::set_step,
+             "Set the step to the given handle, possibly re-linking and cleaning up if needed.")
+        .def("rewrite_segment",
+             &odgi::graph_t::rewrite_segment,
+             "Replace the path range with the new segment, returning the new start and end step handles for the segment.")
+        /*
+        .def("display",
+             &odgi::graph_t::display,
+             "A helper function to visualize the state of the graph")
+        */
+        .def("to_gfa",
+             [](const odgi::graph_t& g) {
+                 py::scoped_ostream_redirect stream(
+                     std::cout,
+                     py::module::import("sys").attr("stdout")
+                     );
+                 g.to_gfa(std::cout);
+             },
+             "Display as GFA")
+        .def("serialize",
+             [](odgi::graph_t& g, const std::string& file) {
+                 std::ofstream out(file.c_str());
+                 g.serialize(out);
+             },
+             "Save the graph to the given file, returning the number of bytes written.")
+        .def("load",
+             [](odgi::graph_t& g, const std::string& file) {
+                 std::ifstream in(file.c_str());
+                 g.load(in);
+             },
+             "Load the graph from the given file.")
         // Definition of class_<odgi::graph_t> ends here.
     ;
 

--- a/src/pythonmodule.cpp
+++ b/src/pythonmodule.cpp
@@ -1,0 +1,60 @@
+// odgi
+#include "odgi.hpp"
+//using namespace odgi;
+
+// Pybind11
+#include <pybind11/pybind11.h>
+#include <pybind11/common.h>
+#include <pybind11/numpy.h>
+#include <pybind11/stl.h>
+//using namespace pybind11 as py;
+namespace py = pybind11;
+
+
+PYBIND11_MODULE(odgi_pybind11, m)
+{
+
+    // Expose class Graph to Python.
+    py::class_<odgi::graph_t>(m, "graph", "the odgi graph type")
+        .def("has_node",
+              &odgi::graph_t::has_node,
+             "Return true if the given node is in the graph.",
+             py::arg("node_id"))
+        .def("get_handle",
+             &odgi::graph_t::get_handle,
+             "Return the handle for the given node id.",
+             py::arg("node_id"),
+             py::arg("is_reverse") = false)
+        .def("get_id",
+             &odgi::graph_t::get_id,
+             "Return the id of the given handle.",
+             py::arg("handle"))
+        .def("get_is_reverse",
+             &odgi::graph_t::get_is_reverse,
+             "Return true if the handle refers to the node reverse complement.",
+             py::arg("handle"))
+        .def("flip",
+             &odgi::graph_t::flip,
+             "Flip the handle to the opposite orientation.",
+             py::arg("handle"))
+        .def("get_length",
+             &odgi::graph_t::get_length,
+             "Return the length of the node referred to by the handle.",
+             py::arg("handle"))
+        .def("get_sequence",
+             &odgi::graph_t::get_sequence,
+             py::arg("handle"))
+        .def("get_node_count",
+             &odgi::graph_t::get_node_count,
+             "Return the number of nodes in the graph.")
+        .def("min_node_id",
+             &odgi::graph_t::min_node_id,
+             "Return the minimum node id in the graph.")
+        .def("max_node_id",
+             &odgi::graph_t::max_node_id,
+             "Return the maximum node id in the graph.")
+        // Definition of class_<odgi::graph_t> ends here.
+    ;
+
+
+}

--- a/src/pythonmodule.cpp
+++ b/src/pythonmodule.cpp
@@ -51,13 +51,13 @@ PYBIND11_MODULE(odgi, m)
              &odgi::graph_t::get_sequence,
              py::arg("handle"))
          .def("follow_edges",
-             [](const odgi::graph_t& g, const handlegraph::handle_t& handle, bool go_left, const std::function<bool(const handlegraph::handle_t&)>& iteratee) {
-                 return g.follow_edges(handle, go_left, iteratee);
-             },
+              [](const odgi::graph_t& g, const handlegraph::handle_t& handle, bool go_left, const std::function<bool(const handlegraph::handle_t&)>& iteratee) {
+                  return g.follow_edges(handle, go_left, [&iteratee](const handlegraph::handle_t& h) { iteratee(h); return true; });
+              },
              "Follow edges starting at a given node.")
         .def("for_each_handle",
              [](const odgi::graph_t& g, const std::function<bool(const handlegraph::handle_t&)>& iteratee, bool parallel) {
-                 return g.for_each_handle(iteratee, parallel);
+                 return g.for_each_handle([&iteratee](const handlegraph::handle_t& h){ iteratee(h); return true; }, parallel);
              },
              "Iterate over all the nodes in the graph.",
              py::arg("iteratee"),
@@ -104,14 +104,18 @@ PYBIND11_MODULE(odgi, m)
         .def("for_each_path_handle",
              [](const odgi::graph_t& g,
                 const std::function<bool(const handlegraph::path_handle_t&)>& iteratee) {
-                 return g.for_each_path_handle(iteratee);
+                 return g.for_each_path_handle([&iteratee](const handlegraph::path_handle_t& p) {
+                         iteratee(p); return true;
+                     });
              },
              "Invoke the callback for each path in the graph.")
         .def("for_each_step_on_handle",
              [](const odgi::graph_t& g,
                 const handlegraph::handle_t& handle,
                 const std::function<bool(const handlegraph::step_handle_t&)>& iteratee) {
-                 return g.for_each_step_on_handle(handle, iteratee);
+                 return g.for_each_step_on_handle(handle, [&iteratee](const handlegraph::step_handle_t& s) {
+                         iteratee(s); return true;
+                     });
              },
              "Invoke the callback for each of the steps on a given handle.")
         .def("get_step_count",


### PR DESCRIPTION
This wraps the main graph object in a python interface, resulting in a shared library that can be imported as a python module.

Future improvements could mirror much of the CLI API in python, which would have benefits for scripting efficiency. Currently, scripted processing with odgi tends to involve lots of piping, which is wasteful due to the cost of repeated loads and serializations.