### PR TITLE
Path-based graph pruning and trimming

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,8 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/normalize.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/simplify_siblings.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/unchop.cpp
-  ${CMAKE_SOURCE_DIR}/src/algorithms/perfect_neighbors.cpp)
+  ${CMAKE_SOURCE_DIR}/src/algorithms/perfect_neighbors.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/remove_isolated.cpp)
 
 set(odgi_DEPS
     sdsl-lite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,8 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/simplify_siblings.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/unchop.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/perfect_neighbors.cpp
-  ${CMAKE_SOURCE_DIR}/src/algorithms/remove_isolated.cpp)
+  ${CMAKE_SOURCE_DIR}/src/algorithms/remove_isolated.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/expand_context.cpp)
 
 set(odgi_DEPS
     sdsl-lite

--- a/src/algorithms/cut_tips.cpp
+++ b/src/algorithms/cut_tips.cpp
@@ -13,6 +13,7 @@ std::vector<handle_t> tip_handles(
         [&tips,&graph](const handle_t& handle) {
             // check if one end of the handle is a tip
             if (graph.get_degree(handle, false) == 0
+                // might be more correct if this were xor
                 || graph.get_degree(handle, true) == 0) {
                 tips.push_back(handle);
             }
@@ -32,17 +33,25 @@ uint64_t cut_tips(
 uint64_t cut_tips(
     MutablePathDeletableHandleGraph& graph) {
     auto tips = tip_handles(graph);
+    std::sort(tips.begin(), tips.end());
     for (auto& tip : tips) {
-        //graph.destroy_handle(tip);
         std::vector<step_handle_t> to_destroy;
         graph.for_each_step_on_handle(
             tip,
             [&](const step_handle_t& step) {
                 to_destroy.push_back(step);
             });
+        // odgi quirk / baddness: we have to destroy step handles from largest to smallest
+        // a generic implementation would iterate through step handles while erasing
+        std::sort(to_destroy.begin(), to_destroy.end(),
+                  [](const step_handle_t& a, const step_handle_t& b) {
+                      return as_integers(a)[1] > as_integers(b)[1]; });
         for (auto& step : to_destroy) {
-            graph.destroy_step(step);
+            graph.rewrite_segment(step, step, {});
         }
+    }
+    for (auto& tip : tips) {
+        graph.destroy_handle(tip);
     }
     return tips.size();
 }

--- a/src/algorithms/cut_tips.cpp
+++ b/src/algorithms/cut_tips.cpp
@@ -29,6 +29,24 @@ uint64_t cut_tips(
     return tips.size();
 }
 
+uint64_t cut_tips(
+    MutablePathDeletableHandleGraph& graph) {
+    auto tips = tip_handles(graph);
+    for (auto& tip : tips) {
+        //graph.destroy_handle(tip);
+        std::vector<step_handle_t> to_destroy;
+        graph.for_each_step_on_handle(
+            tip,
+            [&](const step_handle_t& step) {
+                to_destroy.push_back(step);
+            });
+        for (auto& step : to_destroy) {
+            graph.destroy_step(step);
+        }
+    }
+    return tips.size();
+}
+
 }
 
 }

--- a/src/algorithms/cut_tips.hpp
+++ b/src/algorithms/cut_tips.hpp
@@ -21,7 +21,8 @@ uint64_t cut_tips(
     DeletableHandleGraph& graph);
 
 uint64_t cut_tips(
-    MutablePathDeletableHandleGraph& graph);
+    MutablePathDeletableHandleGraph& graph,
+    uint64_t min_coverage = 0);
 
 }
 

--- a/src/algorithms/cut_tips.hpp
+++ b/src/algorithms/cut_tips.hpp
@@ -2,6 +2,7 @@
 
 #include <handlegraph/handle_graph.hpp>
 #include <handlegraph/deletable_handle_graph.hpp>
+#include <handlegraph/mutable_path_deletable_handle_graph.hpp>
 #include <handlegraph/util.hpp>
 #include <vector>
 #include "odgi.hpp"
@@ -18,6 +19,9 @@ std::vector<handle_t> tip_handles(
 
 uint64_t cut_tips(
     DeletableHandleGraph& graph);
+
+uint64_t cut_tips(
+    MutablePathDeletableHandleGraph& graph);
 
 }
 

