### PR TITLE
Break cycles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/chop_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/layout_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/flatten_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/break_main.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/topological_sort.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/hash.cpp
@@ -307,6 +308,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/temp_file.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/linear_index.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/linear_sgd.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/break_cycles.cpp
   )
 
 set(odgi_DEPS 

--- a/src/algorithms/bfs.hpp
+++ b/src/algorithms/bfs.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/util.hpp>
 #include <vector>
 #include <set>
 #include <deque>
@@ -19,8 +20,10 @@ void bfs(
     // the fourth parameter gives the search depth at this point
     // return true to continue through this node, false to treat it like a sink
     const std::function<void(const handle_t&, const uint64_t&, const uint64_t&, const uint64_t&)>& handle_fn,
-    // the edge we will traverse to get to a new handle, returns true if we should continue
-    const std::function<bool(const handle_t&, const handle_t&)>& seen_fn,
+    // should we consider this handle and its edges?, returns false if we should continue
+    const std::function<bool(const handle_t&)>& seen_handle_fn,
+    // the edge we will traverse to get to a new handle, returns false if we should continue across the edge
+    const std::function<bool(const handle_t&, const handle_t&)>& seen_edge_fn,
     // called to check if we should stop the DFS; we stop when true is returned.
     const std::function<bool(void)>& break_fn,
     // start only at these node traversals

--- a/src/algorithms/bfs.hpp
+++ b/src/algorithms/bfs.hpp
@@ -16,10 +16,11 @@ void bfs(
     // called when a given node orientation is first encountered
     // the second parameter gives the rank of the root among the input set of seeds
     // the third parameter gives the cumulative length from the search root that led to this handle
+    // the fourth parameter gives the search depth at this point
     // return true to continue through this node, false to treat it like a sink
-    const std::function<void(const handle_t&, const uint64_t&, const uint64_t&)>& handle_fn,
-    // have we seen this handle before?
-    const std::function<bool(const handle_t&)>& seen_fn,
+    const std::function<void(const handle_t&, const uint64_t&, const uint64_t&, const uint64_t&)>& handle_fn,
+    // the edge we will traverse to get to a new handle, returns true if we should continue
+    const std::function<bool(const handle_t&, const handle_t&)>& seen_fn,
     // called to check if we should stop the DFS; we stop when true is returned.
     const std::function<bool(void)>& break_fn,
     // start only at these node traversals
@@ -34,6 +35,7 @@ struct bfs_state_t {
     handle_t handle;
     uint64_t root;
     uint64_t length;
+    uint64_t depth;
 };
 
 }

--- a/src/algorithms/break_cycles.cpp
+++ b/src/algorithms/break_cycles.cpp
@@ -81,6 +81,18 @@ std::vector<edge_t> edges_inducing_cycles(
     return edges;
 }
 
+uint64_t break_cycles(
+    DeletableHandleGraph& graph,
+    const uint64_t& max_cycle_size,
+    const uint64_t& max_search_bp) {
+
+    std::vector<edge_t> edges_to_remove = edges_inducing_cycles(graph, max_cycle_size, max_search_bp);
+    for (auto& edge : edges_to_remove) {
+        graph.destroy_edge(edge);
+    }
+    return edges_to_remove.size();
+}
+
 }
 
 }

--- a/src/algorithms/break_cycles.cpp
+++ b/src/algorithms/break_cycles.cpp
@@ -52,6 +52,7 @@ std::vector<edge_t> edges_inducing_cycles(
                     }
                     seen_bp += graph.get_length(h);
                 },
