### PR TITLE
Sorting using 1D stochastic gradient descent

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -49,3 +49,6 @@
 [submodule "deps/structures"]
 	path = deps/structures
 	url = https://github.com/jeizenga/structures.git
+[submodule "deps/libbf"]
+	path = deps/libbf
+	url = https://github.com/ekg/libbf.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/matrix_writer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/temp_file.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/linear_index.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/linear_sgd.cpp
   )
 
 set(odgi_DEPS 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,14 @@ ExternalProject_Get_property(mondriaan SOURCE_DIR)
 set(mondriaan_INCLUDE "${SOURCE_DIR}/src")
 set(mondriaan_LIB "${SOURCE_DIR}/lib")
 
+ExternalProject_Add(libbf
+  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/libbf"
+  CMAKE_ARGS "${CMAKE_ARGS};-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>")
+ExternalProject_Get_property(libbf INSTALL_DIR)
+#message(STATUS "libbf target " ${INSTALL_DIR})
+set(libbf_INCLUDE "${INSTALL_DIR}/include")
+set(libbf_LIB "${INSTALL_DIR}/lib")
+
 # pybind11
 #ExternalProject_Add(pybind11
 #    GIT_REPOSITORY https://github.com/pybind/pybind11.git 
@@ -317,7 +325,8 @@ set(odgi_DEPS
     sonlib
     picosha256
     sgd2
-    mondriaan)
+    mondriaan
+    libbf)
 add_dependencies(odgi_objs ${odgi_DEPS})
 
 set(odgi_INCLUDES
@@ -341,7 +350,8 @@ set(odgi_INCLUDES
   "${sonLib_inc_INCLUDE}"
   "${picosha256_INCLUDE}"
   "${sgd2_INCLUDE}"
-  "${mondriaan_INCLUDE}")
+  "${mondriaan_INCLUDE}"
+  "${libbf_INCLUDE}")
 
 set(odgi_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"
@@ -353,6 +363,7 @@ set(odgi_LIBS
   "${sonLib_LIB}/3EdgeConnected.a"
   "${sonLib_LIB}/sonLib.a"
   "${mondriaan_LIB}/libmondriaan.a"
+  "${libbf_LIB}/libbf.a"
   "-ldl")
 
 set(odgi_HEADERS

--- a/src/algorithms/bfs.cpp
+++ b/src/algorithms/bfs.cpp
@@ -42,12 +42,13 @@ void bfs(
         auto& curr = todo.back();
         handle_t handle = curr.handle;
         uint64_t root = curr.root;
-        uint64_t curr_length = curr.length + graph.get_length(handle);
+        uint64_t curr_length = curr.length;
         // pop the handle off the back of the queue
         todo.pop_back();
         if (!seen_fn(handle)) {
             // handle the handle
             handle_fn(handle, root, curr_length);
+            curr_length += graph.get_length(handle);
             // check if we've hit our break condition
             if (break_fn()) { return; }
             // check if we should stop here

--- a/src/algorithms/linear_sgd.cpp
+++ b/src/algorithms/linear_sgd.cpp
@@ -1,0 +1,170 @@
+#include "linear_sgd.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+std::vector<double> linear_sgd(const HandleGraph& graph,
+                               const uint64_t& bandwidth,
+                               const uint64_t& t_max,
+                               const double& eps,
+                               const double& delta) {
+    // our positions in 1D
+    std::vector<double> X(graph.get_node_count());
+    // seed them with the graph order
+    uint64_t len = 0;
+    graph.for_each_handle(
+        [&X,&graph,&len](const handle_t& handle) {
+            // nb: we assume that the graph provides a compact handle set
+            X[number_bool_packing::unpack_number(handle)] = len;
+            len += graph.get_length(handle);
+        });
+    // run banded BFSs in the graph to build our terms
+    std::vector<sgd_term_t> terms = linear_sgd_search(graph, bandwidth);
+    // get our schedule
+    std::vector<double> etas = linear_sgd_schedule(terms, t_max, eps);
+    // iterate through step sizes
+    /*
+    for (auto &t : terms) {
+        std::cerr << "considering " << graph.get_id(t.i) << " and " << graph.get_id(t.j) << " w = " << t.w << " d = " << t.d << std::endl;
+    }
+    */
+    uint64_t iteration = 0;
+    for (double eta : etas) {
+        // shuffle terms
+        std::random_shuffle(terms.begin(), terms.end());
+        // our max update
+        double Delta_max = 0;
+        for (auto &t : terms) {
+            //std::cerr << "considering " << graph.get_id(t.i) << " and " << graph.get_id(t.j) << " w = " << t.w << " d = " << t.d << std::endl;
+            // cap step size
+            double w_ij = t.w;
+            double mu = eta * w_ij;
+            if (mu > 1) {
+                mu = 1;
+            }
+            // actual distance in graph
+            double d_ij = t.d;
+            // identities
+            uint64_t i = number_bool_packing::unpack_number(t.i);
+            uint64_t j = number_bool_packing::unpack_number(t.j);
+            // distance == magnitude in our 1D situation
+            double dx = X[i]-X[j]; //, dy = X[i*2+1]-X[j*2+1];
+            //double mag = dx; //sqrt(dx*dx + dy*dy);
+            double mag = sqrt(dx*dx);
+            // check distances for early stopping
+            double Delta = mu * (mag-d_ij) / 2;
+            if (Delta > Delta_max) {
+                Delta_max = Delta;
+            }
+            // calculate update
+            double r = Delta / mag;
+            double r_x = r * dx;
+            // update our positions
+            X[i] -= r_x;
+            X[j] += r_x;
+        }
+        std::cerr << ++iteration << ", eta: " << eta << ", Delta: " << Delta_max << std::endl;
+        if (Delta_max < delta) {
+            return X;
+        }
+    }
+    return X;
+}
+
+// find pairs of handles to operate on, searching up to bandwidth steps, recording their graph distance
+std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph,
+                                          const uint64_t& bandwidth) {
+    std::vector<sgd_term_t> terms;
+    ska::flat_hash_set<std::pair<handle_t, handle_t>> seen_pairs;
+    graph.for_each_handle(
+        [&](const handle_t& h) {
+            uint64_t seen_steps = 0;
+            ska::flat_hash_set<handle_t> seen;
+            bfs(graph,
+                [&](const handle_t& n, const uint64_t& depth, const uint64_t& dist) {
+                    seen.insert(n);
+                    if (n != h) {
+                        double weight = 1.0 / ((double)dist*dist);
+                        if (!seen_pairs.count(std::make_pair(h, n))
+                            && !seen_pairs.count(std::make_pair(n, h))) {
+                            terms.push_back(sgd_term_t(h, n, dist, weight));
+                            seen_pairs.insert(std::make_pair(h, n));
+                        }
+                        ++seen_steps;
+                    }
+                },
+                [&](const handle_t& n) { return seen.count(n) > 0; },
+                [&](void) { return seen_steps > bandwidth; },
+                { h },
+                { },
+                false);
+        });
+    // todo take unique terms
+    /*
+    std::sort(terms.begin(), terms.end(),
+              [](const sgd_term_t& a,
+                 const sgd_term_t& b) {
+                  auto& a_i = as_integer(a.i);
+                  auto& a_j = as_integer(a.j);
+                  auto& b_i = as_integer(b.i);
+                  auto& b_j = as_integer(b.j);
+                  return a_i < b_i || a_i == b_i && a_j < b_j;
+              });
+    std::sort(terms.begin(), terms.end(),
+    */
+    return terms;
+}
+
+
+std::vector<double> linear_sgd_schedule(const std::vector<sgd_term_t> &terms,
+                                        const uint64_t& t_max,
+                                        const double& eps) {
+    double w_min = std::numeric_limits<double>::max();
+    double w_max = std::numeric_limits<double>::min();
+    for (auto& term : terms) {
+        auto& w = term.w;
+        if (w < w_min) w_min = w;
+        if (w > w_max) w_max = w;
+    }
+    double eta_max = 1.0 / w_min;
+    double eta_min = eps / w_max;
+    double lambda = log(eta_max/eta_min) / ((double)t_max-1);
+    // initialize step sizes
+    std::vector<double> etas;
+    etas.reserve(t_max);
+    for (uint64_t t=0; t<t_max; t++) {
+        etas.push_back(eta_max * exp(-lambda * t));
+    }
+    return etas;
+}
+
+std::vector<handle_t> linear_sgd_order(const HandleGraph& graph,
+                                       const uint64_t& bandwidth,
+                                       const uint64_t& t_max,
+                                       const double& eps,
+                                       const double& delta) {
+    std::vector<double> layout = linear_sgd(graph, bandwidth, t_max, eps, delta);
+    std::vector<std::pair<double, handle_t>> layout_handles;
+    uint64_t i = 0;
+    graph.for_each_handle([&i,&layout,&layout_handles](const handle_t& handle) {
+                              layout_handles.push_back(
+                                  std::make_pair(
+                                      layout[i++],
+                                      handle));
+                          });
+    std::sort(layout_handles.begin(), layout_handles.end(),
+              [&](const std::pair<double, handle_t>& a,
+                  const std::pair<double, handle_t>& b) {
+                  return a.first < b.first
+                                   || (a.first == b.first
+                                       && as_integer(a.second) < as_integer(b.second));
+              });
+    std::vector<handle_t> order;
+    for (auto& p : layout_handles) {
+        order.push_back(p.second);
+    }
+    return order;
+}
+
+}
+}

