### PR TITLE
odgi stats: metrics for graph sorting goodness evaluation

### DIFF
--- a/docs/asciidocs/odgi_stats.adoc
+++ b/docs/asciidocs/odgi_stats.adoc
@@ -58,7 +58,7 @@ The odgi stats(1) command produces statistics of a variation graph. Among other 
   Don't penalize gap links in the mean links length.
 
 *-s, --sum-path-nodes-distances*::
-  Calculate the sum of path nodes distances. For each path, it iterates from node to node, summing their distances, and normalizing by the path length. If a link go back in the linearized viewpoint of the graph, this is penalized (multiplying by 3 its length).
+  Calculate the sum of path nodes distances. For each path, it iterates from node to node, summing their distances, and normalizing by the path length. If a link goes back in the linearized viewpoint of the graph, this is penalized (multiplying by 3 its length).
 
 *-r, --penalize-reversed-nodes*::
   Penalize reversed nodes in the sum (doubling their distance from the subsequent node in the path).

--- a/docs/asciidocs/odgi_stats.adoc
+++ b/docs/asciidocs/odgi_stats.adoc
@@ -60,7 +60,7 @@ The odgi stats(1) command produces statistics of a variation graph. Among other 
 *-s, --sum-path-nodes-distances*::
   Calculate the sum of path nodes distances. For each path, it iterates from node to node, summing their distances, and normalizing by the path length. If a link goes back in the linearized viewpoint of the graph, this is penalized (adding 3 times its length in the sum).
 
-*-r, --penalize-reversed-nodes*::
+*-d, --penalize-different-orientation*::
   If a link connects two nodes which have different orientations, this is penalized (adding 2 times its length in the sum).
 
 *-P, --path-statistics*::

--- a/docs/asciidocs/odgi_stats.adoc
+++ b/docs/asciidocs/odgi_stats.adoc
@@ -58,10 +58,10 @@ The odgi stats(1) command produces statistics of a variation graph. Among other 
   Don't penalize gap links in the mean links length.
 
 *-s, --sum-path-nodes-distances*::
-  Calculate the sum of path nodes distances. For each path, it iterates from node to node, summing their distances, and normalizing by the path length. If a link goes back in the linearized viewpoint of the graph, this is penalized (multiplying by 3 its length).
+  Calculate the sum of path nodes distances. For each path, it iterates from node to node, summing their distances, and normalizing by the path length. If a link goes back in the linearized viewpoint of the graph, this is penalized (adding 3 times its length in the sum).
 
 *-r, --penalize-reversed-nodes*::
-  Penalize reversed nodes in the sum (doubling their distance from the subsequent node in the path).
+  If a link connects two nodes which have different orientations, this is penalized (adding 2 times its length in the sum).
 
 *-P, --path-statistics*::
   Display the statistics (mean links length or sum path nodes distances) for each path.

--- a/docs/asciidocs/odgi_stats.adoc
+++ b/docs/asciidocs/odgi_stats.adoc
@@ -49,6 +49,24 @@ The odgi stats(1) command produces statistics of a variation graph. Among other 
 *-B, --bed-multicov*=_BED_::
   For each BED entry, provide a table of path coverage over unique multisets of paths in the graph. Each unique multiset of paths overlapping a given BED interval is described in terms of its length relative to the total interval, the number of path traversals and unique paths involved in these traversals.
 
+=== Sorting goodness evaluation
+
+*-l, --mean-links-length*::
+  Calculate the mean links length.
+
+*-g, --no-gap-links*::
+  Don't penalize gap links in the mean links length.
+
+*-s, --sum-path-nodes-distances*::
+  Calculate the sum of path nodes distances. For each path, it iterates from node to node, summing their distances, and normalizing by the path length. If a link go back in the linearized viewpoint of the graph, this is penalized (multiplying by 3 its length).
+
+*-r, --penalize-reversed-nodes*::
+  Penalize reversed nodes in the sum (doubling their distance from the subsequent node in the path).
+
+*-P, --path-statistics*::
+  Display the statistics (mean links length or sum path nodes distances) for each path.
+
+
 === Threading
 
 *-t, --threads*=_N_::

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -218,10 +218,11 @@ int main_stats(int argc, char** argv) {
 
                     sum_node_space += sum_in_path_node_space;
                     sum_nt_space += sum_in_path_nt_space;
-                    num_pairs += num_pairs_in_path;
                 }else{
                     num_pairs_in_path = 1;
                 }
