### PR TITLE
odgi viz gradient mode fix orientation

### DIFF
--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -58,10 +58,12 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
   Show thin links of this relative width to connect path pieces.
 
 *-A, --alignment-prefix*=_STRING_::
-  Apply alignment related visual motifs to paths which have this name prefix. It affects the -S and -d options."
+  Apply alignment related visual motifs to paths which have this name prefix. It affects the [*-S, --show-strand*] and
+  [*-d, --change-darkness*] options.
 
 *-S, --show-strand*::
-  Use red and blue coloring to display forward and reverse alignments. This parameter can be set in combination with [*-A, --alignment-prefix*=_STRING_].
+  Use red and blue coloring to display forward and reverse alignments. This parameter can be set in combination with
+  [*-A, --alignment-prefix*=_STRING_].
 
 
 === Binned Mode Options
@@ -82,10 +84,12 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
   be relevant to understand a path's traversal through the bins. Therefore, they are not drawn in the binned mode.
 
 *-m, --color-by-mean-coverage*::
-  Change the color respect to the mean coverage of the path for each bin, from black (no coverage) to blue (max bin mean coverage in the entire graph).
+  Change the color respect to the mean coverage of the path for each bin, from black (no coverage) to blue (max bin mean
+  coverage in the entire graph).
 
 *-z, --color-by-mean-inversion-rate*::
-  Change the color respect to the mean inversion rate of the path for each bin, from black (no inversions) to red (bin mean inversion rate equals to 1).
+  Change the color respect to the mean inversion rate of the path for each bin, from black (no inversions) to red (bin
+  mean inversion rate equals to 1).
 
 
 === Gradient Mode (also known as Position Mode) Options
@@ -93,7 +97,8 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
 *-d, --change-darkness*::
   Change the color darkness based on nucleotide position in the path. When it is used in binned mode, the mean inversion
   rate of the bin node is considered to set the color gradient starting position: when this rate is greater than 0.5, the
-  bin is considered inverted, and the color gradient starts from the right-end of the bin. This parameter can be set in combination with [*-A, --alignment-prefix*=_STRING_].
+  bin is considered inverted, and the color gradient starts from the right-end of the bin. This parameter can be set in
+  combination with [*-A, --alignment-prefix*=_STRING_].
 
 *-l, --longest-path*::
   Use the longest path length to change the color darkness.

--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -23,10 +23,8 @@ odgi_viz - variation graph visualizations
 
 The odgi viz(1) command can produce a linear, static visualization of an odgi variation graph. It can aggregate the pangenome into bins
 and directly renders a raster image. The binning level can be specified in input or it is calculated from the target width of the PNG to emit.
-Can be used to produce visualizations for gigabase scale pangenomes. For more information  about the binning process,
-please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>. If reverse coloring was selected, only
-the bins with a reverse rate of at least 0.5 are colored. Currently, there is no parameter to color according to the
-sequence coverage in bins available.
+Can be used to produce visualizations for gigabase scale pangenomes. For more information about the binning process,
+please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
 
 == OPTIONS
 

--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -93,7 +93,9 @@ sequence coverage in bins available.
 === Gradient Mode (also known as Position Mode) Options
 
 *-d, --change-darkness*::
-  Change the color darkness based on nucleotide position in the path.  This parameter can be set in combination with [*-A, --alignment-prefix*=_STRING_].
+  Change the color darkness based on nucleotide position in the path. When it is used in binned mode, the mean inversion
+  rate of the bin node is considered to set the color gradient starting position: when this rate is greater than 0.5, the
+  bin is considered inverted, and the color gradient starts from the right-end of the bin. This parameter can be set in combination with [*-A, --alignment-prefix*=_STRING_].
 
 *-l, --longest-path*::
   Use the longest path length to change the color darkness.

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -434,7 +434,7 @@ namespace odgi {
                 if (
                         _show_strands ||
                         (_change_darkness && !_longest_path) ||
-                        (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate))
+                        (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate || _change_darkness))
                         ) {
                     handle_t h;
                     uint64_t hl, p;
@@ -454,7 +454,7 @@ namespace odgi {
                             path_len_to_use += hl;
                         }
 
-                        if (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate)){
+                        if (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate || _change_darkness)){
                             p = position_map[number_bool_packing::unpack_number(h)];
                             for (uint64_t k = 0; k < hl; ++k) {
                                 int64_t curr_bin = (p + k) / _bin_width + 1;
@@ -467,7 +467,7 @@ namespace odgi {
                         }
                     });
 
