### PR TITLE
groom the graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/bin_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/matrix_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/chop_main.cpp
+  ${CMAKE_SOURCE_DIR}/src/subcommand/groom_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/layout_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/flatten_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/break_main.cpp
@@ -320,7 +321,8 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/unchop.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/perfect_neighbors.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/remove_isolated.cpp
-  ${CMAKE_SOURCE_DIR}/src/algorithms/expand_context.cpp)
+  ${CMAKE_SOURCE_DIR}/src/algorithms/expand_context.cpp
+  ${CMAKE_SOURCE_DIR}/src/algorithms/groom.cpp)
 
 set(odgi_DEPS
     sdsl-lite

--- a/src/algorithms/groom.cpp
+++ b/src/algorithms/groom.cpp
@@ -1,0 +1,157 @@
+/**
+ * \file groom.cpp
+ *
+ * Defines an algorithm to remove spurious inverting links from the graph
+ * by exploring the graph from the orientation supported by the most paths.
+ */
+
+#include "groom.hpp"
+
+namespace odgi {
+namespace algorithms {
+
+
+void groom(handlegraph::MutablePathDeletableHandleGraph& source,
+           handlegraph::MutablePathDeletableHandleGraph& target) {
+           //bool use_heads, bool use_tails, bool show_progress) {
+
+    //std::vector<handle_t> sorted = topological_order(&source, use_heads, use_tails, show_progress);
+    /*
+    ska::flat_hash_map<handlegraph::nid_t, std::pair<handlegraph::nid_t, bool>> splits
+        = split_strands(&source, &target);
+    */
+    // the graph must have a compacted ID space
+    //source.optimize(); if needed?
+    /*
+    dyn::succinct_bitvector<dyn::spsi<dyn::packed_vector,256,16> > seen, flipped;
+    for (uint64_t i = 0; i < source.get_node_count(); ++i) {
+        assert(graph.has_node(i+1));
+        seen.push_back(0);
+        flipped.push_back(0);
+    }
+    while (source.get_node_count() > target.get_node_count()) {
+        uint64_t seed_rank = seen.select0(0);
+        seen[seed_rank] = 1;
+        handle_t seed = graph.get_handle(seed_rank+1);
+        // start traversing from here
+        
+    }
+    */
+
+    // This (s) is our set of oriented nodes.
+    //dyn::succinct_bitvector<dyn::spsi<dyn::packed_vector,256,16> > s;
+    uint64_t min_handle_rank = 0;
+    uint64_t max_handle_rank = 0;
+    source.for_each_handle(
+        [&](const handle_t& found) {
+            uint64_t handle_rank = number_bool_packing::unpack_number(found);
+            min_handle_rank = std::min(min_handle_rank, handle_rank);
+            max_handle_rank = std::max(max_handle_rank, handle_rank);
+        });
+
+    // Start with the heads of the graph.
+    // We could also just use the first node of the graph.
+    std::vector<handle_t> seeds;
+    bool use_heads = true;
+    bool use_tails = false;
+    if (use_heads) {
+        seeds = head_nodes(&source);
+    } else if (use_tails) {
+        seeds = tail_nodes(&source);
+    } else {
+        handle_t min_handle = number_bool_packing::pack(min_handle_rank, false);
+        seeds = { min_handle };
+    }
+
+    // We need to keep track of the nodes we haven't visited to seed subsequent
+    // runs of the BFS
+    dyn::succinct_bitvector<dyn::spsi<dyn::packed_vector,256,16> > unvisited, flipped;
+    for (uint64_t i = 0; i <= max_handle_rank; ++i) {
+        unvisited.push_back(1);
+        flipped.push_back(0);
+    }
+
+    uint64_t prev_max_root = 0;
+    uint64_t prev_max_length = 0;
+    
+    while (unvisited.rank1(unvisited.size())!=0) {
+
+        bfs(source,
+            [&source,&target,&unvisited,&flipped]
+            (const handle_t& h, const uint64_t& r, const uint64_t& l, const uint64_t& d) {
+                target.create_handle(source.get_sequence(h), source.get_id(h));
+                uint64_t i = number_bool_packing::unpack_number(h);
+                unvisited.set(i, 0);
+                flipped.set(i, source.get_is_reverse(h));
+            },
+            [&unvisited](const handle_t& h) {
+                uint64_t i = number_bool_packing::unpack_number(h);
+                return unvisited.at(i)==0;
+            },
+            [](const handle_t& l, const handle_t& h) {
+                // add the edge to the graph if it's not there yet
+                //uint64_t i = number_bool_packing::unpack_number(h);
+                //unvisited.set(i, 0);
+                return false;
+            },
+            [](void) { return false; },
+            seeds,
+            { },
+            false); // don't use bidirectional search
+        // get another seed
+        if (unvisited.rank1(unvisited.size())!=0) {
+            uint64_t i = unvisited.select1(0);
+            handle_t h = number_bool_packing::pack(i, false);
+            seeds = { h };
+        }
+    }
+
+    // add the edges
+    source.for_each_edge(
+        [&](const edge_t& edge) {
+            //source.get_id(edge.first),
+            bool from_flipped = flipped[number_bool_packing::unpack_number(edge.first)];
+            handle_t from = target.get_handle(
+                source.get_id(edge.first),
+                source.get_is_reverse(edge.first)^from_flipped);
+            bool to_flipped = flipped[number_bool_packing::unpack_number(edge.second)];
+            handle_t to = target.get_handle(
+                source.get_id(edge.second),
+                source.get_is_reverse(edge.second)^to_flipped);
+            target.create_edge(from, to);
+        });
+    // now add the paths back in
+    source.for_each_path_handle(
+        [&](const path_handle_t& path) {
+            auto into = target.create_path_handle(source.get_path_name(path));
+            source.for_each_step_in_path(
+                path,
+                [&](const step_handle_t& step) {
+                    handle_t h = source.get_handle_of_step(step);
+                    bool h_flipped = flipped[number_bool_packing::unpack_number(h)];
+                    handle_t handle = target.get_handle(source.get_id(h),
+                                                        source.get_is_reverse(h)^h_flipped);
+                    target.append_step(into, handle);
+                });
+        });
+    
+    //std::cerr << "order size " << order.size() << " graph size " << g.get_node_count() << std::endl;
+    //assert(order.size() == g.get_node_count());
+    /*
+    std::sort(order_raw.begin(), order_raw.end(),
+              [](const bfs_state_t& a,
+                 const bfs_state_t& b) {
+                  return a.root < b.root || a.root == b.root && a.length < b.length;
+              });
+
+    std::vector<handle_t> order;
+    for (auto& o : order_raw) order.push_back(o.handle);
+    */
+    //return order;
+
+}
+
+
+}
+}
+

--- a/src/algorithms/groom.hpp
+++ b/src/algorithms/groom.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <handlegraph/types.hpp>
+#include <handlegraph/util.hpp>
+#include <handlegraph/mutable_path_deletable_handle_graph.hpp>
+
+#include <vector>
+
+#include "dynamic.hpp"
+#include "topological_sort.hpp"
+//#include "bfs.cpp"
+
+namespace odgi {
+namespace algorithms {
+
+using namespace handlegraph;
+
+/**
+ * Remove spurious inverting links based on a dominant orientation of the graph
+ */
+void groom(handlegraph::MutablePathDeletableHandleGraph& source,
+           handlegraph::MutablePathDeletableHandleGraph& target);
+
+}
+}

--- a/src/subcommand/groom_main.cpp
+++ b/src/subcommand/groom_main.cpp
@@ -1,0 +1,88 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include "threads.hpp"
+#include "algorithms/groom.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_groom(int argc, char** argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc-1; ++i) {
+        argv[i] = argv[i+1];
+    }
+    std::string prog_name = "odgi groom";
+    argv[0] = (char*)prog_name.c_str();
+    --argc;
+    
+    args::ArgumentParser parser("resolve spurious inverting links");
+    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+    args::ValueFlag<std::string> og_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+    args::ValueFlag<std::string> og_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc==1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    if (!og_in_file) {
+        std::cerr << "[odgi groom] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        return 1;
+    }
+
+    if (!og_out_file) {
+        std::cerr << "[odgi groom] error: Please specify an output file to where to store the groomped graph via -o=[FILE], --out=[FILE]." << std::endl;
+        return 1;
+    }
+
+    graph_t graph;
+    assert(argc > 0);
+    std::string infile = args::get(og_in_file);
+    if (infile.size()) {
+        if (infile == "-") {
+            graph.deserialize(std::cin);
+        } else {
+            ifstream f(infile.c_str());
+            graph.deserialize(f);
+            f.close();
+        }
+    }
+    /*
+    if (args::get(threads)) {
+        omp_set_num_threads(args::get(threads));
+    }
+    */
+    graph_t groomed;
+    algorithms::groom(graph, groomed);
+    
+    std::string outfile = args::get(og_out_file);
+    if (outfile.size()) {
+        if (outfile == "-") {
+            groomed.serialize(std::cout);
+        } else {
+            ofstream f(outfile.c_str());
+            groomed.serialize(f);
+            f.close();
+        }
+    }
+    return 0;
+}
+
+static Subcommand odgi_groom("groom", "resolve spurious inverting links",
+                              PIPELINE, 3, main_groom);
+
+
+}

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -279,7 +279,7 @@ int main_viz(int argc, char** argv) {
                 path_layout_buf[width * path_y + i] = 1;
             }
             //std::cerr << "path_y " << graph.get_path_name(path) << " " << path_count - path_y - 1 << std::endl;
-            path_layout_y[as_integer(path)] = path_count - path_y - 1;
+            path_layout_y[as_integer(path)-1] = path_count - path_y - 1;
         }
     }
 
@@ -340,7 +340,7 @@ int main_viz(int argc, char** argv) {
             //std::cerr << "path " << as_integer(path) << " " << graph.get_path_name(path) << " " << path_r_f << " " << path_g_f << " " << path_b_f
             //          << " " << (int)path_r << " " << (int)path_g << " " << (int)path_b << std::endl;
             /// Loop over all the steps along a path, from first through last and draw them
-            uint64_t path_rank = as_integer(path);
+            uint64_t path_rank = as_integer(path)-1;
             uint64_t step = 0;
             graph.for_each_step_in_path(path, [&](const step_handle_t& occ) {
                     handle_t h = graph.get_handle_of_step(occ);


### PR DESCRIPTION
This uses a breadth first search to reorganize the graph based on the orientation found by traversing from the graph heads. The main goal is to flip nodes that are only connected into the graph by inverting edges. These tend to be generated by paths that are aligned to the standard orientation of the graph in the reverse direction, and can occur in seqwish based graph induction.