--- a/src/algorithms/linear_sgd.cpp
+++ b/src/algorithms/linear_sgd.cpp
@@ -99,7 +99,7 @@ std::vector<double> linear_sgd(const PathHandleGraph& graph,
 //#pragma omp critical (cerr)
 //                  std::cerr << "nodes are " << graph.get_id(t.i) << " and " << graph.get_id(t.j) << std::endl;
                     // distance == magnitude in our 1D situation
-                    double dx = X[i].load()-X[j].load(); //, dy = X[i*2+1]-X[j*2+1];
+                    double dx = X[i].load()-X[j].load();
                     if (dx == 0) {
                         dx = 1e-9; // avoid nan
                     }

--- a/src/algorithms/linear_sgd.hpp
+++ b/src/algorithms/linear_sgd.hpp
@@ -13,6 +13,7 @@
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/util.hpp>
+#include <bf/all.hpp>
 #include "hash_map.hpp"
 #include "bfs.hpp"
 
@@ -28,23 +29,35 @@ struct sgd_term_t {
 };
 
 // use SGD driven by banded pairwise distances to obtain a linear layout of the graph that respects its topology
-std::vector<double> linear_sgd(const HandleGraph& graph,
+std::vector<double> linear_sgd(const PathHandleGraph& graph,
                                const uint64_t& bandwidth,
+                               const double& sampling_rate,
+                               const bool& use_paths,
                                const uint64_t& t_max,
                                const double& eps,
                                const double& delta,
                                const uint64_t& nthreads);
 
+
 // find pairs of handles to operate on, searching up to bandwidth steps, recording their graph distance
-std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph, const uint64_t& bandwidth);
+std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph,
+                                          const uint64_t& bandwidth,
+                                          const double& sampling_rate);
+
+// find pairs of handles to operate on using path iteration to establish distances
+std::vector<sgd_term_t> linear_sgd_path_search(const PathHandleGraph& graph,
+                                               const uint64_t& bandwidth,
+                                               const double& sampling_rate);
 
 // our learning schedule
 std::vector<double> linear_sgd_schedule(const std::vector<sgd_term_t>& terms,
                                         const uint64_t& t_max,
                                         const double& eps);
 