+
+                num_pairs += num_pairs_in_path;
 
                 if (args::get(path_statistics)) {
                     std::cout << graph.get_path_name(path) << "\t" << (double)sum_in_path_node_space / (double)num_pairs_in_path << "\t" << (double)sum_in_path_nt_space / (double)num_pairs_in_path << "\t" << num_pairs_in_path << std::endl;
@@ -346,7 +347,7 @@ int main_stats(int argc, char** argv) {
             uint64_t num_all_penalties_rev_nodes = 0;
 
             std::cout << "#sum_of_path_node_distances" << std::endl;
-            std::cout << "path\tin_node_space\tnodes\tin_nucleotide_space\tnucleotides\tnum_penalties";
+            std::cout << "path\tin_node_space\tin_nucleotide_space\tnodes\tnucleotides\tnum_penalties";
 
             if (_penalize_reversed_nodes){
                 std::cout << "\tnum_penalties_reversed_nodes" << std::endl;
@@ -404,7 +405,7 @@ int main_stats(int argc, char** argv) {
                 });
 
                 if (args::get(path_statistics)) {
-                    std::cout << graph.get_path_name(path) << "\t" << (double)sum_path_node_dist_node_space / (double)len_path_node_space << "\t" << len_path_node_space << "\t" << (double)sum_path_node_dist_nt_space / (double)len_path_nt_space << "\t" << len_path_nt_space  << "\t" << num_penalties;
+                    std::cout << graph.get_path_name(path) << "\t" << (double)sum_path_node_dist_node_space / (double)len_path_node_space << "\t" << (double)sum_path_node_dist_nt_space / (double)len_path_nt_space << "\t" << len_path_node_space << "\t" << len_path_nt_space  << "\t" << num_penalties;
 
                     if (_penalize_reversed_nodes){
                         std::cout << "\t" << num_penalties_rev_nodes << std::endl;
@@ -421,7 +422,7 @@ int main_stats(int argc, char** argv) {
                 num_all_penalties_rev_nodes += num_penalties_rev_nodes;
             });
 
-            std::cout << "all_paths\t" << (double)sum_all_path_node_dist_node_space / (double)len_all_path_node_space << "\t" << len_all_path_node_space << "\t" << (double)sum_all_path_node_dist_nt_space / (double)len_all_path_nt_space << "\t" << len_all_path_nt_space << "\t" << num_all_penalties;
+            std::cout << "all_paths\t" << (double)sum_all_path_node_dist_node_space / (double)len_all_path_node_space << "\t" << (double)sum_all_path_node_dist_nt_space / (double)len_all_path_nt_space << "\t" << len_all_path_node_space << "\t" << len_all_path_nt_space << "\t" << num_all_penalties;
 
             if (_penalize_reversed_nodes){
                 std::cout << "\t" << num_all_penalties_rev_nodes << std::endl;

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -298,7 +298,14 @@ int main_stats(int argc, char** argv) {
                 });
 
                 if (args::get(path_statistics)) {
-                    std::cout << graph.get_path_name(path) << "\t" << (double)sum_node_space / (double)num_links << "\t" << (double)sum_nt_space / (double)num_links << "\t" << num_links;
+                    double ratio_node_space = 0;
+                    double ratio_nt_space = 0;
+                    if (num_links > 0){
+                        ratio_node_space = (double)sum_node_space / (double)num_links;
+                        ratio_nt_space = (double)sum_nt_space / (double)num_links;
+                    }
+
+                    std::cout << graph.get_path_name(path) << "\t" << ratio_node_space << "\t" << ratio_nt_space << "\t" << num_links;
 
                     if (_ignore_gap_links){
                         std::cout << "\t" << num_gap_links_ignored << std::endl;

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -320,7 +320,13 @@ int main_stats(int argc, char** argv) {
                 num_all_gap_links_ignored += num_gap_links_ignored;
             });
 
-            std::cout << "all_paths\t" << (double)sum_all_node_space / (double)num_all_links << "\t" << (double)sum_all_nt_space / (double)num_all_links << "\t" << num_all_links;
+            double ratio_node_space = 0;
+            double ratio_nt_space = 0;
+            if (num_all_links > 0) {
+                ratio_node_space = (double)sum_all_node_space / (double)num_all_links;
+                ratio_nt_space = (double)sum_all_nt_space / (double)num_all_links;
+            }
+            std::cout << "all_paths\t" << ratio_node_space << "\t" << ratio_nt_space << "\t" << num_all_links;
 
             if (_ignore_gap_links){
                 std::cout << "\t" << num_all_gap_links_ignored << std::endl;

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -7,7 +7,7 @@
 //#include "io_helper.hpp"
 #include "threads.hpp"
 
-#define debug_odgi_stats
+//#define debug_odgi_stats
 
 namespace odgi {
 
@@ -181,7 +181,8 @@ int main_stats(int argc, char** argv) {
             uint64_t sum_nt_space = 0;
             uint64_t num_pairs = 0;
 
-            std::cerr << "mean nodes distance\npath\tvalue_in_node_space\tvalue_in_nucleotide_space\tnum_pairs" << std::endl;
+            std::cout << "#mean_nodes_distance" << std::endl;
+            std::cout << "path\tin_node_space\tin_nucleotide_space\tnum_pairs" << std::endl;
 
             graph.for_each_path_handle([&](const path_handle_t &path) {
 #ifdef debug_odgi_stats
@@ -223,11 +224,11 @@ int main_stats(int argc, char** argv) {
                 }
 
                 if (args::get(path_statistics)) {
-                    std::cerr << graph.get_path_name(path) << "\t" << (double)sum_in_path_node_space / (double)num_pairs_in_path << "\t" << (double)sum_in_path_nt_space / (double)num_pairs_in_path << "\t" << num_pairs_in_path << std::endl;
+                    std::cout << graph.get_path_name(path) << "\t" << (double)sum_in_path_node_space / (double)num_pairs_in_path << "\t" << (double)sum_in_path_nt_space / (double)num_pairs_in_path << "\t" << num_pairs_in_path << std::endl;
                 }
             });
 
-            std::cerr << "all_paths\t" << (double)sum_node_space / (double)num_pairs << "\t" << (double)sum_nt_space / (double)num_pairs << "\t" << num_pairs << std::endl;
+            std::cout << "all_paths\t" << (double)sum_node_space / (double)num_pairs << "\t" << (double)sum_nt_space / (double)num_pairs << "\t" << num_pairs << std::endl;
         }
 
         if (args::get(mean_links_length)){
@@ -238,12 +239,13 @@ int main_stats(int argc, char** argv) {
             uint64_t num_all_links = 0;
             uint64_t num_all_gap_links_ignored = 0;
 
-            std::cerr << "mean links length\npath\tvalue_in_node_space\tvalue_in_nucleotide_space\tnum_links_considered";
+            std::cout << "#mean_links_length" << std::endl;
+            std::cout << "path\tin_node_space\tin_nucleotide_space\tnum_links_considered";
 
             if (_ignore_gap_links){
-                std::cerr << "\tnum_gap_links_ignored" << std::endl;
+                std::cout << "\tnum_gap_links_ignored" << std::endl;
             }else{
-                std::cerr << std::endl;
+                std::cout << std::endl;
             }
 
             graph.for_each_path_handle([&](const path_handle_t &path) {
@@ -296,12 +298,12 @@ int main_stats(int argc, char** argv) {
                 });
 
                 if (args::get(path_statistics)) {
-                    std::cerr << graph.get_path_name(path) << "\t" << (double)sum_node_space / (double)num_links << "\t" << (double)sum_nt_space / (double)num_links << "\t" << num_links;
+                    std::cout << graph.get_path_name(path) << "\t" << (double)sum_node_space / (double)num_links << "\t" << (double)sum_nt_space / (double)num_links << "\t" << num_links;
 
                     if (_ignore_gap_links){
-                        std::cerr << "\t" << num_gap_links_ignored << std::endl;
+                        std::cout << "\t" << num_gap_links_ignored << std::endl;
                     }else{
-                        std::cerr << std::endl;
+                        std::cout << std::endl;
                     }
                 }
 
@@ -311,12 +313,12 @@ int main_stats(int argc, char** argv) {
                 num_all_gap_links_ignored += num_gap_links_ignored;
             });
 
-            std::cerr << "all_paths\t" << (double)sum_all_node_space / (double)num_all_links << "\t" << (double)sum_all_nt_space / (double)num_all_links << "\t" << num_all_links;
+            std::cout << "all_paths\t" << (double)sum_all_node_space / (double)num_all_links << "\t" << (double)sum_all_nt_space / (double)num_all_links << "\t" << num_all_links;
 
             if (_ignore_gap_links){
-                std::cerr << "\t" << num_all_gap_links_ignored << std::endl;
+                std::cout << "\t" << num_all_gap_links_ignored << std::endl;
             }else{
-                std::cerr << std::endl;
+                std::cout << std::endl;
             }
         }
 
@@ -330,12 +332,13 @@ int main_stats(int argc, char** argv) {
             uint64_t num_all_penalties = 0;
             uint64_t num_all_penalties_rev_nodes = 0;
 
-            std::cerr << "sum of path node distances\npath\tvalue_in_node_space\tlength_in_nodes\tvalue_in_nucleotide_space\tlength_in_nucleotides\tnum_penalties";
+            std::cout << "#sum_of_path_node_distances" << std::endl;
+            std::cout << "path\tin_node_space\tnodes\tin_nucleotide_space\tnucleotides\tnum_penalties";
 
             if (_penalize_reversed_nodes){
-                std::cerr << "\tnum_penalties_reversed_nodes" << std::endl;
+                std::cout << "\tnum_penalties_reversed_nodes" << std::endl;
             }else{
-                std::cerr << std::endl;
+                std::cout << std::endl;
             }
 
             graph.for_each_path_handle([&](const path_handle_t &path) {
@@ -388,12 +391,12 @@ int main_stats(int argc, char** argv) {
                 });
 
                 if (args::get(path_statistics)) {
-                    std::cerr << graph.get_path_name(path) << "\t" << (double)sum_path_node_dist_node_space / (double)len_path_node_space << "\t" << len_path_node_space << "\t" << (double)sum_path_node_dist_nt_space / (double)len_path_nt_space << "\t" << len_path_nt_space  << "\t" << num_penalties;
+                    std::cout << graph.get_path_name(path) << "\t" << (double)sum_path_node_dist_node_space / (double)len_path_node_space << "\t" << len_path_node_space << "\t" << (double)sum_path_node_dist_nt_space / (double)len_path_nt_space << "\t" << len_path_nt_space  << "\t" << num_penalties;
 
                     if (_penalize_reversed_nodes){
-                        std::cerr << "\t" << num_penalties_rev_nodes << std::endl;
+                        std::cout << "\t" << num_penalties_rev_nodes << std::endl;
                     }else{
-                        std::cerr << std::endl;
+                        std::cout << std::endl;
                     }
                 }
 
@@ -405,12 +408,12 @@ int main_stats(int argc, char** argv) {
                 num_all_penalties_rev_nodes += num_penalties_rev_nodes;
             });
 
-            std::cerr << "all_paths\t" << (double)sum_all_path_node_dist_node_space / (double)len_all_path_node_space << "\t" << len_all_path_node_space << "\t" << (double)sum_all_path_node_dist_nt_space / (double)len_all_path_nt_space << "\t" << len_all_path_nt_space << "\t" << num_all_penalties;
+            std::cout << "all_paths\t" << (double)sum_all_path_node_dist_node_space / (double)len_all_path_node_space << "\t" << len_all_path_node_space << "\t" << (double)sum_all_path_node_dist_nt_space / (double)len_all_path_nt_space << "\t" << len_all_path_nt_space << "\t" << num_all_penalties;
 
             if (_penalize_reversed_nodes){
-                std::cerr << "\t" << num_all_penalties_rev_nodes << std::endl;
+                std::cout << "\t" << num_all_penalties_rev_nodes << std::endl;
             }else{
-                std::cerr << std::endl;
+                std::cout << std::endl;
             }
         }
     }

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -256,24 +256,29 @@ int main_stats(int argc, char** argv) {
                         uint64_t unpacked_h = number_bool_packing::unpack_number(h);
                         uint64_t unpacked_i = number_bool_packing::unpack_number(i);
 
+                        uint64_t dist_node_space = 0;
+                        uint64_t dist_nt_space = 0;
+                        uint8_t weight = 1;
                         if (unpacked_i >= unpacked_h){
-                            sum_path_node_dist_node_space += unpacked_i - unpacked_h;
-                            sum_path_node_dist_nt_space += position_map[unpacked_i] - position_map[unpacked_h];
+                            dist_node_space = unpacked_i - unpacked_h;
+                            dist_nt_space = position_map[unpacked_i] - position_map[unpacked_h];
                         }else{
+                            dist_node_space = unpacked_h - unpacked_i;
+                            dist_nt_space = position_map[unpacked_h] - position_map[unpacked_i];
+
                             // When a path goes back in terms of pangenomic order, this is punished
-                            sum_path_node_dist_node_space += 3 * (unpacked_h - unpacked_i);
-                            sum_path_node_dist_nt_space += 3 * (position_map[unpacked_h] - position_map[unpacked_i]);
+                            weight = 3;
                             num_penalties++;
                         }
 
-                        if (_penalize_reversed_nodes){
-                            // 0/1: forward/reverse: +/-
-                            if(number_bool_packing::unpack_bit(h)){
-                                sum_path_node_dist_node_space += 2 * (unpacked_h - unpacked_i);
-                                sum_path_node_dist_nt_space += 2 * (position_map[unpacked_h] - position_map[unpacked_i]);
+                        sum_path_node_dist_node_space += weight * dist_node_space;
+                        sum_path_node_dist_nt_space += weight * dist_nt_space;
 
-                                num_penalties_rev_nodes++;
-                            }
+                        if (_penalize_reversed_nodes && number_bool_packing::unpack_bit(h)){
+                            sum_path_node_dist_node_space += 2 * dist_node_space;
+                            sum_path_node_dist_nt_space += 2 * dist_nt_space;
+
+                            num_penalties_rev_nodes++;
                         }
                     }
 

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -215,9 +215,9 @@ int main_stats(int argc, char** argv) {
                         uint64_t unpacked_h = number_bool_packing::unpack_number(h);
                         uint64_t unpacked_i = number_bool_packing::unpack_number(i);
 
-                        // The position map is encoding 2x the number of nodes: it includes the start and end of the node in successive
-                        // entries. Edges leave from the end (or start) of one node (depending on whether they are on the forward or
-                        // reverse strand) and go to the start (or end) of the other side of the link.
+                        // The position map includes the start and end of the node in successive entries.
+                        // Edges leave from the end (or start) of one node (depending on whether they are on the
+                        // forward or reverse strand) and go to the start (or end) of the other side of the link.
                         uint64_t _info_a = unpacked_h + !number_bool_packing::unpack_bit(h);
                         uint64_t _info_b = unpacked_i + number_bool_packing::unpack_bit(i);
 


### PR DESCRIPTION
New metrics for evaluating the goodness of a graph sorting. All the metrics are calculated considering all paths togheter, both in node space and nucleotide space. Moreover, they can be displayed for each path too.

The proposed metrics are:
- **mean nodes distance**: sum distances of all pairs of nodes in each path, dividing by the number of pairs considered.
- **mean link length**: sum link lengths in each path; it is possible to ignore gap links in the metric calculation;
- **sum of path node distances**: for each path, we iterate from node to node, summing their distances, and normalizing by the path length. If a link goes back in the linearized viewpoint of the graph, this is penalized (multiplying by 3 their distance); it is possible to penalize also the presence of reversed nodes (doubling their distance).

Little example, showing the metrics for each path too.
```
H	VN:Z:1.0
S	1	TTTTTTT
S	2	CCCC
S	3	AAAAAAAAAAAAAA
S	4	AAAAAAAAAAAAAAAAA
S	5	TTTTTT
S	6	GGGGGGGGGGG
L	1	-	3	-
L	1	+	2	+
L	2	+	4	+
L	4	+	5	+
L	4	+	6	+
L	2	+	6	+
L	6	+	1	+
P	Path1	1-,3-	*
P	Path2	1+,2+,4+,5+	*
P	Path3	4+,6+	*
P	Path4	1+,2+,6+,1+	*
```

```
odgi build -g 1.gfa -o - | odgi sort -i - -o 1.s.odgi
odgi build -g 1.gfa -o - | odgi sort -i - -Y -o 1.Y.odgi

odgi viz -i 1.s.odgi -o 1.s.png
odgi viz -i 1.Y.odgi -o 1.Y.png
```

![image](https://user-images.githubusercontent.com/62253982/87776187-ab36da80-c827-11ea-95de-40f0cb14d67c.png)


**mean nodes distance**
`odgi stats -i 1.s.odgi -nP`

| path      | in_node_space | in_nucleotide_space | num_pairs |
|-----------|---------------|---------------------|-----------|
| Path1     | 2             | 11                  | 1         |
| Path2     | 2.33333       | 24                  | 6         |
| Path3     | 2             | 23                  | 1         |
| Path4     | 3.33333       | 32                  | 3         |
| all_paths | 2.54545       | 24.9091             | 11        |

`odgi stats -i 1.Y.odgi -nP`

| path      | in_node_space | in_nucleotide_space | num_pairs |
|-----------|---------------|---------------------|-----------|
| Path1	|4	|46	|1|
| Path2	|1.66667	|16.8333|	6|
| Path3	|2	|15|	1|
| Path4|	2	|21.3333|	3|
| all_paths|	2|	20.5455	|11|

**mean links length**
odgi stats -i 1.s.odgi -lP`

| path	|in_node_space	|in_nucleotide_space	|num_links_considered|
|-----------|---------------|---------------------|-----------|
| Path1	|3|	25	|1|
| Path2|	0.333333|	4.66667|	3|
| Path3	|1|	6|	1|
| Path4	|3|	32	|3|
| all_paths|	1.75	|17.625|	8|

`odgi stats -i 1.Y.odgi -lP`

| path	|in_node_space	|in_nucleotide_space	|num_links_considered|
|-----------|---------------|---------------------|-----------|
| Path1	|3|	32|	1|
| Path2	|1.33333	|11.6667	|3|
| Path3|	3|	32|	1|
| Path4|	2.33333|	21.3333	|3|
| all_paths|	2.125|	20.375|	8|

Ignoring gap links.

`odgi stats -i 1.s.odgi -lgP`

| path|	in_node_space|	in_nucleotide_space|	num_links_considered	|num_gap_links_ignored|
|-----------|---------------|---------------------|-----------|-----------|
| Path1	|0	|0|	0|	1|
| Path2	|0	|0|	0|	3|
| Path3	|0	|0|	0|	1|
| Path4	|6	|59	|1	|2|
| all_paths|	6|	59|	1|	7|

`odgi stats -i 1.Y.odgi -lgP`

| path|	in_node_space|	in_nucleotide_space|	num_links_considered	|num_gap_links_ignored|
|-----------|---------------|---------------------|-----------|-----------|
| Path1	| 3| 	32| 	1| 	0| 
|  Path2	| 2	| 17.5	| 2	| 1| 
|  Path3	| 3| 	32| 	1| 	0| 
|  Path4	| 2.33333	| 21.3333	| 3	| 0| 
|  all_paths| 	2.42857| 	23.2857| 	7| 	1| 

**sum of path node distances**

`odgi stats -i 1.s.odgi -sP`

|path|	in_node_space|	nodes|	in_nucleotide_space|	nucleotides|	num_penalties|
|-----------|---------------|---------------------|-----------|-----------|-----------|
| Path1	|1|	2|	0.52381|	21|	0|
| Path2	|1	|4	|1.23529	|34	|0|
| Path3	|1|	2|	0.821429|	28|	0|
| Path4	|5	|4	|6.62069	|29	|1|
| all_paths|	2.33333|	12|	2.39286|	112|	1|

`odgi stats -i 1.Y.odgi -sP`

|path|	in_node_space|	nodes|	in_nucleotide_space|	nucleotides|	num_penalties|
|-----------|---------------|---------------------|-----------|-----------|-----------|
|Path1	|6|	2|	6.57143|	21|	1|
| Path2	|2.25	|4	|2.67647	|34	|1|
| Path3	|3|	2|	1.60714|	28|	1|
| Path4	|3	|4	|4.41379	|29	|2|
| all_paths|	3.25|	12|	3.58929|	112|	5|

Penalizing also the presence of reversed nodes.

`odgi stats -i 1.s.odgi -srP`

|path|	in_node_space|	nodes|	in_nucleotide_space|	nucleotides|	num_penalties|	num_penalties_reversed_nodes|
|-----------|---------------|---------------------|-----------|-----------|-----------|-----------|
| Path1	|3	|2	|1.57143	|21	|0	|1|
| Path2	|1	|4|	1.23529|	34|	0|	0|
| Path3	|1	|2	|0.821429	|28	|0	|0|
| Path4	|5|	4|	6.62069|	29|	1|	0|
| all_paths	|2.66667	|12	|2.58929	|112	|1	|1|

`odgi stats -i 1.Y.odgi -srP`

|path|	in_node_space|	nodes|	in_nucleotide_space|	nucleotides|	num_penalties|	num_penalties_reversed_nodes|
|-----------|---------------|---------------------|-----------|-----------|-----------|-----------|
| Path1|	10|	2|	10.9524|	21|	1|	1|
| Path2	|2.25	|4	|2.67647	|34	|1	|0|
| Path3	|3	|2	|1.60714	|28	|1	|0|
| Path4	|3|	4|	4.41379|	29|	2|	0|
| all_paths|	3.91667|	12|	4.41071|	112|	5|	1|