### PR TITLE
progress in all the most-standard parts of the sorting pipeline

### DIFF
--- a/src/algorithms/chop.cpp
+++ b/src/algorithms/chop.cpp
@@ -29,7 +29,7 @@ void chop(handlegraph::MutablePathDeletableHandleGraph &graph,
     });
 
     if (show_info){
-        std::cerr << "[odgi chop]: " << originalRank_handleToChop.size() << " node(s) to chop." << std::endl;
+        std::cerr << "[odgi chop] " << originalRank_handleToChop.size() << " node(s) to chop." << std::endl;
     }
 
     for (auto rank_handle : originalRank_handleToChop) {

--- a/src/algorithms/groom.hpp
+++ b/src/algorithms/groom.hpp
@@ -8,6 +8,7 @@
 
 #include "dynamic.hpp"
 #include "topological_sort.hpp"
+#include "progress.hpp"
 //#include "bfs.cpp"
 
 namespace odgi {
@@ -19,7 +20,8 @@ using namespace handlegraph;
  * Remove spurious inverting links based on a dominant orientation of the graph
  */
 void groom(handlegraph::MutablePathDeletableHandleGraph& source,
-           handlegraph::MutablePathDeletableHandleGraph& target);
+           handlegraph::MutablePathDeletableHandleGraph& target,
+           bool progress_reporting = false);
 
 }
 }

--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -37,7 +37,11 @@ namespace odgi {
 #endif
 
             uint64_t total_term_updates = iter_max * min_term_updates;
-            progress_meter::ProgressMeter progress_meter(total_term_updates, "[odgi::path_linear_sgd] 1D path-guided SGD:", 0);
+            std::unique_ptr<progress_meter::ProgressMeter> progress_meter;
+            if (progress) {
+                progress_meter = std::make_unique<progress_meter::ProgressMeter>(
+                    total_term_updates, "[odgi::path_linear_sgd] 1D path-guided SGD:");
+            }
             using namespace std::chrono_literals; // for timing stuff
             uint64_t num_nodes = graph.get_node_count();
             // our positions in 1D
@@ -144,7 +148,6 @@ namespace odgi {
             auto checker_lambda =
                     [&](void) {
                         while (work_todo.load()) {
-                            progress_meter.update(term_updates.load() + min_term_updates * iteration);
                             if (term_updates.load() > min_term_updates) {
                                 if (snapshot) {
                                     if (snapshot_progress[iteration].load() || iteration == iter_max) {
@@ -337,6 +340,9 @@ namespace odgi {
                                 std::cerr << "after X[i] " << X[i].load() << " X[j] " << X[j].load() << std::endl;
 #endif
                                 term_updates++; // atomic
+                                if (progress) {
+                                    progress_meter->increment(1);
+                                }
                             }
                         }
                     };
@@ -385,7 +391,9 @@ namespace odgi {
 
             checker.join();
 
-            progress_meter.finish();
+            if (progress) {
+                progress_meter->finish();
+            }
 
             // drop out of atomic stuff... maybe not the best way to do this
             std::vector<double> X_final(X.size());

--- a/src/algorithms/path_sgd_layout.cpp
+++ b/src/algorithms/path_sgd_layout.cpp
@@ -33,7 +33,11 @@ namespace odgi {
 #endif
 
             uint64_t total_term_updates = iter_max * min_term_updates;
-            progress_meter::ProgressMeter progress_meter(total_term_updates, "[odgi::path_linear_sgd_layout] 2D path-guided SGD:", 0);
+            std::unique_ptr<progress_meter::ProgressMeter> progress_meter;
+            if (progress) {
+                progress_meter = std::make_unique<progress_meter::ProgressMeter>(
+                    total_term_updates, "[odgi::path_linear_sgd_layout] 2D path-guided SGD:");
+            }
             using namespace std::chrono_literals; // for timing stuff
             uint64_t num_nodes = graph.get_node_count();
             // is a snapshot in progress?
@@ -323,7 +327,9 @@ namespace odgi {
                                 std::cerr << "after X[i] " << X[i].load() << " X[j] " << X[j].load() << std::endl;
 #endif
                                 term_updates++; // atomic
-                                progress_meter.increment(1);
+                                if (progress) {
+                                    progress_meter->increment(1);
+                                }
                             }
                         }
                     };
@@ -376,7 +382,9 @@ namespace odgi {
 
             checker.join();
 
-            progress_meter.finish();
+            if (progress) {
+                progress_meter->finish();
+            }
 
             // drop out of atomic stuff... maybe not the best way to do this
             std::vector<double> X_final(X.size());

--- a/src/algorithms/topological_sort.hpp
+++ b/src/algorithms/topological_sort.hpp
@@ -18,6 +18,7 @@
 #include "is_single_stranded.hpp"
 #include "bfs.hpp"
 #include "dfs.hpp"
+#include "progress.hpp"
 
 namespace odgi {
 namespace algorithms {

--- a/src/algorithms/unchop.cpp
+++ b/src/algorithms/unchop.cpp
@@ -238,7 +238,7 @@ void unchop(handlegraph::MutablePathDeletableHandleGraph& graph, const bool& sho
     }
 
     if (show_info){
-        std::cerr << "[odgi unchop]: unchopped " << num_node_unchopped << " nodes into " << num_new_nodes << " new nodes." << std::endl;
+        std::cerr << "[odgi unchop] unchopped " << num_node_unchopped << " nodes into " << num_new_nodes << " new nodes." << std::endl;
     }
 
     graph.apply_ordering(handle_order, true);

--- a/src/subcommand/groom_main.cpp
+++ b/src/subcommand/groom_main.cpp
@@ -22,6 +22,7 @@ int main_groom(int argc, char** argv) {
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> og_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> og_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});
+    args::Flag progress(parser, "progress", "display progress of the grooming", {'P', "progress"});
 
     try {
         parser.ParseCLI(argc, argv);
@@ -66,7 +67,7 @@ int main_groom(int argc, char** argv) {
     }
     */
     graph_t groomed;
-    algorithms::groom(graph, groomed);
+    algorithms::groom(graph, groomed, progress);
     
     std::string outfile = args::get(og_out_file);
     if (outfile.size()) {

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -402,7 +402,7 @@ int main_sort(int argc, char** argv) {
                     break;
                 case 'g': {
                     graph_t groomed;
-                    algorithms::groom(graph, groomed);
+                    algorithms::groom(graph, groomed, progress);
                     graph = groomed;
                     was_groomed = true;
                     break;


### PR DESCRIPTION
This prints out progress information wherever it might be useful, so that when we run pggb there aren't times where the activity isn't clear.