### PR TITLE
#78 add center_nucleotide output to bin json using the median of a list of positions

### DIFF
--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -3,13 +3,6 @@
 namespace odgi {
 namespace algorithms {
 
-int signum(double value){
-	/*Used for approximating medians without a list.  Caps values at -1,0, or 1 */
-	if(value < -1){ return -1;}
-	if(value > 1){return 1;}
-	return 0;
-}
-
 void bin_path_info(const PathHandleGraph& graph,
                    const std::string& prefix_delimiter,
                    const std::function<void(const std::string&,

--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -63,7 +63,10 @@ void bin_path_info(const PathHandleGraph& graph,
                         }
                         bins[curr_bin].mean_pos += path_pos++;
                         nucleotide_count += 1;
-						bins[curr_bin].position_history.push_back(nucleotide_count);
+						if(bins[curr_bin].first_nucleotide == 0){
+							bins[curr_bin].first_nucleotide = nucleotide_count;
+						}
+						bins[curr_bin].last_nucleotide = nucleotide_count;
                         last_bin = curr_bin;
                         last_is_rev = is_rev;
                         last_pos_in_bin = curr_pos_in_bin;
@@ -77,7 +80,6 @@ void bin_path_info(const PathHandleGraph& graph,
                 v.mean_inv /= (v.mean_cov ? v.mean_cov : 1);
                 v.mean_cov /= bin_width;
                 v.mean_pos /= bin_width * path_length * v.mean_cov;
-				v.center_nucleotide = v.position_history[v.position_history.size()/2];
             }
             handle_path(graph.get_path_name(path), links, bins);
         });

--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -41,6 +41,7 @@ void bin_path_info(const PathHandleGraph& graph,
             uint64_t path_pos = 0;
             int64_t last_bin = 0; // flag meaning "null bin"
             uint64_t last_pos_in_bin = 0;
+	    uint64_t nucleotide_count = 0;
             bool last_is_rev = false;
             graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
                     handle_t h = graph.get_handle_of_step(occ);
@@ -61,6 +62,8 @@ void bin_path_info(const PathHandleGraph& graph,
                             ++bins[curr_bin].mean_inv;
                         }
                         bins[curr_bin].mean_pos += path_pos++;
+			nucleotide_count += 1;
+			bins[curr_bin].center_nucleotide += nucleotide_count;
                         last_bin = curr_bin;
                         last_is_rev = is_rev;
                         last_pos_in_bin = curr_pos_in_bin;
@@ -68,10 +71,14 @@ void bin_path_info(const PathHandleGraph& graph,
                 });
             links.push_back(std::make_pair(last_bin,0));
             uint64_t path_length = path_pos;
+	    uint64_t end_nucleotide = nucleotide_count;
             for (auto& entry : bins) {
                 auto& v = entry.second;
                 v.mean_inv /= (v.mean_cov ? v.mean_cov : 1);
+		v.center_nucleotide /= v.mean_cov; // center_nucleotide is a sum of posititions, dividing by hits gets you average nucleotide position
                 v.mean_cov /= bin_width;
+		//mean_pos starts as the number of bins  -.5 to place it in the center
+		//v.center_nucleotide = int(v.center_nucleotide - 0.5) * bin_width; 
                 v.mean_pos /= bin_width * path_length * v.mean_cov;
             }
             handle_path(graph.get_path_name(path), links, bins);

--- a/src/algorithms/bin_path_info.hpp
+++ b/src/algorithms/bin_path_info.hpp
@@ -23,7 +23,8 @@ struct path_info_t {
     double mean_cov;
     double mean_inv;
     double mean_pos;
-    long int center_nucleotide;
+    double center_nucleotide;
+    std::vector<int> position_history;
 };
 
 void bin_path_info(const PathHandleGraph& graph,

--- a/src/algorithms/bin_path_info.hpp
+++ b/src/algorithms/bin_path_info.hpp
@@ -23,6 +23,7 @@ struct path_info_t {
     double mean_cov;
     double mean_inv;
     double mean_pos;
+    long int center_nucleotide;
 };
 
 void bin_path_info(const PathHandleGraph& graph,

--- a/src/algorithms/bin_path_info.hpp
+++ b/src/algorithms/bin_path_info.hpp
@@ -23,8 +23,8 @@ struct path_info_t {
     double mean_cov;
     double mean_inv;
     double mean_pos;
-    double center_nucleotide;
-    std::vector<int> position_history;
+    long int first_nucleotide;
+    long int last_nucleotide;
 };
 
 void bin_path_info(const PathHandleGraph& graph,

--- a/src/subcommand/bin_main.cpp
+++ b/src/subcommand/bin_main.cpp
@@ -105,7 +105,8 @@ int main_bin(int argc, char** argv) {
             std::cout << "[" << bin_id << ","
                       << info.mean_cov << ","
                       << info.mean_inv << ","
-                      << info.mean_pos << "]";
+                      << info.mean_pos << ","
+					  << info.center_nucleotide << "]";
             if (i+1 != bins.size()) {
                 std::cout << ",";
             }
@@ -144,7 +145,8 @@ int main_bin(int argc, char** argv) {
                           << bin_id << "\t"
                           << info.mean_cov << "\t"
                           << info.mean_inv << "\t"
-                          << info.mean_pos << std::endl;
+                          << info.mean_pos << "\t"
+						  << info.center_nucleotide << std::endl;
             }
         }
     };

--- a/src/subcommand/bin_main.cpp
+++ b/src/subcommand/bin_main.cpp
@@ -106,7 +106,8 @@ int main_bin(int argc, char** argv) {
                       << info.mean_cov << ","
                       << info.mean_inv << ","
                       << info.mean_pos << ","
-					  << info.center_nucleotide << "]";
+					  << info.first_nucleotide << ","
+					  << info.last_nucleotide << "]";
             if (i+1 != bins.size()) {
                 std::cout << ",";
             }
@@ -146,7 +147,8 @@ int main_bin(int argc, char** argv) {
                           << info.mean_cov << "\t"
                           << info.mean_inv << "\t"
                           << info.mean_pos << "\t"
-						  << info.center_nucleotide << std::endl;
+						  << info.first_nucleotide << "\t"
+						  << info.last_nucleotide << std::endl;
             }
         }
     };


### PR DESCRIPTION
This gives the exact correct nucleotide position.  My only concern is that it might be slower than before.  However, if JSON output is not a significant portion of total runtime then that doesn't matter.