### PR TITLE
sampling the first node only by nodes is ready

### DIFF
--- a/docs/asciidocs/odgi_sort.adoc
+++ b/docs/asciidocs/odgi_sort.adoc
@@ -123,7 +123,7 @@ pipeline of sorts within one parameter.
   Apply path guided 1D linear SGD algorithm to organize the graph.
 
 *-J, --path-sgd-sample-from-paths*::
-  Instead of sampling the first node from all nodes we sample from all nucleotide positions of the paths. Default value is _FALSE_.
+  Instead of sampling the first node from all path steps we sample from all nucleotide positions of the paths. Default value is _FALSE_.
 
 *-I, --path-sgd-deterministic*::
   Run the path guided 1D linear SGD in deterministic mode. Will automatically set the number of threads to 1, multithreading is not supported in this mode. Default value is _FALSE_.

--- a/docs/asciidocs/odgi_sort.adoc
+++ b/docs/asciidocs/odgi_sort.adoc
@@ -123,7 +123,10 @@ pipeline of sorts within one parameter.
   Apply path guided 1D linear SGD algorithm to organize the graph.
 
 *-J, --path-sgd-sample-from-paths*::
-  Instead of sampling the first node from all path steps we sample from all nucleotide positions of the paths. Default value is _FALSE_.
+  Instead of sampling the first node from all nodes we sample from all nucleotide positions of the paths. Default value is _FALSE_.
+
+*-l, --path-sgd-sample-from-path-steps*::
+  Instead of sampling the first node from all nodes we sample from all path steps of the paths. Default value is _FALSE_.
 
 *-I, --path-sgd-deterministic*::
   Run the path guided 1D linear SGD in deterministic mode. Will automatically set the number of threads to 1, multithreading is not supported in this mode. Default value is _FALSE_.

