### PR TITLE
cgranges for path-guided SGD

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "deps/cpp_random_distributions"]
 	path = deps/cpp_random_distributions
 	url = https://github.com/llersch/cpp_random_distributions.git
+[submodule "deps/cgranges"]
+	path = deps/cgranges
+	url = https://github.com/lh3/cgranges.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,16 @@ ExternalProject_Add(intervaltree
 ExternalProject_Get_property(intervaltree SOURCE_DIR)
 set(intervaltree_INCLUDE "${SOURCE_DIR}")
 
+# cgranges
+ExternalProject_Add(cgranges
+  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/cgranges"
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND ""
+  CONFIGURE_COMMAND "")
+ExternalProject_Get_property(cgranges SOURCE_DIR)
+set(cgranges_INCLUDE "${SOURCE_DIR}/cpp")
+
 # lodepng
 ExternalProject_Add(lodepng
   SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/lodepng"
@@ -347,6 +357,7 @@ set(odgi_DEPS
     sparsepp
     ska
     intervaltree
+    cgranges
     lodepng
     structures
     picosha256
@@ -371,6 +382,7 @@ set(odgi_INCLUDES
   "${sparsepp_INCLUDE}"
   "${ska_INCLUDE}"
   "${intervaltree_INCLUDE}"
+  "${cgranges_INCLUDE}"
   "${lodepng_INCLUDE}"
   "${bbhash_INCLUDE}"
   "${structures_INCLUDE}"

--- a/src/algorithms/path_sgd.hpp
+++ b/src/algorithms/path_sgd.hpp
@@ -11,7 +11,7 @@
 #include <handlegraph/path_handle_graph.hpp>
 #include "xp.hpp"
 #include "sgd_term.hpp"
-#include "IntervalTree.h"
+#include "IITree.h"
 #include <zipfian_int_distribution.h>
 #include <iomanip>
 #include <string>

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -60,7 +60,7 @@ int main_sort(int argc, char** argv) {
     args::Flag mondriaan_path_weight(parser, "path-weight", "weight mondriaan input matrix by path coverage of edges", {'W', "mondriaan-path-weight"});
     args::Flag p_sgd(parser, "path-sgd", "apply path guided linear 1D SGD algorithm to organize graph", {'Y', "path-sgd"});
     args::ValueFlag<std::string> p_sgd_in_file(parser, "FILE", "specify a line separated list of paths to sample from for the on the fly term generation process in the path guided linear 1D SGD (default: sample from all paths)", {'f', "path-sgd-use-paths"});
-    args::ValueFlag<double> p_sgd_min_term_updates(parser, "N", "minimum number of terms to be updated before a new path guided linear 1D SGD iteration with adjusted learning rate eta starts, expressed as a multiple of total path length (default: 1)", {'G', "path-sgd-min-term-updates"});
+    args::ValueFlag<double> p_sgd_min_term_updates(parser, "N", "minimum number of terms to be updated before a new path guided linear 1D SGD iteration with adjusted learning rate eta starts, expressed as a multiple of total path length (default: 0.1)", {'G', "path-sgd-min-term-updates"});
     args::ValueFlag<double> p_sgd_delta(parser, "N", "threshold of maximum displacement approximately in bp at which to stop path guided linear 1D SGD (default: 0)", {'j', "path-sgd-delta"});
     args::ValueFlag<double> p_sgd_eps(parser, "N", "final learning rate for path guided linear 1D SGD model (default: 0.01)", {'g', "path-sgd-eps"});
     args::ValueFlag<double> p_sgd_zipf_theta(parser, "N", "the theta value for the Zipfian distrubution which is used as the sampling method for the second node of one term in the path guided linear 1D SGD model (default: 0.99)", {'a', "path-sgd-zipf-theta"});
@@ -206,7 +206,7 @@ int main_sort(int argc, char** argv) {
             });
         }
         uint64_t sum_path_length = get_sum_path_lengths(path_sgd_use_paths, path_index);
-        path_sgd_min_term_updates = args::get(p_sgd_min_term_updates) ? (args::get(p_sgd_min_term_updates) * sum_path_length) : sum_path_length;
+        path_sgd_min_term_updates = args::get(p_sgd_min_term_updates) ? (args::get(p_sgd_min_term_updates) * sum_path_length) : 0.1 * sum_path_length;
         path_sgd_zipf_space = args::get(p_sgd_zipf_space) ? args::get(p_sgd_zipf_space) : get_max_path_length(path_sgd_use_paths, path_index);
     }
 


### PR DESCRIPTION
This avoids constructing a potentially large explicit interval tree, using cgranges implicit interval tree instead to record the mapping between the path set and the (virtual) space of concatenated paths. This is used to drive the random sampling of positions in the graph, weighted by path coverage.