-                    if (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate)) {
+                    if (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate || _change_darkness)) {
                         for (auto &entry : bins) {
                             auto &v = entry.second;
                             v.mean_inv /= (v.mean_cov ? v.mean_cov : 1);
@@ -514,7 +514,7 @@ namespace odgi {
             }
 
             if (!(
-                    is_aln && (( _change_darkness && _white_to_black) || (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate)))
+                    is_aln && (( _change_darkness && _white_to_black) || (_binned_mode && (_color_by_mean_coverage || _color_by_mean_inversion_rate || _change_darkness)))
                     )) {
                 // brighten the color
                 float f = std::min(1.5, 1.0 / std::max(std::max(path_r_f, path_g_f), path_b_f));
@@ -556,7 +556,8 @@ namespace odgi {
 
                             if (is_aln) {
                                 if (_change_darkness){
-                                    x = 1 - ( (float)(curr_len + k) / (float)(path_len_to_use)) * 0.9;
+                                    uint64_t ii = bins[curr_bin].mean_inv > 0.5 ? (hl - k) : k;
+                                    x = 1 - ( (float)(curr_len + ii) / (float)(path_len_to_use)) * 0.9;
                                 } else if (_color_by_mean_coverage) {
                                     x = bins[curr_bin].mean_cov / max_mean_cov;
                                 } else if (_color_by_mean_inversion_rate) {

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -109,6 +109,14 @@ namespace odgi {
             return 1;
         }
 
+        if (args::get(change_darkness) && (args::get(color_by_mean_coverage) || args::get(color_by_mean_inversion_rate))) {
+            std::cerr
+                    << "[odgi viz] error: Please specify the -d/--change-darkness option without specifying "
+                       "-m/--color-by-mean-coverage or -z/--color-by-mean-inversion."
+                    << std::endl;
+            return 1;
+        }
+
         graph_t graph;
         assert(argc > 0);
         std::string infile = args::get(dg_in_file);

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -636,7 +636,8 @@ namespace odgi {
                     uint64_t path_y = path_layout_y[path_rank];
                     for (uint64_t i = 0; i < hl; i+=1/scale_x) {
                         if (is_aln && _change_darkness){
-                            x = 1 - ((float)(curr_len + i*scale_x) / (float)(path_len_to_use))*0.9;
+                            uint64_t ii = graph.get_is_reverse(h) ? (hl - i) : i;
+                            x = 1 - ((float)(curr_len + ii*scale_x) / (float)(path_len_to_use))*0.9;
                         }
                         add_path_step(p+i, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
                     }


### PR DESCRIPTION
This PR fixes a missing management of nodes/bins orientation/inversion_ration for the gradient starting position.

With this very small example
```
H	VN:Z:1.0
S	1	CAAATAAGAACCTTAA	DP:i:20	RC:i:320
S	2	AAA	DP:i:15	RC:i:45
S	3	GAA	DP:i:15	RC:i:45
S	4	TAACA	DP:i:15	RC:i:75
S	5	CCCG	DP:i:15	RC:i:60
S	6	TTG	DP:i:15	RC:i:45
S	7	GAA	DP:i:15	RC:i:45
S	8	TAACA	DP:i:15	RC:i:75
S	9	CCCG	DP:i:15	RC:i:60
S	10	TTG	DP:i:15	RC:i:45
S	11	GAA	DP:i:15	RC:i:45
S	12	TAACA	DP:i:15	RC:i:75
S	13	GAATTAA	DP:i:20	RC:i:140
P	A	1+,8+,9+,10+,11+,12+,13+,7-,6-,5-,4-,3-,2-	*
P	B	1-	*
P	C	1+	*
```

I obtain (the fixed images are on the right):

**Default mode**

`odgi build -g xxx.gfa -o - | .../master/odgi viz -i - -o xxx.du.png -du`
`odgi build -g xxx.gfa -o - | .../branch/odgi viz -i - -o xxx.du.branch.png -du`

![image](https://user-images.githubusercontent.com/62253982/94177308-9d41ad80-fe99-11ea-8a47-ed214e6cc259.png)

Note that in the example there are no node links.

**Binned mode**

`odgi build -g xxx.gfa -o - | .../branch/odgi viz -i - -o xxx.bdu.png -bdu`
`odgi build -g xxx.gfa -o - | .../branch/odgi viz -i - -o xxx.bdu.branch.png -bdu`

![image](https://user-images.githubusercontent.com/62253982/94177354-af235080-fe99-11ea-9765-97b964727488.png)

Note that the bin links are visualized.