+                [](const handle_t& h) { return false; },
                 [&root_handle,&edges_to_remove](const handle_t& p, const handle_t& h) {
                     edge_t e = std::make_pair(p, h);
                     if (h == root_handle) {

--- a/src/algorithms/break_cycles.cpp
+++ b/src/algorithms/break_cycles.cpp
@@ -1,0 +1,86 @@
+#include "break_cycles.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+std::vector<edge_t> edges_inducing_cycles(
+    const HandleGraph& graph,
+    const uint64_t& max_cycle_size,
+    const uint64_t& max_search_bp
+    ) {
+
+    uint64_t min_handle_rank = 0;
+    uint64_t max_handle_rank = 0;
+    graph.for_each_handle([&](const handle_t& found) {
+                              uint64_t handle_rank = number_bool_packing::unpack_number(found);
+                              min_handle_rank = std::min(min_handle_rank, handle_rank);
+                              max_handle_rank = std::max(max_handle_rank, handle_rank);
+                          });
+
+    handle_t min_handle = number_bool_packing::pack(min_handle_rank, false);
+    handle_t root_handle = min_handle;
+    //std::vector<handle_t> seeds = { min_handle };
+
+    // edges that we'll find greedily and which we should remove
+    ska::flat_hash_set<edge_t> edges_to_remove;
+
+    graph.for_each_handle(
+        [&](const handle_t& root_handle) {
+            //std::cerr << "on handle " << graph.get_id(root_handle) << std::endl;
+            uint64_t seen_bp = 0;
+            uint64_t max_depth = 0;
+            uint64_t last_min_length_bp = 0; //std::numeric_limits<uint64_t>::max();
+            uint64_t curr_min_length_bp = std::numeric_limits<uint64_t>::max();
+            bfs(graph,
+                [&graph,&edges_to_remove,&seen_bp,&curr_min_length_bp,&last_min_length_bp,&max_depth]
+                (const handle_t& h, const uint64_t& r, const uint64_t& l, const uint64_t& d) {
+                    /*
+                    std::cerr << "stepping onto " << graph.get_id(h) << (graph.get_is_reverse(h)?"-":"+")
+                              << " (" << r << " " << l << " " << d << ")"
+                              << std::endl;
+                    */
+                    // track the minimum length at the last step
+                    if (d > max_depth) {
+                        max_depth = d;
+                        last_min_length_bp = curr_min_length_bp;
+                        curr_min_length_bp = l;
+                    } else {
+                        curr_min_length_bp = std::min(l, curr_min_length_bp);
+                    }
+                    seen_bp += graph.get_length(h);
+                },
+                [&root_handle,&edges_to_remove](const handle_t& p, const handle_t& h) {
+                    edge_t e = std::make_pair(p, h);
+                    if (h == root_handle) {
+                        edges_to_remove.insert(e);
+                        return true;
+                    } else if (edges_to_remove.count(e)) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                },
+                [&last_min_length_bp,&max_cycle_size,&seen_bp,&max_search_bp](void) {
+                    //std::cerr << "min_length_bp " << last_min_length_bp << " seen_bp " << seen_bp << std::endl;
+                    return last_min_length_bp > max_cycle_size
+                        || seen_bp > max_search_bp;
+                },
+                { root_handle },
+                { },
+                false); // don't use bidirectional search
+        });
+
+    std::vector<edge_t> edges;
+    for (auto& e : edges_to_remove) {
+        edges.push_back(e);
+    }
+
+    return edges;
+}
+
+}
+
+}

--- a/src/algorithms/break_cycles.hpp
+++ b/src/algorithms/break_cycles.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/util.hpp>
+#include <vector>
+#include "odgi.hpp"
+#include "bfs.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+std::vector<edge_t> edges_inducing_cycles(
+    const HandleGraph& graph,
+    const uint64_t& max_cycle_size,
+    const uint64_t& max_search_bp
+    );
+
+}
+
+}

--- a/src/algorithms/break_cycles.hpp
+++ b/src/algorithms/break_cycles.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <handlegraph/handle_graph.hpp>
+#include <handlegraph/deletable_handle_graph.hpp>
 #include <handlegraph/util.hpp>
 #include <vector>
 #include "odgi.hpp"
@@ -15,8 +16,13 @@ using namespace handlegraph;
 std::vector<edge_t> edges_inducing_cycles(
     const HandleGraph& graph,
     const uint64_t& max_cycle_size,
-    const uint64_t& max_search_bp
-    );
+    const uint64_t& max_search_bp);
+
+// breaks cycles, returning how many edges we removed
+uint64_t break_cycles(
+    DeletableHandleGraph& graph,
+    const uint64_t& max_cycle_size,
+    const uint64_t& max_search_bp);
 
 }
 