--- a/src/algorithms/expand_context.cpp
+++ b/src/algorithms/expand_context.cpp
@@ -1,0 +1,252 @@
+#include "expand_context.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+using namespace std;
+
+void expand_context_by_steps(const HandleGraph* source, MutableHandleGraph* subgraph,
+                             int64_t dist, bool expand_forward, bool expand_backward) {
+        
+    // let's make an O(1) lookup for the current edges in case the implementation doesn't provide
+    // one (avoids O(N^2) behavior using has_edge)
+    std::unordered_set<edge_t> already_included_edges;
+    subgraph->for_each_edge([&](const edge_t& edge) {
+                                already_included_edges.insert(edge);
+                            });
+        
+    // a fifo queue for BFS
+    std::queue<pair<handle_t, int64_t>> bfs_queue;
+    // all the edges we encounter along the way
+    std::unordered_set<edge_t> seen_edges;
+        
+    // initialize the queue with the current subgraph
+    subgraph->for_each_handle([&](const handle_t& handle) {
+                                  bfs_queue.emplace(source->get_handle(subgraph->get_id(handle)), 0);
+                              });
+        
+    // BFS outward
+    while (!bfs_queue.empty()) {
+        std::pair<handle_t, int64_t> here = bfs_queue.front();
+        bfs_queue.pop();
+            
+        int64_t dist_thru = here.second + 1;
+            
+        if (dist_thru <= dist) {
+            if (expand_forward) {
+                source->follow_edges(here.first, false, [&](const handle_t& next) {
+                                                            seen_edges.insert(source->edge_handle(here.first, next));
+                                                            if (!subgraph->has_node(source->get_id(next))) {
+                                                                subgraph->create_handle(source->get_sequence(source->forward(next)),
+                                                                                        source->get_id(next));
+                                                                bfs_queue.emplace(next, dist_thru);
+                                                            }
+                                                        });
+            }
+                
+            if (expand_backward) {
+                source->follow_edges(here.first, true, [&](const handle_t& prev) {
+                                                           seen_edges.insert(source->edge_handle(prev, here.first));
+                                                           if (!subgraph->has_node(source->get_id(prev))) {
+                                                               subgraph->create_handle(source->get_sequence(source->forward(prev)),
+                                                                                       source->get_id(prev));
+                                                               bfs_queue.emplace(prev, dist_thru);
+                                                           }
+                                                       });
+            }
+        }
+    }
+        
+    // add in the edges we saw
+    for (const edge_t& edge : seen_edges) {
+        edge_t insertable = subgraph->edge_handle(subgraph->get_handle(source->get_id(edge.first),
+                                                                       source->get_is_reverse(edge.first)),
+                                                  subgraph->get_handle(source->get_id(edge.second),
+                                                                       source->get_is_reverse(edge.second)));
+        if (!already_included_edges.count(insertable)) {
+            subgraph->create_edge(insertable);
+        }
+    }
+}
+    
+void expand_context_by_length(const HandleGraph* source, MutableHandleGraph* subgraph,
+                              int64_t dist, bool expand_forward, bool expand_backward) {
+        
+    // let's make an O(1) lookup for the current edges in case the implementation doesn't provide
+    // one (avoids O(N^2) behavior using has_edge)
+    std::unordered_set<edge_t> already_included_edges;
+    subgraph->for_each_edge([&](const edge_t& edge) {
+                                already_included_edges.insert(edge);
+                            });
+        
+    // extra bool indicates whether the position indicated is at the
+    // beginning of the node (beginning = true, end = false)
+    structures::RankPairingHeap<pair<handle_t, bool>, int64_t, greater<int64_t>> dijk_queue;
+    // all the edges we encounter along the way
+    std::unordered_set<edge_t> seen_edges;
+        
+    // initialize the queue at the ends pointing out of the node in the direction
+    // of our search
+    subgraph->for_each_handle([&](const handle_t& handle) {
+                                  handle_t src_handle = source->get_handle(subgraph->get_id(handle));
+                                  if (expand_forward) {
+                                      dijk_queue.push_or_reprioritize(make_pair(src_handle, false), 0);
+                                  }
+                                  if (expand_backward) {
+                                      dijk_queue.push_or_reprioritize(make_pair(src_handle, true), 0);
+                                  }
+                              });
+        
+        
+    while (!dijk_queue.empty()) {
+        // the next closest untraversed node end
+        std::pair<pair<handle_t, bool>, int64_t> here = dijk_queue.top();
+        dijk_queue.pop();
+            
+        if (here.second > dist) {
+            break;
+        }
+            
+        if ((here.first.second && expand_forward)
+            || (!here.first.second && expand_backward)) {
+            // cross the node (traverse the sequence length)
+            int64_t dist_across = here.second + source->get_length(here.first.first);
+            if (dist_across <= dist) {
+                dijk_queue.push_or_reprioritize(make_pair(here.first.first, !here.first.second), dist_across);
+            }
+        }
+        if ((here.first.second && expand_backward)
+            || (!here.first.second && expand_forward)) {
+            // cross an edge (no added distance)
+            source->follow_edges(here.first.first, here.first.second, [&](const handle_t& next) {
+                                                                          dijk_queue.push_or_reprioritize(make_pair(next, !here.first.second), here.second);
+                    
+                                                                          // the edge handle will be in a different order depending on whether we're
+                                                                          // going left or right
+                                                                          if (here.first.second) {
+                                                                              seen_edges.insert(source->edge_handle(next, here.first.first));
+                                                                          }
+                                                                          else {
+                                                                              seen_edges.insert(source->edge_handle(here.first.first, next));
+                                                                          }
+                    
+                                                                          if (!subgraph->has_node(source->get_id(next))) {
+                                                                              subgraph->create_handle(source->get_sequence(source->forward(next)),
+                                                                                                      source->get_id(next));
+                                                                          }
+                                                                      });
+        }
+    }
+        
+    // add in the edges we saw
+    for (const edge_t& edge : seen_edges) {
+        edge_t insertable = subgraph->edge_handle(subgraph->get_handle(source->get_id(edge.first),
+                                                                       source->get_is_reverse(edge.first)),
+                                                  subgraph->get_handle(source->get_id(edge.second),
+                                                                       source->get_is_reverse(edge.second)));
+        if (!already_included_edges.count(insertable)) {
+            subgraph->create_edge(insertable);
+        }
+    }
+}
+    
+void expand_context(const HandleGraph* source, MutableHandleGraph* subgraph,
+                    int64_t dist, bool use_steps, bool expand_forward,
+                    bool expand_backward) {
+        
+    if (use_steps) {
+        expand_context_by_steps(source, subgraph, dist, expand_forward, expand_backward);
+    }
+    else {
+        expand_context_by_length(source, subgraph, dist, expand_forward, expand_backward);
+    }
+}
+    
+void expand_context_with_paths(const PathHandleGraph* source,
+                               MutablePathMutableHandleGraph* subgraph,
+                               int64_t dist, bool use_steps, bool expand_forward,
+                               bool expand_backward) {
+        
+    // get the topology of the subgraph we want
+    expand_context(source, subgraph, dist, use_steps, expand_forward, expand_backward);
+        
+    // find all steps on all nodes
+    std::unordered_set<step_handle_t> seen_steps;
+    subgraph->for_each_handle([&](const handle_t& handle) {
+                                  handle_t src_handle = source->get_handle(subgraph->get_id(handle));
+                                  source->for_each_step_on_handle(src_handle, [&](const step_handle_t& step) {
+                                                                                  seen_steps.insert(step);
+                                                                              });
+                              });
+        
+    // keep track of how many segments we've added for each path
+    std::unordered_map<path_handle_t, int> segment_count;
+        
+    while (!seen_steps.empty()) {
+        // choose a segment arbitrarily
+        step_handle_t segment_seed = *seen_steps.begin();
+        path_handle_t path_handle = source->get_path_handle_of_step(segment_seed);
+            
+            
+        // walk backwards until we're out of the subgraph or we loop around to
+        // the same step
+        auto step = segment_seed;
+        step_handle_t prev;
+        bool first_iter = true;
+        while (seen_steps.count(step) && (first_iter || step != segment_seed)) {
+            prev = step;
+            step = source->get_previous_step(step);
+            first_iter = false;
+        }
+            
+        if (step == segment_seed) {
+            // we walked all the way around a circular path
+            assert(source->get_is_circular(path_handle));
+                
+            // copy the whole path, making the same step the "first"
+            path_handle_t segment_handle = subgraph->create_path_handle(source->get_path_name(path_handle), true);
+            source->for_each_step_in_path(path_handle, [&](const step_handle_t& step) {
+                                                           handle_t handle = source->get_handle_of_step(step);
+                                                           subgraph->append_step(segment_handle,
+                                                                                 subgraph->get_handle(source->get_id(handle),
+                                                                                                      source->get_is_reverse(handle)));
+                                                           seen_steps.erase(step);
+                                                       });
+        }
+        else {
+            // we walked off the subgraph, so this is the start of a segment
+                
+            // get the path name (and possibly disambiguate segments from the same path)
+            string path_name = source->get_path_name(path_handle);
+            if (segment_count[path_handle]) {
+                path_name += "-" + to_string(segment_count[path_handle]);
+            }
+                
+            if (subgraph->has_path(path_name)) {
+                cerr << "error: failed to create a unique path name for segment of " << source->get_path_name(path_handle) << ", there is already path named " << path_name << endl;
+                exit(1);
+            }
+                
+            // make a new path for this segment
+            path_handle_t segment_handle = subgraph->create_path_handle(path_name);
+                
+            for (step = prev;                          // start back on the subgraph
+                 seen_steps.count(step);               // stop once we leave the subgraph
+                 step = source->get_next_step(step)) {
+                    
+                handle_t src_handle = source->get_handle_of_step(step);
+                subgraph->append_step(segment_handle,
+                                      subgraph->get_handle(source->get_id(src_handle),
+                                                           source->get_is_reverse(src_handle)));
+                    
+                // keep track of which steps we've already added
+                seen_steps.erase(step);
+            }
+        }
+            
+        // make note of the fact that we've made a segment from this source path
+        segment_count[path_handle]++;
+    }
+}
+}
+}

