### PR TITLE
odgi bin and odgi viz in binned mode a bit more verbose

### DIFF
--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -61,6 +61,7 @@ namespace odgi {
             graph_seq.clear(); // clean up
             std::unordered_map<path_handle_t, uint64_t> path_length;
             uint64_t gap_links_removed = 0;
+            uint64_t total_links = 0;
             graph.for_each_path_handle([&](const path_handle_t &path) {
                 std::vector<std::pair<uint64_t, uint64_t>> links;
                 std::map<uint64_t, path_info_t> bins;
@@ -135,6 +136,7 @@ namespace odgi {
                         bin_ids.push_back(entry.first);
                     }
                     std::sort(bin_ids.begin(), bin_ids.end());
+                    total_links += links.size();
 
                     uint64_t fill_pos = 0;
 
@@ -164,7 +166,11 @@ namespace odgi {
             });
 
             if (drop_gap_links) {
-                std::cerr << "Gap links removed: " << gap_links_removed << std::endl;
+                uint64_t path_count = graph.get_path_count();
+
+                std::cerr << "Gap links removed: " << gap_links_removed << " (" << path_count << " path start links + "
+                          << path_count << " path end links + " << (gap_links_removed - path_count * 2) << " inner gap links) of "
+                          << total_links << " total links" << std::endl;
             }
         }
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -677,7 +677,9 @@ namespace odgi {
         });
 
         if (args::get(drop_gap_links)) {
-            std::cerr << "Gap links removed: " << gap_links_removed << " of " << total_links << " total links" << std::endl;
+            std::cerr << "Gap links removed: " << gap_links_removed << " (" << path_count << " path start links + "
+            << path_count << " path end links + " << (gap_links_removed - path_count * 2) << " inner gap links) of "
+            << total_links << " total links" << std::endl;
         }
 
         // trim vertical space to fit


### PR DESCRIPTION
The output specifies the total number of links, making explicit how many gap links are path start/end links and how many inner gap links. Useful when working/testing in binned space with odgi sort/cover/bin/viz.

`odgi viz -i DRB1-3123.edyeet.s500n20p75a75.Y.G10.og -o DRB1-3123.edyeet.s500n20p75a75.Y.G10.png -bg -w 100`
> [...]
> Gap links removed: 147 (12 path start links + 12 path end links + 123 inner gap links) of 778 total links

`odgi bin -i DRB1-3123.edyeet.s500n20p75a75.Y.G10.og -g -w 100`
> [...]
> Gap links removed: 147 (12 path start links + 12 path end links + 123 inner gap links) of 778 total links

