### PR TITLE
odgi viz color by nt position

### DIFF
--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -411,12 +411,14 @@ namespace odgi {
             path_g_f /= sum;
             path_b_f /= sum;
 
+            bool _color_by_nt_pos = args::get(color_by_nt_pos);
+
             // Calculate the number or steps, the reverse steps and the length of the path if any of this information
             // is needed depending on the input arguments.
             uint64_t steps = 0;
             uint64_t rev = 0;
             uint64_t path_len = 0;
-            if ((is_aln && args::get(show_strands)) || args::get(color_by_nt_pos)){
+            if ((is_aln && args::get(show_strands)) || _color_by_nt_pos){
                 graph.for_each_step_in_path(path, [&](const step_handle_t &occ) {
                     handle_t h = graph.get_handle_of_step(occ);
                     ++steps;
@@ -455,6 +457,8 @@ namespace odgi {
             //          << " " << (int)path_r << " " << (int)path_g << " " << (int)path_b << std::endl;
             uint64_t path_rank = as_integer(path) - 1;
 
+            uint64_t curr_len = 0;
+            float x = 1;
             if (args::get(binned_mode)) {
                 std::vector<std::pair<uint64_t, uint64_t>> links;
                 std::vector<uint64_t> bin_ids;
@@ -473,7 +477,11 @@ namespace odgi {
 #ifdef debug_odgi_viz
                             std::cerr << "curr_bin: " << curr_bin << std::endl;
 #endif
-                            add_path_step(curr_bin - 1, path_y, path_r, path_g, path_b);
+
+                            if (_color_by_nt_pos){
+                                x = 1 - ( (float)(curr_len + k) / (float)(len))*0.8;
+                            }
+                            add_path_step(curr_bin - 1, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
 
                             if (std::abs(curr_bin - last_bin) > 1 || last_bin == 0) {
                                 // bin cross!
@@ -484,6 +492,8 @@ namespace odgi {
 
                         last_bin = curr_bin;
                     }
+
+                    curr_len += hl;
                 });
                 links.push_back(std::make_pair(last_bin, 0));
 
@@ -543,8 +553,13 @@ namespace odgi {
                     // make contects for the bases in the node
                     uint64_t path_y = path_layout_y[path_rank];
                     for (uint64_t i = 0; i < hl; i+=1/scale_x) {
-                        add_path_step(p+i, path_y, path_r, path_g, path_b);
+                        if (_color_by_nt_pos){
+                            x = 1 - ((float)(curr_len + i*scale_x) / (float)(len))*0.8;
+                        }
+                        add_path_step(p+i, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
                     }
+
+                    curr_len += hl;
                 });
             }
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -92,7 +92,7 @@ namespace odgi {
         args::Flag drop_gap_links(parser, "drop-gap-links", "don't include gap links in the output", {'g', "no-gap-links"});
         args::Flag change_darkness(parser, "change-darkness", "change the color darkness based on nucleotide position in the path", {'d', "change-darkness"});
         args::Flag longest_path(parser, "longest-path", "use the longest path length to change the color darkness", {'l', "longest-path"});
-        args::Flag white_to_black(parser, "white-to-black", "change the color intensity from white to black", {'u', "white-to-black"});
+        args::Flag white_to_black(parser, "white-to-black", "change the color darkness from white (for the first nucleotide position) to black (for the last nucleotide position)", {'u', "white-to-black"});
         args::ValueFlag<uint64_t> threads(parser, "N", "number of threads to use", {'t', "threads"});
 
         try {


### PR DESCRIPTION
Initial implementation to color the paths by nucleotide position percentage.

Little mock example
```
H	VN:Z:1.0
S	1	TTTTTTT
S	2	CCCC
S	3	AAAAAAAAAAAAAAA
S	4	AAAAAAAAAAAAAAAAAAAAA
S	5	AAAAAAAAAA
S	6	GGGGG
P	Path1	1+,2+,3+,4+,5+,6+	*
P	Path2	1-,3+,4-,6+	*
P	Path3	1-,3-,5-,6+	*
L	1	+	3	+
L	3	+	1	+
P	1	1+	*
P	2	2+	*
P	3	3+	*
P	4	4+	*
P	5	5+	*
P	6	6+	*
```
![example](https://user-images.githubusercontent.com/62253982/86516661-d6322f00-be22-11ea-9ffb-d24e5f83bfd9.png)

Keeping the path's color, it becomes darker at the end of it. On the left it is used each individual path length, on the right it is used the position in the pangenome (then, a specific position has the same darkness across all paths regardless of their length).

![image](https://user-images.githubusercontent.com/62253982/86516737-6d978200-be23-11ea-87e1-2317e6d87bb7.png)

The same cases, but using the same color for all the path, from white to black.
![image](https://user-images.githubusercontent.com/62253982/86516818-f9111300-be23-11ea-89f4-d3e9bb98e1dc.png)

The same scenario, but in binned mode (gap links not removed).
![image](https://user-images.githubusercontent.com/62253982/86516838-2c53a200-be24-11ea-9c84-c1540132fd49.png)
![image](https://user-images.githubusercontent.com/62253982/86516843-41303580-be24-11ea-8fb5-c274c3d47b74.png)

@subwaystation, by nose it seems to me that a useful visualization could be that with the white/black colors considering each individual path length. The other visualizations could be removed unless we find cases where they could be useful too.