--- a/src/algorithms/linear_sgd.cpp
+++ b/src/algorithms/linear_sgd.cpp
@@ -170,7 +170,7 @@ std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph,
             uint64_t h_id = graph.get_id(h);
             ska::flat_hash_set<handle_t> seen;
             bfs(graph,
-                [&](const handle_t& n, const uint64_t& depth, const uint64_t& dist) {
+                [&](const handle_t& n, const uint64_t& root, const uint64_t& dist, const uint64_t& depth) {
                     seen.insert(n);
                     if (graph.get_id(n) != h_id) {
                         double weight = 1.0 / ((double)dist*dist);
@@ -188,7 +188,7 @@ std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph,
                         seen_bp += graph.get_length(n);
                     }
                 },
-                [&](const handle_t& n) { return seen.count(n) > 0; },
+                [&](const handle_t& l, const handle_t& n) { return seen.count(n) > 0; },
                 [&](void) { return seen_bp > bandwidth; },
                 { h },
                 { },

--- a/src/algorithms/linear_sgd.cpp
+++ b/src/algorithms/linear_sgd.cpp
@@ -188,7 +188,8 @@ std::vector<sgd_term_t> linear_sgd_search(const HandleGraph& graph,
                         seen_bp += graph.get_length(n);
                     }
                 },
-                [&](const handle_t& l, const handle_t& n) { return seen.count(n) > 0; },
+                [&](const handle_t& n) { return seen.count(n) > 0; },
+                [](const handle_t& l, const handle_t& n) { return false; },
                 [&](void) { return seen_bp > bandwidth; },
                 { h },
                 { },

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -521,22 +521,23 @@ std::vector<handle_t> breadth_first_topological_order(const HandleGraph& g, cons
                 seen_bp += g.get_length(h);
                 unvisited.set(i, 0);
             },
-            [&unvisited](const handle_t& l, const handle_t& h) {
+            [&unvisited](const handle_t& h) {
                 uint64_t i = number_bool_packing::unpack_number(h);
                 return unvisited.at(i)==0;
             },
+            [](const handle_t& l, const handle_t& h) { return false; },
             [&seen_bp,&chunk_size](void) { return seen_bp > chunk_size; },
             seeds,
             { },
             false); // don't use bidirectional search
         // get another seed
+        prev_max_root = curr_max_root;
+        prev_max_length = curr_max_length;
         if (unvisited.rank1(unvisited.size())!=0) {
             uint64_t i = unvisited.select1(0);
             handle_t h = number_bool_packing::pack(i, false);
             seeds = { h };
         }
-        prev_max_root = curr_max_root;
-        prev_max_length = curr_max_length;
     }
     //std::cerr << "order size " << order.size() << " graph size " << g.get_node_count() << std::endl;
     //assert(order.size() == g.get_node_count());

