### PR TITLE
odgi cover - nodes coverage initialization

### DIFF
--- a/docs/asciidocs/odgi_cover.adoc
+++ b/docs/asciidocs/odgi_cover.adoc
@@ -44,6 +44,9 @@ The odgi cover(1) command find a path cover of a variation graph, with a specifi
 *-c, --min-node-coverage*=_N_::
   Minimum node coverage to reach (it has to be greater than 0). There will be generated paths until the specified minimum node coverage is reached, or until the maximum number of allowed generated paths is reached (number of nodes in the input variation graph).
 
+*-i, --ignore-paths*::
+  Ignore the paths already embedded in the graph during the nodes coverage initialization.
+
 *-w, --write-node-coverages*=_FILE_::
   Write the node coverages at the end of the paths generation to FILE. The file will contain tab-separated values (header included), and have 3 columns: _component_id_, _node_id_, and _coverage_.
 

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -296,7 +296,10 @@ namespace odgi {
 #endif
 
                 if (node_coverage.front().second >= min_node_coverage) {
-                    std::cerr << "Minimum node coverage reached after generating " << i << " paths." << std::endl;
+                    if (show_progress) {
+                        std::cerr << "Minimum node coverage reached after generating " << i << " paths." << std::endl;
+                    }
+
                     break;
                 }
 

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -142,7 +142,7 @@ namespace odgi {
             typedef std::pair<nid_t, coverage_t> node_coverage_t;
 
             static std::vector<node_coverage_t>
-            init_node_coverage(const graph_t &graph, const ska::flat_hash_set<handlegraph::nid_t> &component) {
+            init_node_coverage(const MutablePathDeletableHandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component) {
                 std::vector<node_coverage_t> node_coverage;
                 node_coverage.reserve(component.size());
                 for (nid_t id : component) {
@@ -150,8 +150,13 @@ namespace odgi {
                     // For example, some nodes of the original graph may be missing from a GBWTGraph.
                     if (!(graph.has_node(id))) { continue; }
 
-                    // TODO: if the graph already have paths, init with the current already present
-                    node_coverage.emplace_back(id, static_cast<coverage_t>(0));
+                    uint64_t coverage = 0;
+                    graph.for_each_step_on_handle(graph.get_handle(id), [&](const step_handle_t& step) {
+                        coverage++;
+                    });
+
+                    node_coverage.emplace_back(id, static_cast<coverage_t>(coverage));
+
                 }
                 return node_coverage;
             }

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -6,7 +6,7 @@ namespace odgi {
     namespace algorithms {
 
         ska::flat_hash_set<handlegraph::nid_t>
-        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component) {
+        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component, const bool& ignore_paths) {
             ska::flat_hash_set<handlegraph::nid_t> head_nodes;
             if (component.empty()) { return head_nodes; }
 
@@ -142,7 +142,7 @@ namespace odgi {
             typedef std::pair<nid_t, coverage_t> node_coverage_t;
 
             static std::vector<node_coverage_t>
-            init_node_coverage(const MutablePathDeletableHandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component) {
+            init_node_coverage(const MutablePathDeletableHandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component, const bool& ignore_paths) {
                 std::vector<node_coverage_t> node_coverage;
                 node_coverage.reserve(component.size());
                 for (nid_t id : component) {
@@ -151,9 +151,11 @@ namespace odgi {
                     if (!(graph.has_node(id))) { continue; }
 
                     uint64_t coverage = 0;
-                    graph.for_each_step_on_handle(graph.get_handle(id), [&](const step_handle_t& step) {
-                        coverage++;
-                    });
+                    if (!ignore_paths){
+                        graph.for_each_step_on_handle(graph.get_handle(id), [&](const step_handle_t& step) {
+                            coverage++;
+                        });
+                    }
 
                     node_coverage.emplace_back(id, static_cast<coverage_t>(coverage));
 
@@ -243,13 +245,13 @@ namespace odgi {
                              size_t num_paths_per_component, size_t node_window_size,
                              size_t min_node_coverage, size_t max_number_of_paths_generable,
                              bool write_node_covearges, std::string &node_coverages,
-                             const uint64_t& nthreads, const bool& show_progress) {
+                             const uint64_t& nthreads, const bool& ignore_paths, const bool& show_progress) {
             typedef typename Coverage::coverage_t coverage_t;
             typedef typename Coverage::node_coverage_t node_coverage_t;
 
             ska::flat_hash_set<handlegraph::nid_t> &component = components[component_id];
             size_t component_size = component.size();
-            ska::flat_hash_set<handlegraph::nid_t> head_nodes = is_nice_and_acyclic(graph, component);
+            ska::flat_hash_set<handlegraph::nid_t> head_nodes = is_nice_and_acyclic(graph, component, ignore_paths);
             bool acyclic = !(head_nodes.empty());
             if (show_progress) {
                 std::cerr << Coverage::name() << ": processing component " << (component_id + 1) << " / "
@@ -258,8 +260,9 @@ namespace odgi {
             }
 
             // Node coverage for the potential starting nodes.
-            std::vector<node_coverage_t> node_coverage = Coverage::init_node_coverage(graph, (acyclic ? head_nodes
-                                                                                                      : component));
+            std::vector<node_coverage_t> node_coverage = Coverage::init_node_coverage(
+                    graph, (acyclic ? head_nodes : component), ignore_paths
+                    );
             std::map<std::vector<handle_t>, coverage_t> path_coverage; // Path and its reverse complement are equivalent.
 
             // Node coverage will be empty if we cannot create this type of path cover for the component.
@@ -360,7 +363,7 @@ namespace odgi {
                         size_t num_paths_per_component, size_t node_window_size,
                         size_t min_node_coverage, size_t max_number_of_paths_generable,
                         bool write_node_coverages, std::string &node_coverages,
-                        const uint64_t& nthreads, const bool& show_progress) {
+                        const uint64_t& nthreads, const bool& ignore_paths, const bool& show_progress) {
             std::vector<ska::flat_hash_set<handlegraph::nid_t>> weak_components = algorithms::weakly_connected_components(
                     &graph);
 
@@ -371,7 +374,7 @@ namespace odgi {
                                                          num_paths_per_component, node_window_size,
                                                          min_node_coverage, max_number_of_paths_generable,
                                                          write_node_coverages, node_coverages,
-                                                         nthreads, show_progress)) {
+                                                         nthreads, ignore_paths, show_progress)) {
                     processed_components++;
 
                     if (show_progress) {

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -27,7 +27,7 @@ namespace odgi {
           Ignores node ids that are not present in the graph.
         */
         ska::flat_hash_set<handlegraph::nid_t>
-        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component);
+        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component, const bool& ignore_paths);
 
         /*
           Find a path cover of the graph with num_paths_per_component paths per component, adding the generated paths in
@@ -56,6 +56,6 @@ namespace odgi {
                         size_t num_paths_per_component, size_t node_window_size,
                         size_t min_node_coverage, size_t max_number_of_paths_generable,
                         bool write_node_coverages, std::string &node_coverages,
-                        const uint64_t& nthreads, const bool& show_progress);
+                        const uint64_t& nthreads, const bool& ignore_paths, const bool& show_progress);
     }
 }

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -91,13 +91,15 @@ namespace odgi {
         }
 
         uint64_t max_number_of_paths_generable = graph.get_node_count() * 5;
-        if (_min_node_coverage) {
-            std::cerr << "There will be generated paths until the minimum node coverage is " << _min_node_coverage
-                      << ", or until the maximum number of allowed generated paths is reached ("
-                      << max_number_of_paths_generable << ")." << std::endl;
-        } else {
-            std::cerr << "There will be generated " << _num_paths_per_component << " paths per component."
-                      << std::endl;
+        if (args::get(debug)){
+            if (_min_node_coverage) {
+                std::cerr << "There will be generated paths until the minimum node coverage is " << _min_node_coverage
+                          << ", or until the maximum number of allowed generated paths is reached ("
+                          << max_number_of_paths_generable << ")." << std::endl;
+            } else {
+                std::cerr << "There will be generated " << _num_paths_per_component << " paths per component."
+                          << std::endl;
+            }
         }
 
         uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -24,6 +24,7 @@ namespace odgi {
         args::ValueFlag<uint64_t> num_paths_per_component(parser, "N", "number of paths to generate per component",{'n', "num-paths-per-component"});
         args::ValueFlag<uint64_t> node_window_size(parser, "N","size of the node window to check each time a new path is extended (it has to be greater than or equal to 2)",{'k', "node-window-size"});
         args::ValueFlag<uint64_t> min_node_coverage(parser, "N","minimum node coverage to reach (it has to be greater than 0)",{'c', "min-node-coverage"});
+        args::Flag ignore_paths(parser, "ignore-paths", "ignore the paths already embedded in the graph during the nodes coverage initialization",{'I', "ignore-paths"});
         args::ValueFlag<std::string> write_node_coverages(parser, "FILE","write the node coverages at the end of the paths generation in this file",{'w', "write-node-coverages"});
         args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use for the parallel sorter", {'t', "threads"});
         args::Flag debug(parser, "debug", "print information about the components and the progress to stderr",{'d', "debug"});
@@ -108,7 +109,7 @@ namespace odgi {
         algorithms::path_cover(graph, _num_paths_per_component, _node_window_size, _min_node_coverage,
                                max_number_of_paths_generable,
                                write_node_coverages, node_coverages,
-                               num_threads, args::get(debug));
+                               num_threads, args::get(ignore_paths), args::get(debug));
 
         if (write_node_coverages) {
             std::string covfile = args::get(write_node_coverages);


### PR DESCRIPTION
With this update, odgi cover initializes the nodes coverage considering the paths already embedded in the graph. Such paths can also be ignored during this initialization.