### PR TITLE
Remove redundant 0 initialization

### DIFF
--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -443,8 +443,8 @@ private:
     
     struct path_metadata_t {
         uint64_t length = 0;
-        step_handle_t first = {0, 0};
-        step_handle_t last = {0, 0};
+        step_handle_t first ;
+        step_handle_t last ;
         std::string name;
         bool is_circular = false;
     };


### PR DESCRIPTION
This is a work around for issue #158, it seems that the initialized value here doesn't effect functionality, but will cause compile time errors with compilers < GCC7, so it is probably best to just let the comelier give us values here.