### PR TITLE
odgi viz binned mode, color by bin mean coverage, or by bin mean inversion rate

### DIFF
--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -68,7 +68,7 @@ sequence coverage in bins available.
 
 === Binned Mode Options
 
-*-b, --binned-mode*=_N_::
+*-b, --binned-mode*::
   The variation graph is binned before its visualization. Each pixel in the output image will correspond to a bin.
   For more information about the binning process, please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
 
@@ -83,8 +83,14 @@ sequence coverage in bins available.
   2. Class: The links helping to follow simple variations. Such links solely connecting a path from left to right may not
   be relevant to understand a path's traversal through the bins. Therefore, they are not drawn in the binned mode.
 
+*-c, --color-by-mean-coverage*::
+  Change the color (from black to blue) respect to the mean coverage of the path for each bin.
 
-=== Position Mode (also known as Gradient Mode) Options
+*-c, --color-by-mean-inversion*::
+  Change the color (from black to red) respect to the mean inversion rate of the path for each bin".
+
+
+=== Gradient Mode (also known as Position Mode) Options
 
 *-d, --change-darkness*::
   Change the color darkness based on nucleotide position in the path.  This parameter can be set in combination with [*-A, --alignment-prefix*=_STRING_].

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -138,9 +138,15 @@ namespace odgi {
             return 1;
         }
 
-        if (!args::get(binned_mode) && ((args::get(bin_width) > 0) || (args::get(drop_gap_links)))){
+        if (
+                !args::get(binned_mode) &&
+                ((args::get(bin_width) > 0) || args::get(drop_gap_links) ||
+                args::get(color_by_mean_coverage) || args::get(color_by_mean_inversion_rate))
+                ){
             std::cerr
-                    << "[odgi viz] error: Please specify the -b/--binned-mode option to use the -w/--bin_width and -g/--no-gap-links options."
+                    << "[odgi viz] error: Please specify the -b/--binned-mode option to use the "
+                       "-w/--bin_width, -g/--no-gap-links, -c/--color-by-mean-coverage, and -z/--color-by-mean-inversion "
+                       "options."
                     << std::endl;
             return 1;
         }
@@ -152,9 +158,11 @@ namespace odgi {
             return 1;
         }
 
-        if (args::get(show_strands) && args::get(white_to_black)) {
+        if (args::get(show_strands) + args::get(white_to_black) + args::get(color_by_mean_coverage)  + args::get(color_by_mean_inversion_rate) > 1) {
             std::cerr
-                    << "[odgi cover] error: please specify -S/--show-strand or -u/--white-to-black, not both."
+                    << "[odgi cover] error: please specify only one of the following options: "
+                       "-S/--show-strand, -u/--white-to-black, "
+                       "-c/--color-by-mean-coverage, and -z/--color-by-mean-inversion."
                     << std::endl;
             return 1;
         }

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -93,8 +93,8 @@ namespace odgi {
         args::Flag binned_mode(parser, "binned-mode", "bin the variation graph before its visualization", {'b', "binned-mode"});
         args::ValueFlag<uint64_t> bin_width(parser, "bp", "width of each bin in basepairs along the graph vector",{'w', "bin-width"});
         args::Flag drop_gap_links(parser, "drop-gap-links", "don't include gap links in the output", {'g', "no-gap-links"});
-        args::Flag color_by_mean_coverage(parser, "color-by-mean-coverage", "change the color intensity respect to the mean coverage of the path for each bin", {'c', "color-by-mean-coverage"});
-        args::Flag color_by_mean_inversion_rate(parser, "color-by-mean-inversion-rate", "change the color intensity respect to the mean inversion rate of the path for each bin", {'z', "color-by-mean-inversion"});
+        args::Flag color_by_mean_coverage(parser, "color-by-mean-coverage", "change the color respect to the mean coverage of the path for each bin", {'c', "color-by-mean-coverage"});
+        args::Flag color_by_mean_inversion_rate(parser, "color-by-mean-inversion-rate", "change the color respect to the mean inversion rate of the path for each bin", {'z', "color-by-mean-inversion"});
 
         /// Gradient mode
         args::Flag change_darkness(parser, "change-darkness", "change the color darkness based on nucleotide position in the path", {'d', "change-darkness"});

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -581,6 +581,8 @@ namespace odgi {
                         int64_t curr_bin = (p + k) / _bin_width + 1;
 
                         if (curr_bin != last_bin) {
+                            bin_ids.push_back(curr_bin);
+
 #ifdef debug_odgi_viz
                             std::cerr << "curr_bin: " << curr_bin << std::endl;
 #endif
@@ -602,7 +604,6 @@ namespace odgi {
                                 links.push_back(std::make_pair(last_bin, curr_bin));
                             }
                         }
-                        bin_ids.push_back(curr_bin);
 
                         last_bin = curr_bin;
                     }

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -332,9 +332,7 @@ namespace odgi {
                 for (uint64_t i = 0; i < hl; i += 1 / scale_x) {
                     add_point(p + i, 0, 0, 0, 0);
                 }
-            });
 
-            graph.for_each_handle([&](const handle_t& h) {
                 // add contacts for the edges
                 graph.follow_edges(h, false, [&](const handle_t& o) {
                     add_edge_from_handles(h, o);


### PR DESCRIPTION
**Yeast pangenome**
Color by the bin mean coverage:

`odgi viz -i Sc+Sp.pan.fpal10k.sYgs.odgi -o Sc+Sp.pan.fpal10k.sYgs.c.png -b -w 1000 -g -c`

![Sc+Sp.pan.fpal10k.sYgs.c](https://user-images.githubusercontent.com/62253982/90402915-745f1900-e0a0-11ea-8ab9-24e5000020bc.png)


Color by the bin mean inversion rate:

`odgi viz -i Sc+Sp.pan.fpal10k.sYgs.odgi -o Sc+Sp.pan.fpal10k.sYgs.z.png -b -w 1000 -g -z`

![Sc+Sp.pan.fpal10k.sYgs.z](https://user-images.githubusercontent.com/62253982/90402930-79bc6380-e0a0-11ea-8ee4-459e6b275eb1.png)