--- a/src/algorithms/expand_context.hpp
+++ b/src/algorithms/expand_context.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+/**
+ * \file expand_context.hpp
+ *
+ * Defines algorithm for adding graph material from the context around a subgraph
+ * into the subgraph
+ */
+
+#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_handle_graph.hpp>
+#include <handlegraph/path_handle_graph.hpp>
+#include <handlegraph/mutable_path_mutable_handle_graph.hpp>
+#include <handlegraph/util.hpp>
+
+#include "structures/rank_pairing_heap.hpp"
+
+#include <queue>
+#include <unordered_set>
+#include "hash_map.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+// basic method to query regions of the graph. subgraph must have the same
+// ID and sequence space as source.
+// use_steps flag toggles whether dist refers to steps or length in base pairs
+// note: neighboring nodes are considered to be length 0 away from each other,
+// so to do a null expansion by length, use dist < 0.
+void expand_context(const HandleGraph* source, MutableHandleGraph* subgraph,
+                    int64_t dist, bool use_steps = true, bool expand_forward = true,
+                    bool expand_backward = true);
+    
+// same as above but with addition of paths
+// if the subgraph contains disconnected regions of a path, it will attempt to
+// add both regions as separate paths with a disambiguated name
+void expand_context_with_paths(const PathHandleGraph* source,
+                               MutablePathMutableHandleGraph* subgraph,
+                               int64_t dist, bool use_steps = true, bool expand_forward = true,
+                               bool expand_backward = true);
+
+}
+}