--- a/src/algorithms/topological_sort.cpp
+++ b/src/algorithms/topological_sort.cpp
@@ -513,7 +513,7 @@ std::vector<handle_t> breadth_first_topological_order(const HandleGraph& g, cons
             [&g,&order_raw,&unvisited,&seen_bp,
              &prev_max_root,&curr_max_root,
              &prev_max_length,&curr_max_length]
-            (const handle_t& h, const uint64_t& r, const uint64_t& l) {
+            (const handle_t& h, const uint64_t& r, const uint64_t& l, const uint64_t& d) {
                 uint64_t i = number_bool_packing::unpack_number(h);
                 order_raw.push_back({h, r+prev_max_root, l+prev_max_length});
                 curr_max_root = std::max(r+prev_max_root, curr_max_root);
@@ -521,7 +521,7 @@ std::vector<handle_t> breadth_first_topological_order(const HandleGraph& g, cons
                 seen_bp += g.get_length(h);
                 unvisited.set(i, 0);
             },
-            [&unvisited](const handle_t& h) {
+            [&unvisited](const handle_t& l, const handle_t& h) {
                 uint64_t i = number_bool_packing::unpack_number(h);
                 return unvisited.at(i)==0;
             },

--- a/src/subcommand/break_main.cpp
+++ b/src/subcommand/break_main.cpp
@@ -71,7 +71,7 @@ int main_break(int argc, char** argv) {
             = algorithms::break_cycles(graph,
                                        args::get(max_cycle_size),
                                        args::get(max_search_bp));
-        if (removed_edges) {
+        if (removed_edges > 0) {
             graph.clear_paths();
         }
     }

--- a/src/subcommand/break_main.cpp
+++ b/src/subcommand/break_main.cpp
@@ -1,0 +1,86 @@
+#include "subcommand.hpp"
+#include <iostream>
+#include "odgi.hpp"
+#include "args.hxx"
+#include "algorithms/break_cycles.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_break(int argc, char** argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc-1; ++i) {
+        argv[i] = argv[i+1];
+    }
+    std::string prog_name = "odgi break";
+    argv[0] = (char*)prog_name.c_str();
+    --argc;
+    
+    args::ArgumentParser parser("break cycles in the graph");
+    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+    args::ValueFlag<std::string> odgi_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+    args::ValueFlag<std::string> odgi_out_file(parser, "FILE", "store the graph in this file", {'o', "out"});
+    args::ValueFlag<uint64_t> max_cycle_size(parser, "N", "maximum cycle length to break", {'c', "cycle-max-bp"});
+    args::ValueFlag<uint64_t> max_search_bp(parser, "N", "maximum number of bp per BFS from any node", {'s', "max-search-bp"});
+    //args::Flag debug(parser, "debug", "print information about the layout", {'d', "debug"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc==1) {
+        std::cout << parser;
+        return 1;
+    }
+    
+    graph_t graph;
+    assert(argc > 0);
+    std::string infile = args::get(odgi_in_file);
+    if (infile.size()) {
+        if (infile == "-") {
+            graph.deserialize(std::cin);
+        } else {
+            ifstream f(infile.c_str());
+            graph.deserialize(f);
+            f.close();
+        }
+    }
+
+    // break cycles
+    std::vector<edge_t> cycle_edges = algorithms::edges_inducing_cycles(graph,
+                                                                        args::get(max_cycle_size),
+                                                                        args::get(max_search_bp));
+    for (auto& e : cycle_edges) {
+        std::cerr << graph.get_id(e.first) << (graph.get_is_reverse(e.first)?"-":"+")
+                  << " -> "
+                  << graph.get_id(e.second) << (graph.get_is_reverse(e.second)?"-":"+")
+                  << std::endl;
+    }
+
+    std::string outfile = args::get(odgi_out_file);
+    if (outfile.size()) {
+        if (outfile == "-") {
+            graph.serialize(std::cout);
+        } else {
+            ofstream f(outfile.c_str());
+            graph.serialize(f);
+            f.close();
+        }
+    }
+    
+    return 0;
+}
+
+static Subcommand odgi_break("break", "break cycles in the graph",
+                              PIPELINE, 3, main_break);
+
+
+}

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -209,7 +209,6 @@ int main_sort(int argc, char** argv) {
                     std::reverse(order.begin(), order.end());
                     break;
                 case 'm':
-
                     order = algorithms::mondriaan_sort(graph,
                                                        args::get(mondriaan_n_parts),
                                                        args::get(mondriaan_epsilon),
@@ -217,6 +216,11 @@ int main_sort(int argc, char** argv) {
                     break;
                 default:
                     break;
+                }
+                if (order.size() != graph.get_node_count()) {
+                    std::cerr << "[odgi sort] Error: expected " << graph.get_node_count() << " handles in the order "
+                              << "but got " << order.size() << std::endl;
+                    assert(false);
                 }
                 graph.apply_ordering(order, true);
             }


### PR DESCRIPTION
This implements a greedy, breadth first cycle finding algorithm, and uses it to find and edges that induce cycles. The cycle finding algorithm is parameterized by a depth and breadth to limit resource usage and allow it to be applied to find and remove small cycles that can cause pathological problems with GraphAligner (and any other cycle-aware graph alignment algorithm). The problematic motifs can represent "universal graphs" that represent all DNA sequences, and so capture any alignment that drives into them.