### PR TITLE
flatten pangenome graphs into FASTA and BED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/matrix_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/chop_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/layout_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/flatten_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp
@@ -296,6 +297,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/mondriaan_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/matrix_writer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/temp_file.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/linear_index.cpp
   )
 
 set(odgi_DEPS 

--- a/src/algorithms/linear_index.cpp
+++ b/src/algorithms/linear_index.cpp
@@ -1,0 +1,30 @@
+#include "linear_index.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+linear_index_t::linear_index_t(const PathHandleGraph& graph) {
+    // generate our flattened sequence vector and a positional mapping into it for each handle
+    uint64_t graph_seq_size = 0;
+    graph.for_each_handle([&](const handle_t& h) {
+                              graph_seq_size += graph.get_length(h);
+                          });
+    graph_seq.reserve(graph_seq_size);
+    handle_positions.reserve(graph.get_node_count());
+    uint64_t curr_pos_in_seq = 0;
+    graph.for_each_handle([&](const handle_t& h) {
+                              graph_seq.append(graph.get_sequence(h));
+                              // verify that our graph handle space is compact
+                              // it should be when using a freshly loaded odgi graph
+                              assert(number_bool_packing::unpack_number(h) == handle_positions.size());
+                              handle_positions.push_back(curr_pos_in_seq);
+                              curr_pos_in_seq += graph.get_length(h);
+                          });
+}
+
+uint64_t linear_index_t::position_of_handle(const handle_t& handle) {
+    return handle_positions.at(number_bool_packing::unpack_number(handle));
+}
+
+}
+}

--- a/src/algorithms/linear_index.hpp
+++ b/src/algorithms/linear_index.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/path_handle_graph.hpp>
+#include <handlegraph/util.hpp>
+#include <cassert>
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+class linear_index_t {
+public:
+    std::string graph_seq;
+    std::vector<uint64_t> handle_positions;
+    uint64_t position_of_handle(const handle_t& handle);
+    linear_index_t(const PathHandleGraph& graph);
+};
+
+}
+}

--- a/src/subcommand/flatten_main.cpp
+++ b/src/subcommand/flatten_main.cpp
@@ -1,0 +1,124 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include "threads.hpp"
+#include "algorithms/linear_index.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_flatten(int argc, char** argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc-1; ++i) {
+        argv[i] = argv[i+1];
+    }
+    std::string prog_name = "odgi flatten";
+    argv[0] = (char*)prog_name.c_str();
+    --argc;
+
+    args::ArgumentParser parser("generate linearizations of the graph");
+    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+    args::ValueFlag<std::string> odgi_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+    args::ValueFlag<std::string> fasta_out_file(parser, "FILE", "write concatenated node sequences in FASTA format to FILE", {'f', "fasta"});
+    args::ValueFlag<std::string> fasta_seq_name(parser, "FILE", "name to use for the concatenated graph sequence (default: input file name)", {'n', "name-seq"});
+    args::ValueFlag<std::string> bed_out_file(parser, "FILE", "write a BED format FILE describing the mapping between graph paths and the linearized FASTA sequence", {'b', "bed"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc==1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    graph_t graph;
+    assert(argc > 0);
+    std::string infile = args::get(odgi_in_file);
+    if (infile.size()) {
+        if (infile == "-") {
+            graph.deserialize(std::cin);
+        } else {
+            ifstream f(infile.c_str());
+            graph.deserialize(f);
+            f.close();
+        }
+    }
+
+    if (args::get(fasta_out_file).empty() && args::get(bed_out_file).empty()) {
+        std::cerr << "[odgi flatten] Error: a FASTA or BED output must be specified" << std::endl;
+        return 2;
+    }
+
+    // graph linearization with handle to position mapping
+    algorithms::linear_index_t linear(graph);
+
+    std::string fasta_name = !args::get(fasta_seq_name).empty() ? args::get(fasta_seq_name) : args::get(odgi_in_file);
+    std::string fasta_out = args::get(fasta_out_file);
+    uint64_t fasta_line_width = 80;
+    auto write_fasta
+        = [&](ostream& out) {
+              out << ">" << fasta_name << std::endl;
+              for (uint64_t i = 0; i < linear.graph_seq.size(); i+=fasta_line_width) {
+                  out << linear.graph_seq.substr(i, fasta_line_width) << std::endl;
+              }
+          };
+    if (fasta_out.size()) {
+        if (fasta_out == "-") {
+            write_fasta(std::cout);
+        } else {
+            ofstream f(fasta_out.c_str());
+            write_fasta(f);
+        }
+    }
+
+    if (!args::get(bed_out_file).empty()) {
+        auto write_bed_line
+            = [&](ostream& out, const std::string& path_name, const uint64_t& start,
+                  const uint64_t& end, bool is_rev, const uint64_t& rank) {
+                  out << fasta_name << "\t" << start << "\t" << end << "\t"
+                      << path_name << "\t" << (is_rev ? "-" : "+") << "\t" << rank << std::endl;
+              };
+        std::string bed_out = args::get(bed_out_file);
+        ofstream b;
+        bool bed_stdout = true;
+        if (bed_out != "-") {
+            b.open(bed_out.c_str());
+            bed_stdout = false;
+        }
+        graph.for_each_path_handle(
+            [&](const path_handle_t& p) {
+                std::string path_name = graph.get_path_name(p);
+                uint64_t rank = 0;
+                graph.for_each_step_in_path(
+                    p,
+                    [&](const step_handle_t& s) {
+                        handle_t h = graph.get_handle_of_step(s);
+                        uint64_t start = linear.position_of_handle(h);
+                        uint64_t end = start + graph.get_length(h);
+                        bool is_rev = graph.get_is_reverse(h);
+                        if (bed_stdout) {
+                            write_bed_line(std::cout, path_name, start, end, is_rev, rank++);
+                        } else {
+                            write_bed_line(b, path_name, start, end, is_rev, rank++);
+                        }
+                    });
+            });
+    }
+    
+    return 0;
+}
+
+static Subcommand odgi_flatten("flatten", "project the graph sequence and paths into FASTA and BED",
+                               PIPELINE, 3, main_flatten);
+
+
+}


