### PR TITLE
better zeta zipfian values quantization

### DIFF
--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -110,12 +110,14 @@ namespace odgi {
 #pragma omp parallel for schedule(static,1)
             for (uint64_t i = 1; i < space+1; ++i) {
                 uint64_t quantized_i = i;
+                uint64_t compressed_space = i;
                 if (i > space_max){
                     quantized_i = space_max + (i - space_max) / space_quantization_step + 1;
+                    compressed_space = space_max + ((i - space_max) / space_quantization_step) * space_quantization_step;
                 }
 
                 if (quantized_i != last_quantized_i){
-                    dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, quantized_i, theta);
+                    dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, compressed_space, theta);
                     zetas[quantized_i] = z_p.zeta();
 
                     last_quantized_i = quantized_i;

--- a/src/algorithms/path_sgd_layout.cpp
+++ b/src/algorithms/path_sgd_layout.cpp
@@ -64,12 +64,14 @@ namespace odgi {
 #pragma omp parallel for schedule(static,1)
             for (uint64_t i = 1; i < space+1; ++i) {
                 uint64_t quantized_i = i;
+                uint64_t compressed_space = i;
                 if (i > space_max){
                     quantized_i = space_max + (i - space_max) / space_quantization_step + 1;
+                    compressed_space = space_max + ((i - space_max) / space_quantization_step) * space_quantization_step;
                 }
 
                 if (quantized_i != last_quantized_i){
-                    dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, quantized_i, theta);
+                    dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, compressed_space, theta);
                     zetas[quantized_i] = z_p.zeta();
 
                     last_quantized_i = quantized_i;

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -66,9 +66,9 @@ int main_layout(int argc, char **argv) {
                                                                 "iteration where the learning rate is max for path guided linear 1D SGD model (default: 0)",
                                                                 {'F', "iteration-max-learning-rate"});
     args::ValueFlag<uint64_t> p_sgd_zipf_space(parser, "N",
-                                               "the maximum space size of the Zipfian distribution which is used as the sampling method for the second node of one term in the path guided linear 1D SGD model (default: max path lengths)",
+                                               "the maximum space size of the Zipfian distribution which is used as the sampling method for the second node of one term in the path guided linear 1D SGD model (default: min(max path lengths, 10000)))",
                                                {'k', "path-sgd-zipf-space"});
-    args::ValueFlag<uint64_t> p_sgd_zipf_space_max(parser, "N", "the maximum space size of the Zipfian distribution beyond which quantization occurs (default: 1000000)", {'I', "path-sgd-zipf-space-max"});
+    args::ValueFlag<uint64_t> p_sgd_zipf_space_max(parser, "N", "the maximum space size of the Zipfian distribution beyond which quantization occurs (default: 1000)", {'I', "path-sgd-zipf-space-max"});
     args::ValueFlag<uint64_t> p_sgd_zipf_space_quantization_step(parser, "N", "quantization step when the maximum space size of the Zipfian distribution is exceeded (default: 100)", {'l', "path-sgd-zipf-space-quantization-step"});
 
     args::ValueFlag<std::string> p_sgd_seed(parser, "STRING",
@@ -239,7 +239,7 @@ int main_layout(int argc, char **argv) {
         }
     }
     uint64_t max_path_step_count = get_max_path_step_count(path_sgd_use_paths, path_index);
-    path_sgd_zipf_space = args::get(p_sgd_zipf_space) ? args::get(p_sgd_zipf_space) : std::min((uint64_t)1000000, max_path_step_count);
+    path_sgd_zipf_space = args::get(p_sgd_zipf_space) ? std::min(args::get(p_sgd_zipf_space), max_path_step_count) : std::min((uint64_t)10000, max_path_step_count);
     double path_sgd_max_eta = args::get(p_sgd_eta_max) ? args::get(p_sgd_eta_max) : max_path_step_count * max_path_step_count;
 
     path_sgd_zipf_space_max = args::get(p_sgd_zipf_space_max) ? std::min(path_sgd_zipf_space, args::get(p_sgd_zipf_space_max)) : 1000;

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -70,8 +70,8 @@ int main_sort(int argc, char** argv) {
     args::ValueFlag<double> p_sgd_zipf_theta(parser, "N", "the theta value for the Zipfian distribution which is used as the sampling method for the second node of one term in the path guided linear 1D SGD model (default: 0.99)", {'a', "path-sgd-zipf-theta"});
     args::ValueFlag<uint64_t> p_sgd_iter_max(parser, "N", "max number of iterations for path guided linear 1D SGD model (default: 30)", {'x', "path-sgd-iter-max"});
     args::ValueFlag<uint64_t> p_sgd_iter_with_max_learning_rate(parser, "N", "iteration where the learning rate is max for path guided linear 1D SGD model (default: 0)", {'F', "iteration-max-learning-rate"});
-    args::ValueFlag<uint64_t> p_sgd_zipf_space(parser, "N", "the maximum space size of the Zipfian distribution which is used as the sampling method for the second node of one term in the path guided linear 1D SGD model (default: min(max path lengths, 1000))", {'k', "path-sgd-zipf-space"});
-    args::ValueFlag<uint64_t> p_sgd_zipf_space_max(parser, "N", "the maximum space size of the Zipfian distribution beyond which quantization occurs (default: 1000000)", {'I', "path-sgd-zipf-space-max"});
+    args::ValueFlag<uint64_t> p_sgd_zipf_space(parser, "N", "the maximum space size of the Zipfian distribution which is used as the sampling method for the second node of one term in the path guided linear 1D SGD model (default: min(max path lengths, 10000))", {'k', "path-sgd-zipf-space"});
+    args::ValueFlag<uint64_t> p_sgd_zipf_space_max(parser, "N", "the maximum space size of the Zipfian distribution beyond which quantization occurs (default: 1000)", {'I', "path-sgd-zipf-space-max"});
     args::ValueFlag<uint64_t> p_sgd_zipf_space_quantization_step(parser, "N", "quantization step when the maximum space size of the Zipfian distribution is exceeded (default: 100)", {'l', "path-sgd-zipf-space-quantization-step"});
     args::ValueFlag<std::string> p_sgd_seed(parser, "STRING", "set the base seed for the 1-threaded path guided linear 1D SGD model (default: pangenomic!)", {'q', "path-sgd-seed"});
     args::ValueFlag<std::string> p_sgd_snapshot(parser, "STRING", "set the prefix to which each snapshot graph of a path guided 1D SGD iteration should be written to, no default", {'u', "path-sgd-snapshot"});
@@ -241,10 +241,9 @@ int main_sort(int argc, char** argv) {
             }
         }
         uint64_t max_path_step_count = get_max_path_step_count(path_sgd_use_paths, path_index);
-        path_sgd_zipf_space = args::get(p_sgd_zipf_space) ? args::get(p_sgd_zipf_space) : std::min((uint64_t)1000000, max_path_step_count);
+        path_sgd_zipf_space = args::get(p_sgd_zipf_space) ? std::min(args::get(p_sgd_zipf_space), max_path_step_count) : std::min((uint64_t)10000, max_path_step_count);
         path_sgd_max_eta = args::get(p_sgd_eta_max) ? args::get(p_sgd_eta_max) : max_path_step_count * max_path_step_count;
-
-        path_sgd_zipf_space_max = args::get(p_sgd_zipf_space_max) ? std::min(path_sgd_zipf_space, args::get(p_sgd_zipf_space_max)) : 1000;
+        path_sgd_zipf_space_max = args::get(p_sgd_zipf_space_max) ? args::get(p_sgd_zipf_space_max) : 1000;
         path_sgd_zipf_space_quantization_step = args::get(p_sgd_zipf_space_quantization_step) ? std::max((uint64_t)2, args::get(p_sgd_zipf_space_quantization_step)) : 100;
     }
 


### PR DESCRIPTION
In this implementation, the zipfian values' space is less compressed during the quantization. With less zetas values we have slightly better results (lower metrics in node space and nucleotide space).

`odgi sort -i Sc+Sp.pan.fpal10k.og -o master.og -P -Y -t 16`

```
[path sgd sort]: calculating linear SGD schedule (6.41478e-12 1 30 0 0.01)
[path sgd sort]: calculating zetas for 4939 zipf distributions
[path sgd sort]: running SGD
...
```

`branch/odgi sort -i Sc+Sp.pan.fpal10k.og -o master.og -P -Y -t 16`

```
[path sgd sort]: calculating linear SGD schedule (6.41478e-12 1 30 0 0.01)
[path sgd sort]: calculating zetas for 1091 zipf distributions
[path sgd sort]: running SGD
...
```

**mean_links_length**
| who|path|	in_node_space|	in_nucleotide_space|	num_links_considered|	num_gap_links_ignored|
|-----------|---------------|---------------------|-----------|----------|------|
| master	|all_paths	|141.267	|615.078 | 34132187 | 5092502|
| branch	|all_paths|107.602 | 473.938 | 34132187 | 5323854|

**sum_of_path_node_distances**
|who| path	|in_node_space|	nodes|	in_nucleotide_space|	nucleotides|	num_penalties|
|-----------|---------------|---------------------|-----------|----------|--------|----------|
| master	|all_paths	|306.262 | 318.229 | 34132379 | 143169270 | 14817252 | 148225|
| branch	|all_paths|235.584 | 247.808 | 34132379 | 143169270 | 15750931 | 148225|