-std::vector<handle_t> linear_sgd_order(const HandleGraph& graph,
+std::vector<handle_t> linear_sgd_order(const PathHandleGraph& graph,
                                        const uint64_t& bandwidth,
+                                       const double& sampling_rate,
+                                       const bool& use_paths,
                                        const uint64_t& t_max,
                                        const double& eps,
                                        const double& delta,

--- a/src/algorithms/linear_sgd.hpp
+++ b/src/algorithms/linear_sgd.hpp
@@ -6,6 +6,10 @@
 #include <algorithm>
 #include <random>
 #include <set>
+#include <thread>
+#include <mutex>
+#include <atomic>
+#include <chrono>
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/path_handle_graph.hpp>
 #include <handlegraph/util.hpp>
@@ -28,7 +32,8 @@ std::vector<double> linear_sgd(const HandleGraph& graph,
                                const uint64_t& bandwidth,
                                const uint64_t& t_max,
                                const double& eps,
-                               const double& delta);
+                               const double& delta,
+                               const uint64_t& nthreads);
 
 // find pairs of handles to operate on, searching up to bandwidth steps, recording their graph distance
 std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph, const uint64_t& bandwidth);
@@ -42,7 +47,8 @@ std::vector<handle_t> linear_sgd_order(const HandleGraph& graph,
                                        const uint64_t& bandwidth,
                                        const uint64_t& t_max,
                                        const double& eps,
-                                       const double& delta);
+                                       const double& delta,
+                                       const uint64_t& nthreads);
 
 }
 }