### PR DESCRIPTION
This adds a command line API to project graphs into FASTA and BED.

Using this example graph (https://github.com/vgteam/odgi/blob/master/docs/assets/lil.gfa):

```
H       VN:Z:1.0
S       1       CAAATAAG
L       1       +       2       +       0M
L       1       +       3       +       0M
S       2       A
L       2       +       4       +       0M
L       2       +       5       +       0M
S       3       G
L       3       +       4       +       0M
L       3       +       5       +       0M
S       4       T
L       4       +       6       +       0M
S       5       C
L       5       +       6       +       0M
S       6       TTG
L       6       +       7       +       0M
L       6       +       8       +       0M
S       7       A
L       7       +       9       +       0M
S       8       G
L       8       +       9       +       0M
S       9       AAATTTTCTGGAGTTCTAT
L       9       +       10      +       0M
L       9       +       11      +       0M
S       10      A
L       10      +       12      +       0M
S       11      T
L       11      +       12      +       0M
S       12      ATAT
L       12      +       13      +       0M
L       12      +       14      +       0M
S       13      A
L       13      +       15      +       0M
S       14      T
L       14      +       15      +       0M
S       15      CCAACTCTCTG
P       x       1+,3+,5+,6+,8+,9+,11+,12+,14+,15+       *,*,*,*,*,*,*,*,*
P       y       1+,2+,4+,6+,7+,9+,11+,12+,14+,15+       *,*,*,*,*,*,*,*,*
P       z       1+,3+,5+,6+,7+,9+,10+,12+,13+,15+       *,*,*,*,*,*,*,*,*
```

![image](https://user-images.githubusercontent.com/145425/72606950-e52e2f00-391f-11ea-8810-364d99c531b4.png)

We can project out the concatenated sequence vector of the graph in FASTA:

```
odgi build -g ../docs/assets/lil.gfa -s -o lil.odgi
odgi flatten -i lil.odgi -f - 
```

```
>lil.odgi
CAAATAAGAGTCTTGAGAAATTTTCTGGAGTTCTATATATATATCCAACTCTCTG
```

... or a BED file that shows how the paths (sequences) in our graph map into this sequence vector. Both order and orientation are shown in the last columns of the BED records.

```
odgi flatten -i lil.odgi -b - 
```

```
lil.odgi        0       8       x       +       0
lil.odgi        9       10      x       +       1
lil.odgi        11      12      x       +       2
lil.odgi        12      15      x       +       3
lil.odgi        16      17      x       +       4
lil.odgi        17      36      x       +       5
lil.odgi        37      38      x       +       6
lil.odgi        38      42      x       +       7
lil.odgi        43      44      x       +       8
lil.odgi        44      55      x       +       9
lil.odgi        0       8       y       +       0
lil.odgi        8       9       y       +       1
lil.odgi        10      11      y       +       2
lil.odgi        12      15      y       +       3
lil.odgi        15      16      y       +       4
lil.odgi        17      36      y       +       5
lil.odgi        37      38      y       +       6
lil.odgi        38      42      y       +       7
lil.odgi        43      44      y       +       8
lil.odgi        44      55      y       +       9
lil.odgi        0       8       z       +       0
lil.odgi        9       10      z       +       1
lil.odgi        11      12      z       +       2
lil.odgi        12      15      z       +       3
lil.odgi        15      16      z       +       4
lil.odgi        17      36      z       +       5
lil.odgi        36      37      z       +       6
lil.odgi        38      42      z       +       7
lil.odgi        42      43      z       +       8
lil.odgi        44      55      z       +       9
```

The last column is the rank of the record in those for the given path.

This transformation lets us apply bedtools directly to the genome graph. For instance, we can extract the sequence of a given path (in ordered pieces) using `getfasta`:

```
bedtools getfasta -fi lil.fasta -bed <(awk '$4 == "z"' lil.bed)
```

```
>lil.odgi:0-8
CAAATAAG
>lil.odgi:9-10
G
>lil.odgi:11-12
C
>lil.odgi:12-15
TTG
>lil.odgi:15-16
A
>lil.odgi:17-36
AAATTTTCTGGAGTTCTAT
>lil.odgi:36-37
A
>lil.odgi:38-42
ATAT
>lil.odgi:42-43
A
>lil.odgi:44-55
CCAACTCTCTG
```

The format of the BED records isn't quite what bedtools expects (strandedness seems to be in the wrong field). @arq5x might have some tips on how to sync things with bedtools!