--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -22,7 +22,8 @@ namespace odgi {
                                             const bool &progress,
                                             const bool &snapshot,
                                             std::vector<std::vector<double>> &snapshots,
-                                            const bool &sample_from_paths) {
+                                            const bool &sample_from_paths,
+                                            const bool &sample_from_nodes) {
 #ifdef debug_path_sgd
             std::cerr << "iter_max: " << iter_max << std::endl;
             std::cerr << "min_term_updates: " << min_term_updates << std::endl;
@@ -33,8 +34,9 @@ namespace odgi {
 #endif
 
             using namespace std::chrono_literals; // for timing stuff
+            uint64_t num_nodes = graph.get_node_count();
             // our positions in 1D
-            std::vector<std::atomic<double>> X(graph.get_node_count());
+            std::vector<std::atomic<double>> X(num_nodes);
             // seed them with the graph order
             uint64_t len = 0;
             graph.for_each_handle(
@@ -142,7 +144,18 @@ namespace odgi {
                         if (!sample_from_paths) {
                             dis = std::uniform_int_distribution<uint64_t>(0, path_index.get_np_bv().size() - 1);
                         }
+                        if (sample_from_nodes) {
+                            dis = std::uniform_int_distribution<uint64_t>(1, num_nodes);
+                        }
                         std::uniform_int_distribution<uint64_t> flip(0, 1);
+                        const sdsl::bit_vector& np_bv = path_index.get_np_bv();
+                        const sdsl::int_vector<>& nr_iv = path_index.get_nr_iv();
+                        const sdsl::int_vector<>& npi_iv = path_index.get_npi_iv();
+                        auto& np_bv_select = path_index.get_np_bv_select();
+                        uint64_t hit_num_paths = 0;
+                        step_handle_t s_h;
+                        uint64_t node_index;
+                        uint64_t next_node_index;
                         while (work_todo.load()) {
                             uint64_t pos = dis(gen);
                             size_t pos_in_path_a;
@@ -170,28 +183,66 @@ namespace odgi {
 
                                 // pick a random position from all nodes
                             } else {
-                                sdsl::bit_vector np_bv = path_index.get_np_bv();
-                                sdsl::int_vector<> nr_iv = path_index.get_nr_iv();
-                                sdsl::int_vector<> npi_iv = path_index.get_npi_iv();
-                                sdsl::rank_support_v<1> np_bv_rank = path_index.get_np_bv_rank();
-                                // did we hit a node and not a path?
-                                if (np_bv[pos] == 1) {
-                                    continue;
-                                } else {
-                                    path = as_path_handle(npi_iv[pos]);
-                                    step_handle_t s_h;
-                                    as_integers(s_h)[0] = npi_iv[pos]; // path handle
-                                    as_integers(s_h)[1] = nr_iv[pos] - 1; // maybe -1?! // step rank in path
-                                    pos_in_path_a = path_index.get_position_of_step(s_h);
-                                    path_len = path_index.get_path_length(path) - 1;
+                                if (sample_from_nodes) {
+                                    node_index = np_bv_select(pos);
+                                    // did we hit the last node?
+                                    if (pos == num_nodes) {
+                                        next_node_index = np_bv.size();
+                                    } else {
+                                        next_node_index = np_bv_select(pos + 1);
+                                    }
+                                    hit_num_paths = next_node_index - node_index - 1;
+                                    if (hit_num_paths == 0) {
+                                        continue;
+                                    }
+                                    std::uniform_int_distribution<uint64_t> dis_path(1, hit_num_paths);
+                                    uint64_t path_pos_in_np_iv = dis_path(gen);
 #ifdef debug_sample_from_nodes
-                                    std::cerr << "path_len: " << path_len << std::endl;
-                                    std::cerr << "path id: " << (npi_iv[pos]) << std::endl;
-                                    std::cerr << "step rank in path: " << (nr_iv[pos] - 1) << std::endl;
+                                    std::cerr << "path_pos_in_np_iv first: " << path_pos_in_np_iv << std::endl;
+                                    std::cerr << "node_index: " << node_index << std::endl;
+#endif
+                                    path_pos_in_np_iv = node_index + path_pos_in_np_iv;
+#ifdef debug_sample_from_nodes
+                                    std::cerr << "path pos in np_iv: " << path_pos_in_np_iv << std::endl;
+#endif
+                                    uint64_t path_i = npi_iv[path_pos_in_np_iv];
+                                    path = as_path_handle(path_i);
+#ifdef debug_sample_from_nodes
+                                    std::cerr << "path integer: " << path_i << std::endl;
+#endif
+                                    as_integers(s_h)[0] = path_i; // path index
+                                    as_integers(s_h)[1] = nr_iv[path_pos_in_np_iv] - 1; // step rank in path
+#ifdef debug_sample_from_nodes
+                                    std::cerr << "step rank in path: " << nr_iv[path_pos_in_np_iv]  << std::endl;
+#endif
+                                    pos_in_path_a = path_index.get_position_of_step(s_h);
+#ifdef debug_sample_from_nodes
                                     std::cerr << "pos_in_path_a: " << pos_in_path_a << std::endl;
 #endif
+                                    path_len = path_index.get_path_length(path) - 1;
+#ifdef debug_sample_from_nodes
+                                    std::cerr << "path_len " << path_len << std::endl;
+                                    std::cerr << "node count " << num_nodes << std::endl;
+#endif
+                                } else {
+                                    // did we hit a node and not a path?
+                                    if (np_bv[pos] == 1) {
+                                        continue;
+                                    } else {
+                                        uint64_t path_i = npi_iv[pos];
+                                        path = as_path_handle(path_i);
+                                        as_integers(s_h)[0] = path_i; // path index
+                                        as_integers(s_h)[1] = nr_iv[pos] - 1; // maybe -1?! // step rank in path
+                                        pos_in_path_a = path_index.get_position_of_step(s_h);
+                                        path_len = path_index.get_path_length(path) - 1;
+#ifdef debug_sample_from_nodes
+                                        std::cerr << "path_len: " << path_len << std::endl;
+                                        std::cerr << "path id: " << (npi_iv[pos]) << std::endl;
+                                        std::cerr << "step rank in path: " << (nr_iv[pos] - 1) << std::endl;
+                                        std::cerr << "pos_in_path_a: " << pos_in_path_a << std::endl;
+#endif
+                                    }
                                 }
-
                             }
                             uint64_t zipf_int = zipfian(gen);
 #ifdef debug_path_sgd
@@ -433,7 +484,8 @@ namespace odgi {
                                                           const bool &progress,
                                                           const bool &snapshot,
                                                           std::vector<std::vector<double>> &snapshots,
-                                                          const bool &sample_from_paths) {
+                                                          const bool &sample_from_paths,
+                                                          const bool &sample_from_nodes) {
             using namespace std::chrono_literals; // for timing stuff
             // our positions in 1D
             std::vector<std::atomic<double>> X(graph.get_node_count());
@@ -750,7 +802,8 @@ namespace odgi {
                                                     const bool &snapshot,
                                                     std::vector<std::vector<handle_t>> &snapshots,
                                                     const bool &sample_from_paths,
-                                                    const bool &path_sgd_deterministic) {
+                                                    const bool &path_sgd_deterministic,
+                                                    const bool &sample_from_nodes) {
             std::vector<double> layout;
             std::vector<std::vector<double>> snapshots_layouts;
             if (path_sgd_deterministic) {
@@ -769,7 +822,8 @@ namespace odgi {
                                                        progress,
                                                        snapshot,
                                                        snapshots_layouts,
-                                                       sample_from_paths);
+                                                       sample_from_paths,
+                                                       sample_from_nodes);
 
             } else {
                 layout = path_linear_sgd(graph,
@@ -787,7 +841,8 @@ namespace odgi {
                                          progress,
                                          snapshot,
                                          snapshots_layouts,
-                                         sample_from_paths);
+                                         sample_from_paths,
+                                         sample_from_nodes);
             }
             // TODO move the following into its own function that we can reuse
 #ifdef debug_components

--- a/src/algorithms/path_sgd.hpp
+++ b/src/algorithms/path_sgd.hpp
@@ -47,7 +47,7 @@ std::vector<double> path_linear_sgd(const PathHandleGraph &graph,
                                     const bool &snapshot,
                                     std::vector<std::vector<double>> &snapshots,
                                     const bool &sample_from_paths,
-                                    const bool &sample_from_nodes);
+                                    const bool &sample_from_path_steps);
 
 /// our learning schedule
 std::vector<double> path_linear_sgd_schedule(const double &w_min,
@@ -73,7 +73,7 @@ std::vector<double> deterministic_path_linear_sgd(const PathHandleGraph &graph,
                                                   const bool &snapshot,
                                                   std::vector<std::vector<double>> &snapshots,
                                                   const bool &sample_from_paths,
-                                                  const bool &sample_from_nodes);
+                                                  const bool &sample_from_path_steps);
 
 std::vector<handle_t> path_linear_sgd_order(const PathHandleGraph &graph,
                                             const xp::XP &path_index,
@@ -93,7 +93,7 @@ std::vector<handle_t> path_linear_sgd_order(const PathHandleGraph &graph,
                                             std::vector<std::vector<handle_t>> &snapshots,
                                             const bool &sample_from_paths,
                                             const bool &path_sgd_deterministic,
-                                            const bool &sample_from_nodes);
+                                            const bool &sample_from_path_steps);
 
 }
 

--- a/src/algorithms/path_sgd.hpp
+++ b/src/algorithms/path_sgd.hpp
@@ -46,7 +46,8 @@ std::vector<double> path_linear_sgd(const PathHandleGraph &graph,
                                     const bool &progress,
                                     const bool &snapshot,
                                     std::vector<std::vector<double>> &snapshots,
-                                    const bool &sample_from_paths);
+                                    const bool &sample_from_paths,
+                                    const bool &sample_from_nodes);
 
 /// our learning schedule
 std::vector<double> path_linear_sgd_schedule(const double &w_min,
@@ -71,7 +72,8 @@ std::vector<double> deterministic_path_linear_sgd(const PathHandleGraph &graph,
                                                   const bool &progress,
                                                   const bool &snapshot,
                                                   std::vector<std::vector<double>> &snapshots,
-                                                  const bool &sample_from_paths);
+                                                  const bool &sample_from_paths,
+                                                  const bool &sample_from_nodes);
 
 std::vector<handle_t> path_linear_sgd_order(const PathHandleGraph &graph,
                                             const xp::XP &path_index,
@@ -90,7 +92,8 @@ std::vector<handle_t> path_linear_sgd_order(const PathHandleGraph &graph,
                                             const bool &snapshot,
                                             std::vector<std::vector<handle_t>> &snapshots,
                                             const bool &sample_from_paths,
-                                            const bool &path_sgd_deterministic);
+                                            const bool &path_sgd_deterministic,
+                                            const bool &sample_from_nodes);
 
 }
 

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -61,8 +61,8 @@ int main_sort(int argc, char** argv) {
     args::Flag mondriaan_path_weight(parser, "path-weight", "weight mondriaan input matrix by path coverage of edges", {'W', "mondriaan-path-weight"});
     /// path guided linear 1D SGD
     args::Flag p_sgd(parser, "path-sgd", "apply path guided linear 1D SGD algorithm to organize graph", {'Y', "path-sgd"});
-    args::Flag p_sgd_sample_from_paths(parser, "path-sgd-sample-from-paths", "instead of sampling the first node from all path steps of the graph we sample from all nucleotide positions of the paths (default: flag not set)", {'J', "path-sgd-sample-from-paths"});
-    args::Flag p_sgd_sample_from_nodes(parser, "path-sgd-sample-from-nodes", "instead of sampling the first node from all path steps of the graph we sample from all nodes of the graph (default: flag not set)", {'l', "path-sgd-sample-from-nodes"});
+    args::Flag p_sgd_sample_from_paths(parser, "path-sgd-sample-from-paths", "instead of sampling the first node from all nodes of the graph we sample from all nucleotide positions of the paths (default: flag not set)", {'J', "path-sgd-sample-from-paths"});
+    args::Flag p_sgd_sample_from_path_steps(parser, "path-sgd-sample-from-path-steps", "instead of sampling the first node from all nodes of the graph we sample from all path steps of the graph (default: flag not set)", {'l', "path-sgd-sample-from-nodes"});
     args::Flag p_sgd_deterministic(parser, "path-sgd-deterministic", "run the path guided 1D linear SGD in deterministic mode, will automatically set the number of threads to 1, multithreading is not supported in this mode (default: flag not set)", {'I', "path-sgd-deterministic"});
     args::ValueFlag<std::string> p_sgd_in_file(parser, "FILE", "specify a line separated list of paths to sample from for the on the fly term generation process in the path guided linear 1D SGD (default: sample from all paths)", {'f', "path-sgd-use-paths"});
     args::ValueFlag<double> p_sgd_min_term_updates_paths(parser, "N", "minimum number of terms to be updated before a new path guided linear 1D SGD iteration with adjusted learning rate eta starts, expressed as a multiple of total path length (default: 0.1)", {'G', "path-sgd-min-term-updates-paths"});
@@ -191,11 +191,11 @@ int main_sort(int argc, char** argv) {
     const bool snapshot = p_sgd_snapshot;
     const bool sample_from_paths = args::get(p_sgd_sample_from_paths) ? args::get(p_sgd_sample_from_paths) : false;
     const bool path_sgd_deterministic = p_sgd_deterministic;
-    const bool path_sgd_sample_from_nodes = args::get(p_sgd_sample_from_nodes) ? args::get(p_sgd_sample_from_nodes) : false;
-    if (sample_from_paths && path_sgd_sample_from_nodes) {
+    const bool path_sgd_sample_from_path_steps = args::get(p_sgd_sample_from_path_steps) ? args::get(p_sgd_sample_from_path_steps) : false;
+    if (sample_from_paths && path_sgd_sample_from_path_steps) {
         std::cerr
-                << "[odgi sort] Error: There can only be one argument provided for the sampling of the first note in the path guided 1D SGD."
-                   "Please either use -J=, path-sgd-sample-from-paths or -l=, path-sgd-sample-from-nodes, or none of them to sample from all path steps."
+                << "[odgi sort] Error: There can only be one argument provided for the sampling of the first node in the path guided 1D SGD."
+                   "Please either use -J=, path-sgd-sample-from-paths or -l=, path-sgd-sample-from-path-steps, or none of them to sample from all nodes of the graph."
                 << std::endl;
         return 1;
     }
@@ -312,7 +312,7 @@ int main_sort(int argc, char** argv) {
                                                   snapshots,
                                                   sample_from_paths,
                                                   path_sgd_deterministic,
-                                                  path_sgd_sample_from_nodes);
+                                                  path_sgd_sample_from_path_steps);
             // TODO Check if we have to emit the snapshots
             if (snapshot) {
                 std::string snapshot_prefix = args::get(p_sgd_snapshot);
@@ -403,7 +403,7 @@ int main_sort(int argc, char** argv) {
                                                               snapshots,
                                                               sample_from_paths,
                                                               path_sgd_deterministic,
-                                                              path_sgd_sample_from_nodes);
+                                                              path_sgd_sample_from_path_steps);
                     break;
                 }
                 case 'f':


### PR DESCRIPTION
This PR brings in the code so that we sample the first node only from the nodes space in the graph.

In addition, it fixes a performance issue with the node_path_step sampling. Now we don't copy all the path index vectors anymore in each term update. @AndreaGuarracino please take a brief look and merge, if you are happy.