--- a/src/algorithms/linear_sgd.hpp
+++ b/src/algorithms/linear_sgd.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include <cassert>
+#include <algorithm>
+#include <random>
+#include <set>
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/path_handle_graph.hpp>
+#include <handlegraph/util.hpp>
+#include "hash_map.hpp"
+#include "bfs.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+struct sgd_term_t {
+    handle_t i, j;
+    double d, w;
+    sgd_term_t(const handle_t& i, const handle_t& j, const double& d, const double& w) : i(i), j(j), d(d), w(w) {}
+};
+
+// use SGD driven by banded pairwise distances to obtain a linear layout of the graph that respects its topology
+std::vector<double> linear_sgd(const HandleGraph& graph,
+                               const uint64_t& bandwidth,
+                               const uint64_t& t_max,
+                               const double& eps,
+                               const double& delta);
+
+// find pairs of handles to operate on, searching up to bandwidth steps, recording their graph distance
+std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph, const uint64_t& bandwidth);
+
+// our learning schedule
+std::vector<double> linear_sgd_schedule(const std::vector<sgd_term_t>& terms,
+                                        const uint64_t& t_max,
+                                        const double& eps);
+
+std::vector<handle_t> linear_sgd_order(const HandleGraph& graph,
+                                       const uint64_t& bandwidth,
+                                       const uint64_t& t_max,
+                                       const double& eps,
+                                       const double& delta);
+
+}
+}

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -41,12 +41,12 @@ int main_sort(int argc, char** argv) {
     args::Flag eades(parser, "eades", "use eades algorithm", {'e', "eades"});
     //args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
     args::Flag lsgd(parser, "linear-sgd", "apply 1D (linear) SGD algorithm to organize graph", {'S', "linear-sgd"});
-    args::ValueFlag<uint64_t> lsgd_bandwidth(parser, "sgd-bandwidth", "bandwidth of linear SGD model", {'O', "sgd-bandwidth"});
-    args::ValueFlag<double> lsgd_sampling_rate(parser, "sgd-sampling-rate", "rate to sample pairs of nodes, scaled by squared graph distance", {'Q', "sgd-sampling-rate"});
+    args::ValueFlag<uint64_t> lsgd_bandwidth(parser, "sgd-bandwidth", "bandwidth of linear SGD model (default: 1000)", {'O', "sgd-bandwidth"});
+    args::ValueFlag<double> lsgd_sampling_rate(parser, "sgd-sampling-rate", "sample pairs of nodes with probability distance between them divided by the sampling rate (default: 20)", {'Q', "sgd-sampling-rate"});
     args::Flag lsgd_use_paths(parser, "sgd-use-paths", "use paths to structure internode distances in SGD", {'K', "sgd-use-paths"});
-    args::ValueFlag<uint64_t> lsgd_iter_max(parser, "sgd-iter-max", "max number of iterations for linear SGD model", {'T', "sgd-iter-max"});
-    args::ValueFlag<double> lsgd_eps(parser, "sgd-eps", "learning rate for linear SGD model", {'V', "sgd-eps"});
-    args::ValueFlag<double> lsgd_delta(parser, "sgd-delta", "learning rate for linear SGD model", {'C', "sgd-delta"});
+    args::ValueFlag<uint64_t> lsgd_iter_max(parser, "sgd-iter-max", "max number of iterations for linear SGD model (default: 30)", {'T', "sgd-iter-max"});
+    args::ValueFlag<double> lsgd_eps(parser, "sgd-eps", "final learning rate for linear SGD model (default: 0.01)", {'V', "sgd-eps"});
+    args::ValueFlag<double> lsgd_delta(parser, "sgd-delta", "threshold of maximum node displacement (approximately in bp) at which to stop SGD (default: 0)", {'C', "sgd-delta"});
     args::Flag two(parser, "two", "use two-way (max of head-first and tail-first) topological algorithm", {'w', "two-way"});
     args::Flag randomize(parser, "random", "randomly sort the graph", {'r', "random"});
     args::Flag no_seeds(parser, "no-seeds", "don't use heads or tails to seed topological sort", {'n', "no-seeds"});
@@ -102,8 +102,8 @@ int main_sort(int argc, char** argv) {
     // default settings
     uint64_t df_chunk_size = args::get(depth_first_chunk) ? args::get(depth_first_chunk) : 1000;
     uint64_t bf_chunk_size = args::get(breadth_first_chunk) ? args::get(breadth_first_chunk) : std::numeric_limits<uint64_t>::max();
-    uint64_t sgd_bandwidth = args::get(lsgd_bandwidth) ? args::get(lsgd_bandwidth) : 100;
-    double sgd_sampling_rate = args::get(lsgd_sampling_rate) ? args::get(lsgd_sampling_rate) : 10;
+    uint64_t sgd_bandwidth = args::get(lsgd_bandwidth) ? args::get(lsgd_bandwidth) : 1000;
+    double sgd_sampling_rate = args::get(lsgd_sampling_rate) ? args::get(lsgd_sampling_rate) : 20;
     double sgd_iter_max = args::get(lsgd_iter_max) ? args::get(lsgd_iter_max) : 30;
     double sgd_eps = args::get(lsgd_eps) ? args::get(lsgd_eps) : 0.01;
     double sgd_delta = args::get(lsgd_delta) ? args::get(lsgd_delta) : 0;

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -10,6 +10,7 @@
 #include "algorithms/dagify_sort.hpp"
 #include "algorithms/random_order.hpp"
 #include "algorithms/mondriaan_sort.hpp"
+#include "algorithms/linear_sgd.hpp"
 
 namespace odgi {
 
@@ -29,7 +30,7 @@ int main_sort(int argc, char** argv) {
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph in this file", {'o', "out"});
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
-    args::Flag show_sort(parser, "show", "write the sort order mapping", {'S', "show"});
+    //args::Flag show_sort(parser, "show", "write the sort order mapping", {'S', "show"});
     args::ValueFlag<std::string> sort_order_in(parser, "FILE", "load the sort order from this file", {'s', "sort-order"});
     args::Flag cycle_breaking(parser, "cycle_breaking", "use a cycle breaking sort", {'c', "cycle-breaking"});
     args::Flag breadth_first(parser, "breadth_first", "use a breadth first topological sort", {'b', "breadth-first"});
@@ -38,7 +39,12 @@ int main_sort(int argc, char** argv) {
     args::ValueFlag<uint64_t> depth_first_chunk(parser, "N", "chunk size for depth first topological sort", {'Z', "depth-first-chunk"});
     args::Flag dagify(parser, "dagify", "sort on the basis of the DAGified graph", {'d', "dagify-sort"});
     args::Flag eades(parser, "eades", "use eades algorithm", {'e', "eades"});
-    args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
+    //args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
+    args::Flag lsgd(parser, "linear-sgd", "apply 1D (linear) SGD algorithm to organize graph", {'S', "linear-sgd"});
+    args::ValueFlag<uint64_t> lsgd_bandwidth(parser, "sgd-bandwidth", "bandwidth of linear SGD model", {'O', "sgd-bandwidth"});
+    args::ValueFlag<uint64_t> lsgd_iter_max(parser, "sgd-iter-max", "max number of iterations for linear SGD model", {'T', "sgd-iter-max"});
+    args::ValueFlag<double> lsgd_eps(parser, "sgd-eps", "learning rate for linear SGD model", {'V', "sgd-eps"});
+    args::ValueFlag<double> lsgd_delta(parser, "sgd-delta", "learning rate for linear SGD model", {'C', "sgd-delta"});
     args::Flag two(parser, "two", "use two-way (max of head-first and tail-first) topological algorithm", {'w', "two-way"});
     args::Flag randomize(parser, "random", "randomly sort the graph", {'r', "random"});
     args::Flag no_seeds(parser, "no-seeds", "don't use heads or tails to seed topological sort", {'n', "no-seeds"});
@@ -81,17 +87,28 @@ int main_sort(int argc, char** argv) {
             f.close();
         }
     }
+    /*
     if (args::get(show_sort)) {
         std::vector<handle_t> order = (args::get(lazy) ? algorithms::lazy_topological_order(&graph) : algorithms::topological_order(&graph));
         for (auto& handle : order) {
             std::cout << graph.get_id(handle) << std::endl;
         }
     }
+    */
 
     uint64_t df_chunk_size = args::get(depth_first_chunk);
     df_chunk_size = df_chunk_size ? df_chunk_size : 1000;
     uint64_t bf_chunk_size = args::get(breadth_first_chunk);
     bf_chunk_size = bf_chunk_size ? bf_chunk_size : std::numeric_limits<uint64_t>::max();
+
+    uint64_t sgd_bandwidth = args::get(lsgd_bandwidth);
+    sgd_bandwidth = sgd_bandwidth ? sgd_bandwidth : 100;
+    double sgd_iter_max = args::get(lsgd_iter_max);
+    sgd_iter_max = sgd_iter_max ? sgd_iter_max : 30;
+    double sgd_eps = args::get(lsgd_eps);
+    sgd_eps = sgd_eps ? sgd_eps : 0.01;
+    double sgd_delta = args::get(lsgd_delta);
+    sgd_delta = sgd_delta ? sgd_delta : 0;
 
     // helper, TODO: move into its own file
     // make a dagified copy, get its sort, and apply the order to our graph
@@ -100,8 +117,6 @@ int main_sort(int argc, char** argv) {
     if (outfile.size()) {
         if (args::get(eades)) {
             graph.apply_ordering(algorithms::eades_algorithm(&graph), true);
-        } else if (args::get(lazy)) {
-            graph.apply_ordering(algorithms::lazy_topological_order(&graph), true);
         } else if (args::get(two)) {
             graph.apply_ordering(algorithms::two_way_topological_order(&graph), true);
         } else if (args::get(optimize)) {
@@ -126,6 +141,12 @@ int main_sort(int argc, char** argv) {
                                                             args::get(mondriaan_n_parts),
                                                             args::get(mondriaan_epsilon),
                                                             args::get(mondriaan_path_weight), false), true);
+        } else if (args::get(lsgd)) {
+            graph.apply_ordering(algorithms::linear_sgd_order(graph,
+                                                              sgd_bandwidth,
+                                                              sgd_iter_max,
+                                                              sgd_eps,
+                                                              sgd_delta));
         } else if (args::get(breadth_first)) {
             graph.apply_ordering(algorithms::breadth_first_topological_order(graph, bf_chunk_size), true);
         } else if (args::get(depth_first)) {
@@ -161,14 +182,18 @@ int main_sort(int argc, char** argv) {
                 case 'z':
                     order = algorithms::depth_first_topological_order(graph, df_chunk_size);
                     break;
-                case 'l':
-                    order = algorithms::lazy_topological_order(&graph);
-                    break;
                 case 'w':
                     order = algorithms::two_way_topological_order(&graph);
                     break;
                 case 'r':
                     order = algorithms::random_order(graph);
+                    break;
+                case 'S':
+                    order = algorithms::linear_sgd_order(graph,
+                                                         sgd_bandwidth,
+                                                         sgd_iter_max,
+                                                         sgd_eps,
+                                                         sgd_delta);
                     break;
                 case 'f':
                     order.clear();


### PR DESCRIPTION
This PR includes a specialization of the 2D SGD model used in the paper "Graph Drawing by Stochastic Gradient Descent" https://doi.org/10.1109/TVCG.2018.2859997. The algorithm is also extended to run in parallel. The code from that paper was already included in `odgi layout` for small graph drawing.

This still a work in progress. Although it does work, it's not very efficient in terms of runtime. We randomly collect a subset of the node pairs using BFS or path walking in the graph to measure their actual graph distance. A parallel, lock-free stochastic gradient descent algorithm then drives computation of the layout.

The layouts that can be achieved for small graphs are great. However, they require something close to quadratic space in the node count of the graph. This really isn't tenable, and so I've implemented various sampling strategies that adjust the probability of considering a node pair by their relative distance, and explores up to some fixed bandwidth. This is all configurable from the command line.