--- a/src/algorithms/remove_isolated.cpp
+++ b/src/algorithms/remove_isolated.cpp
@@ -10,22 +10,25 @@ using namespace handlegraph;
 std::vector<std::pair<path_handle_t, handle_t>> isolated_path_handles(
     const MutablePathDeletableHandleGraph& graph) {
     std::vector<std::pair<path_handle_t, handle_t>> isolated;
-    // todo: check edge count of the node
     graph.for_each_handle(
         [&](const handle_t& handle) {
             uint64_t step_count = 0;
             step_handle_t single_step;
-            graph.for_each_step_on_handle(handle,
-                [&](const step_handle_t& step) {
-                    single_step = step;
-                    ++step_count;
-                });
-            if (step_count = 1) {
-                // is the single step the only step in that path?
-                path_handle_t path = graph.get_path_handle_of_step(single_step);
-                if (single_step == graph.path_begin(path)
-                    && single_step == graph.path_back(path)) {
-                    isolated.push_back(std::make_pair(path, handle));
+            size_t degree = graph.get_degree(handle, false) + graph.get_degree(handle, true);
+            if (degree == 0) {
+                graph.for_each_step_on_handle(
+                    handle,
+                    [&](const step_handle_t& step) {
+                        single_step = step;
+                        ++step_count;
+                    });
+                if (step_count == 1) {
+                    // is the single step the only step in that path?
+                    path_handle_t path = graph.get_path_handle_of_step(single_step);
+                    if (single_step == graph.path_begin(path)
+                        && single_step == graph.path_back(path)) {
+                        isolated.push_back(std::make_pair(path, handle));
+                    }
                 }
             }
         });

--- a/src/algorithms/remove_isolated.cpp
+++ b/src/algorithms/remove_isolated.cpp
@@ -1,0 +1,49 @@
+#include "cut_tips.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+// find and remove isolated nodes which have only a single path on them
+std::vector<std::pair<path_handle_t, handle_t>> isolated_path_handles(
+    const MutablePathDeletableHandleGraph& graph) {
+    std::vector<std::pair<path_handle_t, handle_t>> isolated;
+    // todo: check edge count of the node
+    graph.for_each_handle(
+        [&](const handle_t& handle) {
+            uint64_t step_count = 0;
+            step_handle_t single_step;
+            graph.for_each_step_on_handle(handle,
+                [&](const step_handle_t& step) {
+                    single_step = step;
+                    ++step_count;
+                });
+            if (step_count = 1) {
+                // is the single step the only step in that path?
+                path_handle_t path = graph.get_path_handle_of_step(single_step);
+                if (single_step == graph.path_begin(path)
+                    && single_step == graph.path_back(path)) {
+                    isolated.push_back(std::make_pair(path, handle));
+                }
+            }
+        });
+    return isolated;
+}
+
+uint64_t remove_isolated_paths(
+    MutablePathDeletableHandleGraph& graph) {
+    auto isolated = isolated_path_handles(graph);
+    for (auto& p : isolated) {
+        auto& path = p.first;
+        auto& handle = p.second;
+        graph.destroy_path(path);
+        graph.destroy_handle(handle);
+    }
+    return isolated.size();
+}
+
+}
+
+}

--- a/src/algorithms/remove_isolated.hpp
+++ b/src/algorithms/remove_isolated.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+//#include <handlegraph/handle_graph.hpp>
+#include <handlegraph/mutable_path_deletable_handle_graph.hpp>
+//#include <handlegraph/path_handle_graph.hpp>
+//#include <handlegraph/deletable_handle_graph.hpp>
+#include <handlegraph/util.hpp>
+#include <vector>
+#include "odgi.hpp"
+
+namespace odgi {
+
+namespace algorithms {
+
+using namespace handlegraph;
+
+std::vector<std::pair<path_handle_t, handle_t>> isolated_path_handles(
+    const MutablePathDeletableHandleGraph& graph);
+
+uint64_t remove_isolated_paths(
+    MutablePathDeletableHandleGraph& graph);
+
+}
+
+}

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -1263,15 +1263,15 @@ std::pair<step_handle_t, step_handle_t> graph_t::rewrite_segment(const step_hand
                                                                  const std::vector<handle_t>& new_segment) {
     // collect the steps to replace
     std::vector<step_handle_t> steps;
-    std::string old_seq, new_seq;
+    //std::string old_seq, new_seq;
     for (step_handle_t step = segment_begin; ; step = get_next_step(step)) {
         steps.push_back(step);
-        old_seq.append(get_sequence(get_handle_of_step(step)));
+        //old_seq.append(get_sequence(get_handle_of_step(step)));
         if (step == segment_end) break;
     }
-    for (auto& handle : new_segment) new_seq.append(get_sequence(handle));
+    //for (auto& handle : new_segment) new_seq.append(get_sequence(handle));
     // verify that we're making a valid rewrite
-    assert(old_seq == new_seq);
+    //assert(old_seq == new_seq); // not required, we could be modifying the path
     // find the before and after steps, which we'll link into
     bool is_begin = !has_previous_step(segment_begin);
     bool is_end = !has_next_step(segment_end);
@@ -1284,33 +1284,31 @@ std::pair<step_handle_t, step_handle_t> graph_t::rewrite_segment(const step_hand
     std::sort(steps.begin(), steps.end(), [](const step_handle_t& a, const step_handle_t& b) {
             return as_integers(a)[0] == as_integers(b)[0] && as_integers(a)[1] > as_integers(b)[1]
                 || as_integers(a)[0] < as_integers(b)[0]; });
-    /* // must be handled in the calling context
     for (auto& step : steps) {
         destroy_step(step);
     }
-    */
     // create the new steps
     std::vector<step_handle_t> new_steps;
     for (auto& handle : new_segment) {
         new_steps.push_back(create_step(path, handle));
     }
-    // link new steps together
-    for (uint64_t i = 0; i < new_steps.size()-1; ++i) {
-        link_steps(new_steps[i], new_steps[i+1]);
-    }
-    if (!is_begin) {
-        link_steps(before, new_steps.front());
-    } else {
-        path_meta.first = new_steps.front();
-    }
-    if (!is_end) {
-        link_steps(new_steps.back(), after);
-    } else {
-        path_meta.last = new_steps.back();
-    }
-    // delete the previous steps
-    path_meta.length += (new_steps.size() - steps.size());
     if (new_steps.size()) {
+        // link new steps together
+        for (uint64_t i = 0; i < new_steps.size()-1; ++i) {
+            link_steps(new_steps[i], new_steps[i+1]);
+        }
+        if (!is_begin) {
+            link_steps(before, new_steps.front());
+        } else {
+            path_meta.first = new_steps.front();
+        }
+        if (!is_end) {
+            link_steps(new_steps.back(), after);
+        } else {
+            path_meta.last = new_steps.back();
+        }
+        // delete the previous steps
+        path_meta.length += (new_steps.size() - steps.size());
         return make_pair(new_steps.front(), new_steps.back());
     } else {
         return make_pair(path_front_end(path), path_end(path));

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -6,6 +6,7 @@
 #include "algorithms/coverage.hpp"
 #include "algorithms/remove_high_degree.hpp"
 #include "algorithms/cut_tips.hpp"
+#include "algorithms/remove_isolated.hpp"
 
 namespace odgi {
 
@@ -34,6 +35,7 @@ int main_prune(int argc, char** argv) {
     args::ValueFlag<uint64_t> best_edges(parser, "N", "keep only the N most-covered inbound and outbound edge of each node", {'b', "best-edges"});
     args::Flag drop_paths(parser, "bool", "remove the paths from the graph", {'D', "drop-paths"});
     args::Flag cut_tips(parser, "bool", "remove nodes which are graph tips", {'T', "cut-tips"});
+    args::Flag remove_isolated(parser, "bool", "remove isolated nodes covered by a single path", {'I', "remove-isolated"});
     args::ValueFlag<uint64_t> threads(parser, "N", "number of threads to use", {'t', "threads"});
 
     try {
@@ -120,6 +122,9 @@ int main_prune(int argc, char** argv) {
     }
     if (args::get(cut_tips)) {
         algorithms::cut_tips(graph);
+    }
+    if (args::get(remove_isolated)) {
+        algorithms::remove_isolated_paths(graph);
     }
     if (args::get(drop_paths)) {
         graph.clear_paths();

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -34,7 +34,9 @@ int main_prune(int argc, char** argv) {
     args::ValueFlag<uint64_t> max_coverage(parser, "N", "remove nodes covered by more than this number of path steps", {'C', "max-coverage"});
     args::Flag edge_coverage(parser, "bool", "remove edges outside of the min and max coverage (rather than nodes)", {'E', "edge-coverage"});
     args::ValueFlag<uint64_t> best_edges(parser, "N", "keep only the N most-covered inbound and outbound edge of each node", {'b', "best-edges"});
-    args::ValueFlag<uint64_t> expand_context(parser, "N", "include nodes within this many steps of a component passing the prune thresholds", {'n', "expand-context"});
+    args::ValueFlag<uint64_t> expand_steps(parser, "N", "include nodes within this many steps of a component passing the prune thresholds", {'s', "expand-steps"});
+    args::ValueFlag<uint64_t> expand_length(parser, "N", "include nodes within this graph distance of a component passing the prune thresholds", {'l', "expand-length"});
+    args::ValueFlag<uint64_t> expand_path_length(parser, "N", "include nodes within this path length of a component passing the prune thresholds", {'p', "expand-path-length"});
     args::Flag drop_paths(parser, "bool", "remove the paths from the graph", {'D', "drop-paths"});
     args::Flag cut_tips(parser, "bool", "remove nodes which are graph tips", {'T', "cut-tips"});
     args::Flag remove_isolated(parser, "bool", "remove isolated nodes covered by a single path", {'I', "remove-isolated"});
@@ -124,13 +126,15 @@ int main_prune(int argc, char** argv) {
                     graph.destroy_handle(handle);
                 }
             };
-        if (args::get(expand_context)) {
-            // copy the graph
-            graph_t source = graph;
-            do_destroy();
-            // expand context
-            algorithms::expand_context(&source, &graph, args::get(expand_context));
-            // todo... test using paths for guidance
+        if (args::get(expand_steps)) {
+            graph_t source = graph; do_destroy();
+            algorithms::expand_context(&source, &graph, args::get(expand_steps), true);
+        } else if (args::get(expand_length)) {
+            graph_t source = graph; do_destroy();
+            algorithms::expand_context(&source, &graph, args::get(expand_length), false);
+        } else if (args::get(expand_path_length)) {
+            graph_t source = graph; do_destroy();
+            algorithms::expand_context_with_paths(&source, &graph, args::get(expand_length), false);
         } else {
             do_destroy();
         }

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -39,6 +39,7 @@ int main_prune(int argc, char** argv) {
     args::ValueFlag<uint64_t> expand_path_length(parser, "N", "include nodes within this path length of a component passing the prune thresholds", {'p', "expand-path-length"});
     args::Flag drop_paths(parser, "bool", "remove the paths from the graph", {'D', "drop-paths"});
     args::Flag cut_tips(parser, "bool", "remove nodes which are graph tips", {'T', "cut-tips"});
+    args::ValueFlag<uint64_t> cut_tips_min_coverage(parser, "bool", "remove nodes which are graph tips and have less than this path coverage", {'m', "cut-tips-min-coverage"});
     args::Flag remove_isolated(parser, "bool", "remove isolated nodes covered by a single path", {'I', "remove-isolated"});
     args::ValueFlag<uint64_t> threads(parser, "N", "number of threads to use", {'t', "threads"});
 
@@ -140,7 +141,7 @@ int main_prune(int argc, char** argv) {
         }
     }
     if (args::get(cut_tips)) {
-        algorithms::cut_tips(graph);
+        algorithms::cut_tips(graph, args::get(cut_tips_min_coverage));
     }
     if (args::get(remove_isolated)) {
         algorithms::remove_isolated_paths(graph);

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -41,7 +41,7 @@ int main_sort(int argc, char** argv) {
     args::Flag eades(parser, "eades", "use eades algorithm", {'e', "eades"});
     //args::Flag lazy(parser, "lazy", "use lazy topological algorithm (DAG only)", {'l', "lazy"});
     args::Flag lsgd(parser, "linear-sgd", "apply 1D (linear) SGD algorithm to organize graph", {'S', "linear-sgd"});
-    args::ValueFlag<uint64_t> lsgd_bandwidth(parser, "sgd-bandwidth", "bandwidth of linear SGD model (default: 1000)", {'O', "sgd-bandwidth"});
+    args::ValueFlag<uint64_t> lsgd_bandwidth(parser, "sgd-bandwidth", "bandwidth of linear SGD model (default: 1000)", {'H', "sgd-bandwidth"});
     args::ValueFlag<double> lsgd_sampling_rate(parser, "sgd-sampling-rate", "sample pairs of nodes with probability distance between them divided by the sampling rate (default: 20)", {'Q', "sgd-sampling-rate"});
     args::Flag lsgd_use_paths(parser, "sgd-use-paths", "use paths to structure internode distances in SGD", {'K', "sgd-use-paths"});
     args::ValueFlag<uint64_t> lsgd_iter_max(parser, "sgd-iter-max", "max number of iterations for linear SGD model (default: 30)", {'T', "sgd-iter-max"});


### PR DESCRIPTION
This branch will include algorithms to clean up graphs based on path coverage.

The first part is a bit of code that lets us remove isolated single-path components which don't align to anything else in the graph. These correspond to fragments that weren't aligned to anything else during graph induction with seqwish.