### PR TITLE
Added the new command 'odgi cover' to generate paths covering the graph

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/algorithms/chop.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/unchop.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/perfect_neighbors.cpp
+        ${CMAKE_SOURCE_DIR}/src/algorithms/cover.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/path_sgd.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/remove_isolated.cpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/expand_context.cpp
@@ -454,6 +455,7 @@ set(odgi_HEADERS
   ${CMAKE_SOURCE_DIR}/src/algorithms/split_strands.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/extract_extending_graph.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/extract_connecting_graph.hpp
+        ${CMAKE_SOURCE_DIR}/src/algorithms/cover.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/path_sgd.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/kmer.hpp
   ${CMAKE_SOURCE_DIR}/src/algorithms/expand_context.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ add_library(odgi_objs OBJECT
   ${CMAKE_SOURCE_DIR}/src/subcommand/build_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/test_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/stats_main.cpp
+        ${CMAKE_SOURCE_DIR}/src/subcommand/cover_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/sort_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/view_main.cpp
   ${CMAKE_SOURCE_DIR}/src/subcommand/kmers_main.cpp

--- a/docs/asciidocs/odgi.adoc
+++ b/docs/asciidocs/odgi.adoc
@@ -205,7 +205,7 @@ Refer to the *odgi* issue tracker at https://github.com/vgteam/odgi/issues.
 
 == AUTHORS
 
-Erik Garrison from the University of California Santa Cruz wrote the whole *odgi* tool. Simon Heumos from the Quantitative Biology Center Tübingen wrote *odgi pathindex*, *odgi panpos*, *odgi server*, and this documentation.
+Erik Garrison from the University of California Santa Cruz wrote the whole *odgi* tool. Simon Heumos from the Quantitative Biology Center Tübingen wrote *odgi pathindex*, *odgi panpos*, *odgi server*, and this documentation. Andrea Guarracino from the University of Rome Tor Vergata wrote *odgi cover*.
 
 == RESOURCES
 

--- a/docs/asciidocs/odgi.adoc
+++ b/docs/asciidocs/odgi.adoc
@@ -18,6 +18,8 @@ odgi - dynamic succinct variation graph tool
 
 *odgi* <<odgi_stats.adoc#_odgi_stats1, stats>> -i graph.og -S
 
+*odgi* <<odgi_cover.adoc#_odgi_cover1, cover>> -i graph.og -o graph.paths.og
+
 *odgi* <<odgi_sort.adoc#_odgi_sort1, sort>> -i graph.og -o graph.sorted.og -p bSnSnS
 
 *odgi* <<odgi_view.adoc#_odgi_view1, view>> -i graph.og -g
@@ -78,6 +80,9 @@ The odgi build(1) command constructs a succinct variation graph from a GFA. Curr
 
 *odgi stats* [*-i, --idx*=_FILE_] [_OPTION_]... +
 The odgi stats(1) command produces statistics of a variation graph. Among other metrics, it can calculate the #nodes, #edges, #paths and the total nucleotide length of the graph. Various histogram summary options complement the tool. If [*-B, --bed-multicov*=_BED_] is set, the metrics will be produced for the intervals specified in the BED.
+
+*odgi cover* [*-i, --idx*=_FILE_] [*-o, --out*=_FILE_] [_OPTION_]... +
+The odgi cover(1) command find a path cover of a variation graph, with a specified number of paths per component.
 
 *odgi sort* [*-i, --idx*=_FILE_] [*-o, --out*=_FILE_] [_OPTION_]... +
 The odgi sort(1) command sorts a succinct variation graph. Odgi sort offers a diverse palette of sorting algorithms to

--- a/docs/asciidocs/odgi_cover.adoc
+++ b/docs/asciidocs/odgi_cover.adoc
@@ -41,14 +41,17 @@ The odgi cover(1) command find a path cover of a variation graph, with a specifi
 *-k, --node-windows-size*=_N_::
   Size of the node window to check each time a new path is extended (it has to be greater than or equal to 2).
 
-*-c/ --min-node-coverage*=_N_::
+*-c, --min-node-coverage*=_N_::
   Minimum node coverage to reach (it has to be greater than 0). There will be generated paths until the specified minimum node coverage is reached, or until the maximum number of allowed generated paths is reached (number of nodes in the input variation graph).
+
+*-w, --write-node-coverages*=_FILE_::
+  Write the node coverages at the end of the paths generation to FILE. The file will contain tab-separated values (header included), and have 3 columns: _component_id_, _node_id_, and _coverage_.
 
 
 === Processing Information
 
 *-d, --debug*::
-  Print information about the components and the progress to stdout.
+  Print information about the components and the progress to stderr.
 
 
 === Program Information

--- a/docs/asciidocs/odgi_cover.adoc
+++ b/docs/asciidocs/odgi_cover.adoc
@@ -1,0 +1,100 @@
+= odgi cover(1)
+ifdef::backend-manpage[]
+Erik Garrison
+:doctype: manpage
+:release-version: v0.4.1 
+:man manual: odgi cover
+:man source: odgi v0.4.1 
+:page-layout: base
+endif::[]
+
+== NAME
+
+odgi_cover - find a path cover of the variation graph
+
+== SYNOPSIS
+
+*odgi cover* [*-i, --idx*=_FILE_] [*-o, --out*=_FILE_] [_OPTION_]...
+
+== DESCRIPTION
+
+The odgi cover(1) command find a path cover of a variation graph, with a specified number of paths per component.
+
+== OPTIONS
+
+=== Graph Files IO
+
+*-i, --idx*=_FILE_::
+  File containing the succinct variation graph where find a path cover. The file name usually ends with _.og_.
+
+*-o, --out*=_FILE_::
+  Write the succinct variation graph with the generated paths to _FILE_. The file name usually ends with _.og_.
+
+=== Cover Options
+
+*-n, --num-paths-per-component*=_N_::
+  Number of paths to generate per component.
+
+*-k, --node-windows-size*=_N_::
+  Size of the node window to check each time a new path is extended (it has to be greater than or equal to 2).
+
+=== Processing Information
+
+*-d, --debug*::
+  Print information about the components and the progress to stdout.
+
+=== Program Information
+
+*-h, --help*::
+  Print a help message for *odgi cover*.
+
+== EXIT STATUS
+
+*0*::
+  Success.
+
+*1*::
+  Failure (syntax or usage error; parameter error; file processing failure; unexpected error).
+
+== BUGS
+
+Refer to the *odgi* issue tracker at https://github.com/vgteam/odgi/issues.
+
+== AUTHORS
+
+*odgi cover* was written by Erik Garrison.
+
+ifdef::backend-manpage[]
+== RESOURCES
+
+*Project web site:* https://github.com/vgteam/odgi
+
+*Git source repository on GitHub:* https://github.com/vgteam/odgi
+
+*GitHub organization:* https://github.com/vgteam
+
+*Discussion list / forum:* https://github.com/vgteam/odgi/issues
+
+== COPYING
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Erik Garrison
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+endif::[]

--- a/docs/asciidocs/odgi_cover.adoc
+++ b/docs/asciidocs/odgi_cover.adoc
@@ -1,6 +1,6 @@
 = odgi cover(1)
 ifdef::backend-manpage[]
-Erik Garrison
+Andrea Guarracino
 :doctype: manpage
 :release-version: v0.4.1 
 :man manual: odgi cover
@@ -12,6 +12,7 @@ endif::[]
 
 odgi_cover - find a path cover of the variation graph
 
+
 == SYNOPSIS
 
 *odgi cover* [*-i, --idx*=_FILE_] [*-o, --out*=_FILE_] [_OPTION_]...
@@ -19,6 +20,7 @@ odgi_cover - find a path cover of the variation graph
 == DESCRIPTION
 
 The odgi cover(1) command find a path cover of a variation graph, with a specified number of paths per component.
+
 
 == OPTIONS
 
@@ -30,6 +32,7 @@ The odgi cover(1) command find a path cover of a variation graph, with a specifi
 *-o, --out*=_FILE_::
   Write the succinct variation graph with the generated paths to _FILE_. The file name usually ends with _.og_.
 
+
 === Cover Options
 
 *-n, --num-paths-per-component*=_N_::
@@ -38,15 +41,21 @@ The odgi cover(1) command find a path cover of a variation graph, with a specifi
 *-k, --node-windows-size*=_N_::
   Size of the node window to check each time a new path is extended (it has to be greater than or equal to 2).
 
+*-c/ --min-node-coverage*=_N_::
+  Minimum node coverage to reach (it has to be greater than 0). There will be generated paths until the specified minimum node coverage is reached, or until the maximum number of allowed generated paths is reached (number of nodes in the input variation graph).
+
+
 === Processing Information
 
 *-d, --debug*::
   Print information about the components and the progress to stdout.
 
+
 === Program Information
 
 *-h, --help*::
   Print a help message for *odgi cover*.
+
 
 == EXIT STATUS
 

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -1,10 +1,12 @@
+
 #include "cover.hpp"
 
-// #define debug_cover
+#define debug_cover
 
 namespace odgi {
     namespace algorithms {
 
+        //TODO: check if there is already an implementation like that somewhere
         ska::flat_hash_set<handlegraph::nid_t>
         is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<long int> &component) {
             ska::flat_hash_set<handlegraph::nid_t> head_nodes;
@@ -302,6 +304,12 @@ namespace odgi {
             }
 
             return true;
+        }
+
+        void path_cover(handlegraph::MutablePathDeletableHandleGraph &graph,
+                        size_t n, size_t k,
+                        bool show_progress) {
+
         }
 
     }

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -235,6 +235,7 @@ namespace odgi {
                              std::vector<ska::flat_hash_set<handlegraph::nid_t>> &components, size_t component_id,
                              size_t num_paths_per_component, size_t node_window_size,
                              size_t min_node_coverage, size_t max_number_of_paths_generable,
+                             bool write_node_covearges, std::string &node_coverages,
                              bool show_progress) {
             typedef typename Coverage::coverage_t coverage_t;
             typedef typename Coverage::node_coverage_t node_coverage_t;
@@ -268,9 +269,9 @@ namespace odgi {
             // the component.
             component = ska::flat_hash_set<handlegraph::nid_t>();
 
-            if (num_paths_per_component > 0){
+            if (num_paths_per_component > 0) {
                 min_node_coverage = std::numeric_limits<uint64_t>::max();
-            }else{
+            } else {
                 num_paths_per_component = max_number_of_paths_generable;
             }
             // Generate num_paths_per_component paths in the component.
@@ -286,7 +287,7 @@ namespace odgi {
                 std::cerr << node_coverage.front().first << " --- " << node_coverage.front().second << std::endl;
 #endif
 
-                if (node_coverage.front().second >= min_node_coverage){
+                if (node_coverage.front().second >= min_node_coverage) {
                     std::cerr << "Minimum node coverage reached after generating " << i << " paths." << std::endl;
                     break;
                 }
@@ -325,12 +326,25 @@ namespace odgi {
 #endif
             }
 
+            if (write_node_covearges) {
+                if (component_id == 0) {
+                    node_coverages += "component_id\tnode_id\tcoverage\n";
+                }
+
+                for (node_coverage_t single_coverage : node_coverage) {
+                    node_coverages +=
+                            std::to_string(component_id) + "\t" + std::to_string(single_coverage.first) + "\t" +
+                            std::to_string(single_coverage.second) + "\n";
+                }
+            }
+
             return true;
         }
 
         void path_cover(handlegraph::MutablePathDeletableHandleGraph &graph,
                         size_t num_paths_per_component, size_t node_window_size,
                         size_t min_node_coverage, size_t max_number_of_paths_generable,
+                        bool write_node_coverages, std::string &node_coverages,
                         bool show_progress) {
             std::vector<ska::flat_hash_set<handlegraph::nid_t>> weak_components = algorithms::weakly_connected_components(
                     &graph);
@@ -341,6 +355,7 @@ namespace odgi {
                 if (component_path_cover<SimpleCoverage>(graph, weak_components, contig,
                                                          num_paths_per_component, node_window_size,
                                                          min_node_coverage, max_number_of_paths_generable,
+                                                         write_node_coverages, node_coverages,
                                                          show_progress)) {
                     processed_components++;
 

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -149,6 +149,8 @@ namespace odgi {
                     // We are actually interested in the intersection of this graph and the component.
                     // For example, some nodes of the original graph may be missing from a GBWTGraph.
                     if (!(graph.has_node(id))) { continue; }
+
+                    // TODO: if the graph already have paths, init with the current already present
                     node_coverage.emplace_back(id, static_cast<coverage_t>(0));
                 }
                 return node_coverage;
@@ -275,7 +277,8 @@ namespace odgi {
                 num_paths_per_component = max_number_of_paths_generable;
             }
             // Generate num_paths_per_component paths in the component.
-            for (size_t i = 0; i < num_paths_per_component; i++) {
+            uint64_t i;
+            for (i = 0; i < num_paths_per_component; i++) {
                 // Choose a starting node with minimum coverage and then sort the nodes by id.
                 std::deque<handle_t> path;
                 std::sort(node_coverage.begin(), node_coverage.end(),
@@ -324,6 +327,10 @@ namespace odgi {
                 }
                 std::cerr << std::endl;
 #endif
+            }
+
+            if ((min_node_coverage != std::numeric_limits<uint64_t>::max()) && (i >= num_paths_per_component)){
+                std::cerr << "Maximum number of generable paths reached." << std::endl;
             }
 
             if (write_node_covearges) {

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -1,0 +1,308 @@
+#include "cover.hpp"
+
+// #define debug_cover
+
+namespace odgi {
+    namespace algorithms {
+
+        ska::flat_hash_set<handlegraph::nid_t>
+        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<long int> &component) {
+            ska::flat_hash_set<handlegraph::nid_t> head_nodes;
+            if (component.empty()) { return head_nodes; }
+
+            constexpr size_t NOT_SEEN = std::numeric_limits<size_t>::max();
+            std::unordered_map<nid_t, std::pair<size_t, bool>> nodes; // (remaining indegree, orientation)
+            std::stack<handle_t> active;
+            size_t found = 0; // Number of nodes that have become head nodes.
+
+            // Find the head nodes.
+            size_t missing_nodes = 0;
+            for (nid_t node : component) {
+                if (!(graph.has_node(node))) {
+                    missing_nodes++;
+                    continue;
+                }
+                handle_t handle = graph.get_handle(node, false);
+                size_t indegree = graph.get_degree(handle, true);
+                if (indegree == 0) {
+                    nodes[node] = std::make_pair(indegree, false);
+                    head_nodes.insert(node);
+                    active.push(handle);
+                    found++;
+                } else {
+                    nodes[node] = std::make_pair(NOT_SEEN, false);
+                }
+            }
+
+            // Active nodes are the current head nodes. Process the successors, determine their
+            // orientations, and decrement their indegrees. If the indegree becomes 0, activate
+            // the node.
+            bool ok = true;
+            while (!(active.empty())) {
+                handle_t curr = active.top();
+                active.pop();
+                graph.follow_edges(curr, false, [&](const handle_t &next) -> bool {
+                    nid_t next_id = graph.get_id(next);
+                    bool next_orientation = graph.get_is_reverse(next);
+                    auto iter = nodes.find(next_id);
+                    if (iter->second.first == NOT_SEEN) // First visit to the node.
+                    {
+                        iter->second.first = graph.get_degree(next, true);
+                        iter->second.second = next_orientation;
+                    } else if (next_orientation != iter->second.second) // Already visited, wrong orientation.
+                    {
+                        ok = false;
+                        return false;
+                    }
+                    iter->second.first--;
+                    if (iter->second.first == 0) {
+                        active.push(next);
+                        found++;
+                    }
+                    return true;
+                });
+                if (!ok) { break; }
+            }
+            if (found != component.size() - missing_nodes) { ok = false; }
+
+            if (!ok) { head_nodes.clear(); }
+            return head_nodes;
+        }
+
+        template<class NodeCoverage>
+        size_t
+        find_first(std::vector<NodeCoverage> &array, nid_t id) {
+            size_t first = 0, mid = 0;
+            size_t count = array.size();
+            while (count > 0) {
+                size_t step = count / 2;
+                mid = first + step;
+                if (array[mid].first < id) {
+                    first = mid + 1;
+                    count -= step + 1;
+                } else { count = step; }
+            }
+            return first;
+        }
+
+        std::vector<handle_t>
+        reverse_complement(const HandleGraph &graph, std::vector<handle_t> &forward) {
+            std::vector<handle_t> result = forward;
+            std::reverse(result.begin(), result.end());
+            for (handle_t &handle : result) { handle = graph.flip(handle); }
+            return result;
+        }
+
+        std::vector<handle_t>
+        forward_window(const HandleGraph &graph, const std::deque<handle_t> &path, const handle_t &successor,
+                       size_t k) {
+            if (path.size() + 1 < k) { k = path.size() + 1; } // Handle the short initial paths in DAGs.
+            std::vector<handle_t> forward;
+            forward.reserve(k);
+            forward.insert(forward.end(), path.end() - (k - 1), path.end());
+            forward.push_back(successor);
+
+            std::vector<handle_t> reverse = reverse_complement(graph, forward);
+            return (forward < reverse ? forward : reverse);
+        }
+
+        std::vector<handle_t>
+        backward_window(const HandleGraph &graph, const std::deque<handle_t> &path, const handle_t &predecessor,
+                        size_t k) {
+            std::vector<handle_t> forward;
+            forward.reserve(k);
+            forward.push_back(predecessor);
+            forward.insert(forward.end(), path.begin(), path.begin() + (k - 1));
+
+            std::vector<handle_t> reverse = reverse_complement(graph, forward);
+            return (forward < reverse ? forward : reverse);
+        }
+
+        template<class Coverage>
+        struct BestCoverage {
+            typedef typename Coverage::coverage_t coverage_t;
+
+            coverage_t coverage;
+            handle_t handle;
+
+            BestCoverage() : coverage(Coverage::worst_coverage()), handle() {}
+
+            void update(const coverage_t &new_coverage, const handle_t &new_handle) {
+                if (new_coverage < this->coverage) {
+                    this->coverage = new_coverage;
+                    this->handle = new_handle;
+                }
+            }
+        };
+
+        struct SimpleCoverage {
+            typedef HandleGraph graph_t;
+
+            typedef size_t coverage_t;
+            typedef std::pair<nid_t, coverage_t> node_coverage_t;
+
+            static std::vector<node_coverage_t>
+            init_node_coverage(const graph_t &graph, const ska::flat_hash_set<handlegraph::nid_t> &component) {
+                std::vector<node_coverage_t> node_coverage;
+                node_coverage.reserve(component.size());
+                for (nid_t id : component) {
+                    // We are actually interested in the intersection of this graph and the component.
+                    // For example, some nodes of the original graph may be missing from a GBWTGraph.
+                    if (!(graph.has_node(id))) { continue; }
+                    node_coverage.emplace_back(id, static_cast<coverage_t>(0));
+                }
+                return node_coverage;
+            }
+
+            static bool extend_forward(const graph_t &graph, std::deque<handle_t> &path, size_t k,
+                                       std::vector<node_coverage_t> &node_coverage,
+                                       std::map<std::vector<handle_t>, coverage_t> &path_coverage, bool acyclic) {
+                bool success = false;
+                BestCoverage<SimpleCoverage> best;
+                graph.follow_edges(path.back(), false, [&](const handle_t &next) {
+                    success = true;
+                    if (!acyclic && path.size() + 1 < k) // Node coverage.
+                    {
+                        size_t first = find_first(node_coverage, graph.get_id(next));
+                        best.update(node_coverage[first].second, next);
+                    } else {
+                        std::vector<handle_t> window = forward_window(graph, path, next, k);
+                        best.update(path_coverage[window], next);
+                    }
+                });
+
+                if (success) {
+                    if (acyclic || path.size() + 1 >= k) {
+                        std::vector<handle_t> window = forward_window(graph, path, best.handle, k);
+                        increase_coverage(path_coverage[window]);
+                    }
+                    if (!acyclic) {
+                        size_t first = find_first(node_coverage, graph.get_id(best.handle));
+                        increase_coverage(node_coverage[first]);
+                    }
+                    path.push_back(best.handle);
+                }
+
+                return success;
+            }
+
+            static bool extend_backward(const graph_t &graph, std::deque<handle_t> &path, size_t k,
+                                        std::vector<node_coverage_t> &node_coverage,
+                                        std::map<std::vector<handle_t>, coverage_t> &path_coverage) {
+                bool success = false;
+                BestCoverage<SimpleCoverage> best;
+                graph.follow_edges(path.front(), true, [&](const handle_t &prev) {
+                    success = true;
+                    if (path.size() + 1 < k) // Node coverage.
+                    {
+                        size_t first = find_first(node_coverage, graph.get_id(prev));
+                        best.update(node_coverage[first].second, prev);
+                    } else {
+                        std::vector<handle_t> window = backward_window(graph, path, prev, k);
+                        best.update(path_coverage[window], prev);
+                    }
+                });
+
+                if (success) {
+                    if (path.size() + 1 >= k) {
+                        std::vector<handle_t> window = backward_window(graph, path, best.handle, k);
+                        increase_coverage(path_coverage[window]);
+                    }
+                    size_t first = find_first(node_coverage, graph.get_id(best.handle));
+                    increase_coverage(node_coverage[first]);
+                    path.push_front(best.handle);
+                }
+
+                return success;
+            }
+
+            static void increase_coverage(coverage_t &coverage) {
+                coverage++;
+            }
+
+            static void increase_coverage(node_coverage_t &node) {
+                increase_coverage(node.second);
+            }
+
+            static coverage_t worst_coverage() { return std::numeric_limits<coverage_t>::max(); }
+
+            static std::string name() { return "SimpleCoverage"; }
+        };
+
+        template<class Coverage>
+        bool
+        component_path_cover(const typename Coverage::graph_t &graph,
+                             std::vector<ska::flat_hash_set<handlegraph::nid_t>> &components, size_t component_id,
+                             size_t n, size_t k, bool show_progress, size_t sample_id_offset, size_t contig_id) {
+            typedef typename Coverage::coverage_t coverage_t;
+            typedef typename Coverage::node_coverage_t node_coverage_t;
+
+            ska::flat_hash_set<handlegraph::nid_t> &component = components[component_id];
+            size_t component_size = component.size();
+            ska::flat_hash_set<handlegraph::nid_t> head_nodes = is_nice_and_acyclic(graph, component);
+            bool acyclic = !(head_nodes.empty());
+            if (show_progress) {
+                std::cerr << Coverage::name() << ": Processing component " << (component_id + 1) << " / "
+                          << components.size();
+                if (acyclic) { std::cerr << " (acyclic)"; }
+                std::cerr << std::endl;
+            }
+
+            // Node coverage for the potential starting nodes.
+            std::vector<node_coverage_t> node_coverage = Coverage::init_node_coverage(graph, (acyclic ? head_nodes
+                                                                                                      : component));
+            std::map<std::vector<handle_t>, coverage_t> path_coverage; // Path and its reverse complement are equivalent.
+
+            // Node coverage will be empty if we cannot create this type of path cover for the component.
+            // For example, if there are no haplotypes for LocalHaplotypes.
+            if (node_coverage.empty()) {
+                if (show_progress) {
+                    std::cerr << Coverage::name() << ": Cannot find this type of path cover for the component"
+                              << std::endl;
+                }
+                return false;
+            }
+
+            // Now that we know that we can find a path cover, we can save a little bit of memory by deleting
+            // the component.
+            component = ska::flat_hash_set<handlegraph::nid_t>();
+
+            // Generate n paths in the component.
+            for (size_t i = 0; i < n; i++) {
+                // Choose a starting node with minimum coverage and then sort the nodes by id.
+                std::deque<handle_t> path;
+                std::sort(node_coverage.begin(), node_coverage.end(),
+                          [](const node_coverage_t &a, const node_coverage_t &b) -> bool {
+                              return (a.second < b.second);
+                          });
+                path.push_back(graph.get_handle(node_coverage.front().first, false));
+                Coverage::increase_coverage(node_coverage.front());
+                std::sort(node_coverage.begin(), node_coverage.end(),
+                          [](const node_coverage_t &a, const node_coverage_t &b) -> bool {
+                              return (a.first < b.first);
+                          });
+
+                // Extend the path forward if acyclic or in both directions otherwise.
+                bool success = true;
+                while (success && path.size() < component_size) {
+                    success = false;
+                    success |= Coverage::extend_forward(graph, path, k, node_coverage, path_coverage, acyclic);
+                    if (!acyclic && path.size() < component_size) {
+                        success |= Coverage::extend_backward(graph, path, k, node_coverage, path_coverage);
+                    }
+                }
+
+#ifdef debug_cover
+                std::cerr << "Path " << i << " -->";
+                for (handle_t handle : path) {
+                    std::cerr << " " << graph.get_id(handle);
+                }
+                std::cerr << std::endl;
+#endif
+            }
+
+            return true;
+        }
+
+    }
+}

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -13,20 +13,32 @@ namespace odgi {
 
         using namespace handlegraph;
 
+        /* This implementation has been took, and slightly modified, by: https://github.com/jltsiren/gbwtgraph */
+
         constexpr size_t PATH_COVER_DEFAULT_N = 16;
-        constexpr size_t PATH_COVER_DEFAULT_K = 4;
+        constexpr size_t PATH_COVER_DEFAULT_K = 3;
 
         /*
-          From https://github.com/jltsiren/gbwtgraph
-
-          Find a path cover of the graph with n paths per component and return a GBWT of the paths.
-          The path cover is built greedily. Each time we extend a path, we choose the extension
+          Determine whether the given component is acyclic in a nice way. In such graphs,
+          when we start from nodes with indegree 0 in forward orientation, we reach each node
+          in a single orientation and find no cycles. Return the head nodes when the component
+          passes the tests or an empty vector otherwise.
+          Ignores node ids that are not present in the graph.
+        */
+        ska::flat_hash_set<handlegraph::nid_t>
+        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component);
+cd
+        /*
+          Find a path cover of the graph with n paths per component, adding the generated paths in the graph.
+          The path cover is built greedily. Each time we extend a path, we choose the extension,
           where the coverage of the k >= 2 node window is the lowest. Note that this is a maximum
           coverage algorithm that tries to maximize the number of windows covered by a fixed number
           of paths.
+
           This algorithm has been inspired by:
             Ghaffaari and Marschall: Fully-sensitive seed finding in sequence graphs using a
             hybrid index. Bioinformatics, 2019.
+
           Because the graph here may have cycles and orientation flips, some changes were necessary:
             - If the component is not a DAG, we start from an arbitrary node with minimal
               coverage and extend in both directions.

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -27,7 +27,7 @@ namespace odgi {
         */
         ska::flat_hash_set<handlegraph::nid_t>
         is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component);
-cd
+
         /*
           Find a path cover of the graph with n paths per component, adding the generated paths in the graph.
           The path cover is built greedily. Each time we extend a path, we choose the extension,

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -4,6 +4,7 @@
 #include <stack>
 #include <map>
 
+#include <handlegraph/mutable_path_deletable_handle_graph.hpp>
 #include <handlegraph/util.hpp>
 #include "weakly_connected_components.hpp"
 
@@ -38,11 +39,8 @@ namespace odgi {
             - When determining window coverage, we consider the window equivalent to its reverse
               complement.
         */
-        /*gbwt::GBWT path_cover_gbwt(const HandleGraph &graph,
-                                   size_t n = PATH_COVER_DEFAULT_N, size_t k = PATH_COVER_DEFAULT_K,
-                                   gbwt::size_type batch_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE,
-                                   gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL,
-                                   bool show_progress = false);*/
+        void path_cover(handlegraph::MutablePathDeletableHandleGraph &graph,
+                        size_t n, size_t k,
+                        bool show_progress = false);
     }
-
 }

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -16,7 +16,7 @@ namespace odgi {
         /* This implementation has been been inspired by: https://github.com/jltsiren/gbwtgraph */
 
         constexpr size_t PATH_COVER_DEFAULT_N = 16;
-        constexpr size_t PATH_COVER_DEFAULT_K = 3;
+        constexpr size_t PATH_COVER_DEFAULT_K = 2;
 
         /*
           Determine whether the given component is acyclic in a nice way. In such graphs,
@@ -54,6 +54,7 @@ namespace odgi {
         void path_cover(handlegraph::MutablePathDeletableHandleGraph &graph,
                         size_t num_paths_per_component, size_t node_window_size,
                         size_t min_node_coverage, size_t max_number_of_paths_generable,
+                        bool write_node_coverages, std::string &node_coverages,
                         bool show_progress = false);
     }
 }

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <unordered_map>
+#include <stack>
+#include <map>
+
+#include <handlegraph/util.hpp>
+#include "weakly_connected_components.hpp"
+
+namespace odgi {
+    namespace algorithms {
+
+        using namespace handlegraph;
+
+        constexpr size_t PATH_COVER_DEFAULT_N = 16;
+        constexpr size_t PATH_COVER_DEFAULT_K = 4;
+
+        /*
+          From https://github.com/jltsiren/gbwtgraph
+
+          Find a path cover of the graph with n paths per component and return a GBWT of the paths.
+          The path cover is built greedily. Each time we extend a path, we choose the extension
+          where the coverage of the k >= 2 node window is the lowest. Note that this is a maximum
+          coverage algorithm that tries to maximize the number of windows covered by a fixed number
+          of paths.
+          This algorithm has been inspired by:
+            Ghaffaari and Marschall: Fully-sensitive seed finding in sequence graphs using a
+            hybrid index. Bioinformatics, 2019.
+          Because the graph here may have cycles and orientation flips, some changes were necessary:
+            - If the component is not a DAG, we start from an arbitrary node with minimal
+              coverage and extend in both directions.
+            - In a DAG, we start from the head node with the lowest coverage so far.
+            - We stop when the length of the path reaches the size of the component.
+            - The length of the window is in nodes instead of base pairs. We expect a sparse graph,
+              where the nodes between variants are long.
+            - If the component is not a DAG and the path is shorter than k - 1 nodes, we consider
+              the coverage of individual nodes instead of windows.
+            - When determining window coverage, we consider the window equivalent to its reverse
+              complement.
+        */
+        /*gbwt::GBWT path_cover_gbwt(const HandleGraph &graph,
+                                   size_t n = PATH_COVER_DEFAULT_N, size_t k = PATH_COVER_DEFAULT_K,
+                                   gbwt::size_type batch_size = gbwt::DynamicGBWT::INSERT_BATCH_SIZE,
+                                   gbwt::size_type sample_interval = gbwt::DynamicGBWT::SAMPLE_INTERVAL,
+                                   bool show_progress = false);*/
+    }
+
+}

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -13,7 +13,7 @@ namespace odgi {
 
         using namespace handlegraph;
 
-        /* This implementation has been took, and slightly modified, by: https://github.com/jltsiren/gbwtgraph */
+        /* This implementation has been been inspired by: https://github.com/jltsiren/gbwtgraph */
 
         constexpr size_t PATH_COVER_DEFAULT_N = 16;
         constexpr size_t PATH_COVER_DEFAULT_K = 3;
@@ -29,9 +29,9 @@ namespace odgi {
         is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component);
 
         /*
-          Find a path cover of the graph with n paths per component, adding the generated paths in the graph.
-          The path cover is built greedily. Each time we extend a path, we choose the extension,
-          where the coverage of the k >= 2 node window is the lowest. Note that this is a maximum
+          Find a path cover of the graph with num_paths_per_component paths per component, adding the generated paths in
+          the graph. The path cover is built greedily. Each time we extend a path, we choose the extension,
+          where the coverage of the node_window_size >= 2 node window is the lowest. Note that this is a maximum
           coverage algorithm that tries to maximize the number of windows covered by a fixed number
           of paths.
 
@@ -46,13 +46,14 @@ namespace odgi {
             - We stop when the length of the path reaches the size of the component.
             - The length of the window is in nodes instead of base pairs. We expect a sparse graph,
               where the nodes between variants are long.
-            - If the component is not a DAG and the path is shorter than k - 1 nodes, we consider
+            - If the component is not a DAG and the path is shorter than node_window_size - 1 nodes, we consider
               the coverage of individual nodes instead of windows.
             - When determining window coverage, we consider the window equivalent to its reverse
               complement.
         */
         void path_cover(handlegraph::MutablePathDeletableHandleGraph &graph,
-                        size_t n, size_t k,
+                        size_t num_paths_per_component, size_t node_window_size,
+                        size_t min_node_coverage, size_t max_number_of_paths_generable,
                         bool show_progress = false);
     }
 }

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -1,0 +1,93 @@
+#include "subcommand.hpp"
+#include "odgi.hpp"
+#include "args.hxx"
+#include "algorithms/cover.hpp"
+
+namespace odgi {
+
+using namespace odgi::subcommand;
+
+int main_cover(int argc, char** argv) {
+
+    // trick argumentparser to do the right thing with the subcommand
+    for (uint64_t i = 1; i < argc-1; ++i) {
+        argv[i] = argv[i+1];
+    }
+    std::string prog_name = "odgi cover";
+    argv[0] = (char*)prog_name.c_str();
+    --argc;
+    
+    args::ArgumentParser parser("find a path cover of the graph");
+    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+    args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+    args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph with the generated paths in this file", {'o', "out"});
+    args::ValueFlag<uint64_t> num_paths_per_component(parser, "N", "number of paths to generate per component", {'n', "num-paths-per-component"});
+    args::ValueFlag<uint64_t> node_window_size(parser, "N", "size of the node window to check each time a new path is extended (it has to be greater than or equal to 2)", {'k', "node-window-size"});
+    args::Flag debug(parser, "debug", "print information about the components", {'d', "debug"});
+
+    try {
+        parser.ParseCLI(argc, argv);
+    } catch (args::Help) {
+        std::cout << parser;
+        return 0;
+    } catch (args::ParseError e) {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    if (argc==1) {
+        std::cout << parser;
+        return 1;
+    }
+
+    if (!dg_in_file) {
+        std::cerr << "[odgi cover] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        return 1;
+    }
+
+    if (!dg_out_file) {
+        std::cerr << "[odgi cover] error: Please specify an output file to where to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
+        return 1;
+    }
+
+    uint64_t _num_paths_per_component = args::get(num_paths_per_component) ? args::get(num_paths_per_component) : algorithms::PATH_COVER_DEFAULT_N;
+    uint64_t _node_window_size = args::get(node_window_size) ? args::get(node_window_size) : algorithms::PATH_COVER_DEFAULT_K;
+
+    if (_node_window_size < 2){
+        std::cerr << "[odgi cover] error: Please specify a node windows size greater than or equal to 2 -k=[N], --node-window-size=[N]." << std::endl;
+        return 1;
+    }
+
+    graph_t graph;
+    assert(argc > 0);
+    std::string infile = args::get(dg_in_file);
+    if (infile.size()) {
+        if (infile == "-") {
+            graph.deserialize(std::cin);
+        } else {
+            ifstream f(infile.c_str());
+            graph.deserialize(f);
+            f.close();
+        }
+    }
+
+    algorithms::path_cover(graph, _num_paths_per_component, _node_window_size, args::get(debug));
+    
+    std::string outfile = args::get(dg_out_file);
+    if (outfile.size()) {
+        if (outfile == "-") {
+            graph.serialize(std::cout);
+        } else {
+            ofstream f(outfile.c_str());
+            graph.serialize(f);
+            f.close();
+        }
+    }
+    return 0;
+}
+
+static Subcommand odgi_cover("cover", "find a path cover of the graph",
+                            PIPELINE, 3, main_cover);
+
+
+}

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -5,89 +5,123 @@
 
 namespace odgi {
 
-using namespace odgi::subcommand;
+    using namespace odgi::subcommand;
 
-int main_cover(int argc, char** argv) {
+    int main_cover(int argc, char **argv) {
 
-    // trick argumentparser to do the right thing with the subcommand
-    for (uint64_t i = 1; i < argc-1; ++i) {
-        argv[i] = argv[i+1];
-    }
-    std::string prog_name = "odgi cover";
-    argv[0] = (char*)prog_name.c_str();
-    --argc;
-    
-    args::ArgumentParser parser("find a path cover of the graph");
-    args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
-    args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
-    args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph with the generated paths in this file", {'o', "out"});
-    args::ValueFlag<uint64_t> num_paths_per_component(parser, "N", "number of paths to generate per component", {'n', "num-paths-per-component"});
-    args::ValueFlag<uint64_t> node_window_size(parser, "N", "size of the node window to check each time a new path is extended (it has to be greater than or equal to 2)", {'k', "node-window-size"});
-    args::Flag debug(parser, "debug", "Print information about the components and the progress to stdout", {'d', "debug"});
+        // trick argumentparser to do the right thing with the subcommand
+        for (uint64_t i = 1; i < argc - 1; ++i) {
+            argv[i] = argv[i + 1];
+        }
+        std::string prog_name = "odgi cover";
+        argv[0] = (char *) prog_name.c_str();
+        --argc;
 
-    try {
-        parser.ParseCLI(argc, argv);
-    } catch (args::Help) {
-        std::cout << parser;
+        args::ArgumentParser parser("find a path cover of the graph");
+        args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
+        args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
+        args::ValueFlag<std::string> dg_out_file(parser, "FILE",
+                                                 "store the graph with the generated paths in this file", {'o', "out"});
+        args::ValueFlag<uint64_t> num_paths_per_component(parser, "N", "number of paths to generate per component",
+                                                          {'n', "num-paths-per-component"});
+        args::ValueFlag<uint64_t> node_window_size(parser, "N",
+                                                   "size of the node window to check each time a new path is extended (it has to be greater than or equal to 2)",
+                                                   {'k', "node-window-size"});
+        args::ValueFlag<uint64_t> min_node_coverage(parser, "N",
+                                                    "minimum node coverage to reach (it has to be greater than 0)",
+                                                    {'c', "min-node-coverage"});
+        args::Flag debug(parser, "debug", "print information about the components and the progress to stdout",
+                         {'d', "debug"});
+
+        try {
+            parser.ParseCLI(argc, argv);
+        } catch (args::Help) {
+            std::cout << parser;
+            return 0;
+        } catch (args::ParseError e) {
+            std::cerr << e.what() << std::endl;
+            std::cerr << parser;
+            return 1;
+        }
+        if (argc == 1) {
+            std::cout << parser;
+            return 1;
+        }
+
+        if (!dg_in_file) {
+            std::cerr
+                    << "[odgi cover] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+                    << std::endl;
+            return 1;
+        }
+
+        if (!dg_out_file) {
+            std::cerr
+                    << "[odgi cover] error: please specify an output file to where to store the graph via -o=[FILE], --out=[FILE]."
+                    << std::endl;
+            return 1;
+        }
+
+        uint64_t _num_paths_per_component = args::get(num_paths_per_component);
+        uint64_t _min_node_coverage = args::get(min_node_coverage);
+        if (_num_paths_per_component && _min_node_coverage) {
+            std::cerr
+                    << "[odgi cover] error: please specify -n/--num-paths-per-component or -c/--min-node-coverage, not both."
+                    << std::endl;
+            return 1;
+        } else if (!_num_paths_per_component && !_min_node_coverage) {
+            _num_paths_per_component = algorithms::PATH_COVER_DEFAULT_N;
+        }
+
+        uint64_t _node_window_size = args::get(node_window_size) ? args::get(node_window_size)
+                                                                 : algorithms::PATH_COVER_DEFAULT_K;
+        if (_node_window_size < 2) {
+            std::cerr
+                    << "[odgi cover] error: please specify a node window size greater than or equal to 2 via -k=[N], --node-window-size=[N]."
+                    << std::endl;
+            return 1;
+        }
+
+        graph_t graph;
+        assert(argc > 0);
+        std::string infile = args::get(dg_in_file);
+        if (infile.size()) {
+            if (infile == "-") {
+                graph.deserialize(std::cin);
+            } else {
+                ifstream f(infile.c_str());
+                graph.deserialize(f);
+                f.close();
+            }
+        }
+
+        uint64_t max_number_of_paths_generable = graph.get_node_count();
+        if (_min_node_coverage) {
+            std::cerr << "There will be generated paths until the minimum node coverage is " << _min_node_coverage
+                      << ", or until the maximum number of allowed generated paths is reached ("
+                      << max_number_of_paths_generable << ")." << std::endl;
+        } else {
+            std::cerr << "There will be generated " << _num_paths_per_component << " paths per component." << std::endl;
+        }
+
+        algorithms::path_cover(graph, _num_paths_per_component, _node_window_size, _min_node_coverage,
+                               max_number_of_paths_generable, args::get(debug));
+
+        std::string outfile = args::get(dg_out_file);
+        if (outfile.size()) {
+            if (outfile == "-") {
+                graph.serialize(std::cout);
+            } else {
+                ofstream f(outfile.c_str());
+                graph.serialize(f);
+                f.close();
+            }
+        }
         return 0;
-    } catch (args::ParseError e) {
-        std::cerr << e.what() << std::endl;
-        std::cerr << parser;
-        return 1;
-    }
-    if (argc==1) {
-        std::cout << parser;
-        return 1;
     }
 
-    if (!dg_in_file) {
-        std::cerr << "[odgi cover] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
-        return 1;
-    }
-
-    if (!dg_out_file) {
-        std::cerr << "[odgi cover] error: Please specify an output file to where to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
-        return 1;
-    }
-
-    uint64_t _num_paths_per_component = args::get(num_paths_per_component) ? args::get(num_paths_per_component) : algorithms::PATH_COVER_DEFAULT_N;
-    uint64_t _node_window_size = args::get(node_window_size) ? args::get(node_window_size) : algorithms::PATH_COVER_DEFAULT_K;
-
-    if (_node_window_size < 2){
-        std::cerr << "[odgi cover] error: Please specify a node windows size greater than or equal to 2 -k=[N], --node-window-size=[N]." << std::endl;
-        return 1;
-    }
-
-    graph_t graph;
-    assert(argc > 0);
-    std::string infile = args::get(dg_in_file);
-    if (infile.size()) {
-        if (infile == "-") {
-            graph.deserialize(std::cin);
-        } else {
-            ifstream f(infile.c_str());
-            graph.deserialize(f);
-            f.close();
-        }
-    }
-
-    algorithms::path_cover(graph, _num_paths_per_component, _node_window_size, args::get(debug));
-    
-    std::string outfile = args::get(dg_out_file);
-    if (outfile.size()) {
-        if (outfile == "-") {
-            graph.serialize(std::cout);
-        } else {
-            ofstream f(outfile.c_str());
-            graph.serialize(f);
-            f.close();
-        }
-    }
-    return 0;
-}
-
-static Subcommand odgi_cover("cover", "find a path cover of the graph",
-                            PIPELINE, 3, main_cover);
+    static Subcommand odgi_cover("cover", "find a path cover of the graph",
+                                 PIPELINE, 3, main_cover);
 
 
 }

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -23,7 +23,7 @@ int main_cover(int argc, char** argv) {
     args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph with the generated paths in this file", {'o', "out"});
     args::ValueFlag<uint64_t> num_paths_per_component(parser, "N", "number of paths to generate per component", {'n', "num-paths-per-component"});
     args::ValueFlag<uint64_t> node_window_size(parser, "N", "size of the node window to check each time a new path is extended (it has to be greater than or equal to 2)", {'k', "node-window-size"});
-    args::Flag debug(parser, "debug", "print information about the components", {'d', "debug"});
+    args::Flag debug(parser, "debug", "Print information about the components and the progress to stdout", {'d', "debug"});
 
     try {
         parser.ParseCLI(argc, argv);


### PR DESCRIPTION
The implementation was taken, and slightly modified, from Jouni's code: [gbwtgraph](https://github.com/jltsiren/gbwtgraph). With this command, a specified number of paths can be generated for each graph component.
 
Here an example using a SARS-CoV-2 pangenome with 169 individuals, plus the gene annotations, which has 7 components. A visualization of the original graph is the following:
![allvsall](https://user-images.githubusercontent.com/62253982/89706730-9c47d180-d968-11ea-99f0-e079e33b5465.png)

I removed all the paths, and tried to generate new ones, specifying 10 paths per component (`-n` option), and displaying information about the components and the progress (`-d` option).

```
odgi build -g allvsall.no_paths.gfa -o - | odgi cover -i - -o allvsall.paths.odgi -n 10 -d && odgi viz -i allvsall.paths.odgi -o allvsall.paths.png -x 5000

SimpleCoverage: processing component 1 / 7, which has 1128 node(s) and it is cyclic.
Processed: 1
SimpleCoverage: processing component 2 / 7, which has 1 node(s) and it is acyclic.
Processed: 2
SimpleCoverage: processing component 3 / 7, which has 1 node(s) and it is acyclic.
Processed: 3
SimpleCoverage: processing component 4 / 7, which has 1 node(s) and it is acyclic.
Processed: 4
SimpleCoverage: processing component 5 / 7, which has 1 node(s) and it is acyclic.
Processed: 5
SimpleCoverage: processing component 6 / 7, which has 1 node(s) and it is acyclic.
Processed: 6
SimpleCoverage: processing component 7 / 7, which has 1 node(s) and it is acyclic.
Processed: 7
```
![allvsall paths](https://user-images.githubusercontent.com/62253982/89706809-56d7d400-d969-11ea-9763-d31f09280abe.png)

Here the same test, but sorting the graph without paths before the paths generation (`-s` option in odgi build):

`odgi build -g allvsall.no_paths.gfa -o - -s | odgi cover -i - -o allvsall.s.paths.odgi -n 10 && odgi viz -i allvsall.s.paths.odgi -o allvsall.s.paths.png -x 5000`

![allvsall s paths](https://user-images.githubusercontent.com/62253982/89706830-8a1a6300-d969-11ea-80ac-486b68525b37.png)

The problem is that, depending on the user input (`-n` option), several duplicated paths are generated for small components. For 1-node components, it would be enough to impose to generate just 1 path, but, in general, it should be checked efficiently the number of unique paths for verifying if the max number of unique paths is reached during the execution, avoiding to create duplicated ones, or tolerating a max percentage of duplication.