### PR TITLE
union-find based unchop

### DIFF
--- a/src/algorithms/perfect_neighbors.cpp
+++ b/src/algorithms/perfect_neighbors.cpp
@@ -3,41 +3,43 @@
 namespace odgi {
 namespace algorithms {
 
+//#define debug_perfect_neighbors
+
 /// Return true if nodes share all paths and the mappings they share in these paths
 /// are adjacent, in the specified relative order and orientation.
 bool nodes_are_perfect_path_neighbors(const PathHandleGraph& graph, handle_t left_handle, handle_t right_handle) {
     
-#ifdef debug
+#ifdef debug_perfect_neighbors
     std::cerr << "Check if " << graph.get_id(left_handle) << (graph.get_is_reverse(left_handle) ? "-" : "+") << " and "
-        << graph.get_id(right_handle) << (graph.get_is_reverse(right_handle) ? "-" : "+") << " are perfect path neighbors" << std::endl;
+              << graph.get_id(right_handle) << (graph.get_is_reverse(right_handle) ? "-" : "+") << " are perfect path neighbors" << std::endl;
 #endif
-    
+
     // Set this false if we find an impermissible step
     bool ok = true;
-    
+
     // Count the number of permissible steps on the next node we find
     size_t expected_next = 0;
-    
+
     graph.for_each_step_on_handle(left_handle, [&](const step_handle_t& here) {
         // For each path step on the left
-        
+
         // We need to work out if the path traverses this handle backward.
         bool step_is_to_reverse_of_handle = (graph.get_handle_of_step(here) != left_handle);
-        
-#ifdef debug
+
+#ifdef debug_perfect_neighbors
         std::cerr << "Consider visit of path " << graph.get_path_name(graph.get_path_handle_of_step(here))
-            << " to " << (step_is_to_reverse_of_handle ? "reverse" : "forward") << " orientation of handle" << std::endl;
+                  << " to " << (step_is_to_reverse_of_handle ? "reverse" : "forward") << " orientation of handle" << std::endl;
 #endif
-        
+
         if (!(step_is_to_reverse_of_handle ? graph.has_previous_step(here) : graph.has_next_step(here))) {
             // If there's no visit to the right of this handle, it can't be to the right next place
-#ifdef debug
+#ifdef debug_perfect_neighbors
             std::cerr << "Path stops here so no subsequent handle is a perfect path neighbor" << std::endl;
 #endif
             ok = false;
             return false;
         }
-        
+
         // Walk along the path whatever direction is forward relative to our left handle.
         step_handle_t step_to_right = step_is_to_reverse_of_handle ? graph.get_previous_step(here) : graph.get_next_step(here);
         handle_t handle_to_right = graph.get_handle_of_step(step_to_right);
@@ -45,45 +47,44 @@ bool nodes_are_perfect_path_neighbors(const PathHandleGraph& graph, handle_t lef
             // If we had to walk back along the reverse strand of the path, we have to flip where we ended up.
             handle_to_right = graph.flip(handle_to_right);
         }
-        
+
         if (handle_to_right != right_handle) {
             // It goes to the wrong next place
-            
-#ifdef debug
+
+#ifdef debug_perfect_neighbors
             std::cerr << "Path goes to the wrong place ("
                 << graph.get_id(handle_to_right) << (graph.get_is_reverse(handle_to_right) ? "-" : "+")
                 << ") and so these nodes are not perfect path neighbors"  << std::endl;
 #endif
-            
             ok = false;
             return false;
         }
-        
+
         // Otherwise, record a step that is allowed to exist on the next handle
         expected_next++;
         return true;
     });
-    
+
     if (!ok) {
         // We found a bad step, or the path stopped.
         return false;
     }
-    
+
     // Now count up the path steps on the right handle
     size_t observed_next = 0;
     graph.for_each_step_on_handle(right_handle, [&](const step_handle_t& ignored) {
-#ifdef debug
+#ifdef debug_perfect_neighbors
         std::cerr << "Next node has path " << graph.get_path_name(graph.get_path_handle_of_step(ignored)) << std::endl;
 #endif
         observed_next++;
     });
-    
-#ifdef debug
+
+#ifdef debug_perfect_neighbors
     if (observed_next != expected_next) {
         std::cerr << "Next node has " << observed_next << " path visits but should have " << expected_next << std::endl;
     }
 #endif
-    
+
     // If there are any steps on the right node that weren't accounted for on
     // the left node, fail. Otherwise, succeed.
     return observed_next == expected_next;

--- a/src/algorithms/simple_components.cpp
+++ b/src/algorithms/simple_components.cpp
@@ -2,102 +2,119 @@
 
 namespace odgi {
 
-    namespace algorithms {
+namespace algorithms {
 
-        using namespace handlegraph;
+using namespace handlegraph;
 
-        // the set of components that could be merged into single nodes without changing the path space of the graph
-        std::vector<std::vector<handle_t>> simple_components(
-                const PathHandleGraph &graph, uint64_t min_size, const bool return_all_handles) {
-            std::unordered_set<handle_t> seen;
-            std::set<std::vector<uint64_t>> components;
-            graph.for_each_handle([&](const handle_t &handle) {
-                if (!seen.count(handle)) {
-                    // go left and right through each as far as we have only single edges connecting us
-                    // to nodes that have only single edges coming in or out
-                    // that go to other nodes
-                    std::vector<handle_t> right_linear_component;
-                    std::unordered_set<handle_t> todo;
-                    // check the inbound edge count of each node in the direction we are walking
-                    // if it's > 1 then don't pass through it
-                    bool stop = false;
-                    todo.insert(handle);
-                    while (!stop && todo.size() == 1) {
-                        handle_t curr = *todo.begin();
-                        if (seen.count(curr)) {
-                            stop = true;
-                            break;
-                        }
-                        seen.insert(curr);
-                        todo.clear();
-                        if (curr != handle) right_linear_component.push_back(curr);
-                        graph.follow_edges(curr, false, [&](const handle_t &next) {
-                            uint64_t left_edge_count = 0;
-                            graph.follow_edges(next, true, [&](const handle_t &h) { ++left_edge_count; });
-                            if (graph.get_is_reverse(handle) == graph.get_is_reverse(next)
-                                && left_edge_count == 1
-                                && nodes_are_perfect_path_neighbors(graph, curr, next)) {
-                                todo.insert(next);
-                            } else {
-                                stop = true;
-                            }
-                        });
-                    }
-                    stop = false;
-                    todo.clear();
-                    todo.insert(handle);
-                    std::vector<handle_t> left_linear_component;
-                    while (!stop && todo.size() == 1) {
-                        handle_t curr = *todo.begin();
-                        if (seen.count(curr)) {
-                            stop = true;
-                            break;
-                        }
-                        seen.insert(curr);
-                        todo.clear();
-                        if (curr != handle) left_linear_component.push_back(curr);
-                        graph.follow_edges(curr, true, [&](const handle_t &prev) {
-                            uint64_t right_edge_count = 0;
-                            graph.follow_edges(prev, false, [&](const handle_t &h) { ++right_edge_count; });
-                            if (graph.get_is_reverse(handle) == graph.get_is_reverse(prev)
-                                && right_edge_count == 1
-                                && nodes_are_perfect_path_neighbors(graph, prev, curr)) {
-                                todo.insert(prev);
-                            } else {
-                                stop = true;
-                            }
-                        });
-                    }
-                    std::vector<uint64_t> linear_component;
-                    linear_component.reserve(left_linear_component.size() + 1 + right_linear_component.size());
-                    for (auto i = left_linear_component.rbegin(); i != left_linear_component.rend(); ++i) {
-                        linear_component.push_back(as_integer(*i));
-                    }
-                    linear_component.push_back(as_integer(handle));
-                    for (auto i = right_linear_component.begin(); i != right_linear_component.end(); ++i) {
-                        linear_component.push_back(as_integer(*i));
-                    }
-                    if (linear_component.size() >= min_size) {
-                        components.insert(linear_component);
-                    }else if (return_all_handles){
-                        // Take all nodes, without grouping them
-                        for (auto& x : linear_component){
-                            std::vector<uint64_t> shorter_linear_component{x};
-                            components.insert(shorter_linear_component);
-                        }
-                    }
-                }
+// the set of components that could be merged into single nodes without changing the path space of the graph
+std::vector<std::vector<handle_t>> simple_components(
+    const PathHandleGraph &graph, const uint64_t& min_size, const bool return_all_handles) {
+
+    boophf_uint64_t* bphf = nullptr;
+    uint64_t data_size = 0;
+    {
+        std::vector<uint64_t> data; data.reserve(graph.get_node_count()*2);
+        graph.for_each_handle(
+            [&](const handle_t& handle) {
+                data.push_back(as_integer(handle));
+                data.push_back(as_integer(graph.flip(handle)));
             });
-            std::vector<std::vector<handle_t>> handle_components;
-            for (auto &v : components) {
-                handle_components.emplace_back();
-                auto &n = handle_components.back();
-                for (auto &i : v) {
-                    n.push_back(as_handle(i));
-                }
+        uint64_t nthreads = get_thread_count();
+        bphf = new boophf_uint64_t(data.size(),data,nthreads,2.0,false,false);
+        data_size = data.size();
+    }
+
+    std::vector<DisjointSets::Aint> simple_data(data_size);
+    auto simple_dset = DisjointSets(simple_data.data(), simple_data.size());
+
+    auto self_unite =
+        [&](const handle_t& h) {
+            uint64_t h_i = bphf->lookup(as_integer(h)) - 1;
+            uint64_t h_j = bphf->lookup(as_integer(graph.flip(h))) - 1;
+            simple_dset.unite(h_i, h_j);
+        };
+
+    graph.for_each_edge(
+        [&](const edge_t& edge) {
+            const handle_t& from = edge.first;
+            const handle_t& to = edge.second;
+            // unite the handles with themselves
+            self_unite(from);
+            self_unite(to);
+            // check if they can be linked across the edge
+            if (graph.get_degree(from, false) == 1
+                && graph.get_degree(to, true) == 1
+                && nodes_are_perfect_path_neighbors(graph, from, to)) {
+                //std::cerr << "would merge " << graph.get_id(from)
+                //          << " with " << graph.get_id(to) << std::endl;
+                uint64_t from_i = bphf->lookup(as_integer(from)) - 1;
+                uint64_t to_i = bphf->lookup(as_integer(to)) - 1;
+                //std::cerr << "indexes " << from_i << " and " << to_i << std::endl;
+                simple_dset.unite(from_i, to_i);
             }
-            return handle_components;
+        },
+        true); // parallel
+
+    ska::flat_hash_map<uint64_t, std::vector<handle_t>> simple_components;
+    //std::vector<uint64_t> node_dset(simple_dset.size());
+    graph.for_each_handle(
+        [&](const handle_t& handle) {
+            uint64_t a_id = simple_dset.find(bphf->lookup(as_integer(handle))-1);
+            uint64_t b_id = simple_dset.find(bphf->lookup(as_integer(graph.flip(handle))-1));
+            //assert(a_id == b_id); // apparently not needed
+            //node_dset[++i] = a_id;
+            simple_components[a_id].push_back(handle);
+            //std::cerr << "node " << graph.get_id(handle) << " " << a_id << " " << b_id << std::endl;
+        });
+
+    delete bphf;
+
+    // now we combine and order the nodes in each dset
+    std::vector<std::vector<handle_t>> handle_components;
+    for (auto& c : simple_components) {
+        auto& comp = c.second;
+        if (comp.size() >= min_size) {
+            // start somewhere
+            ska::flat_hash_set<uint64_t> comp_set;
+            for (auto& h : comp) comp_set.insert(as_integer(h));
+            handle_t h = comp.front();
+            bool has_prev = false;
+            do {
+                has_prev = graph.get_degree(h, true) == 1;
+                handle_t prev = h;
+                if (has_prev) {
+                    graph.follow_edges(h, true, [&](const handle_t& p) { prev = p; });
+                }
+                if (comp_set.count(as_integer(prev))) {
+                    h = prev;
+                } else {
+                    has_prev = false;
+                }
+            } while (has_prev);
+
+            //handle_t front = h;
+            //std::cerr << "Front is " << graph.get_id(h) << std::endl;
+            handle_components.emplace_back();
+            auto& sorted_comp = handle_components.back();
+            bool has_next = false;
+            do {
+                sorted_comp.push_back(h);
+                has_next = graph.get_degree(h, false) == 1;
+                handle_t next = h;
+                if (has_next) {
+                    graph.follow_edges(h, false, [&](const handle_t& n) { next = n; });
+                }
+                if (comp_set.count(as_integer(next))) {
+                    h = next;
+                } else {
+                    has_next = false;
+                }
+            } while (has_next);
         }
     }
+
+    return handle_components;
+}
+}
 
 }

--- a/src/algorithms/simple_components.cpp
+++ b/src/algorithms/simple_components.cpp
@@ -37,16 +37,18 @@ std::vector<std::vector<handle_t>> simple_components(
             // unite the handles with themselves
             self_unite(from);
             self_unite(to);
-            // check if they can be linked across the edge
-            if (graph.get_degree(from, false) == 1
-                && graph.get_degree(to, true) == 1
-                && nodes_are_perfect_path_neighbors(graph, from, to)) {
-                //std::cerr << "would merge " << graph.get_id(from)
-                //          << " with " << graph.get_id(to) << std::endl;
-                uint64_t from_i = bphf.lookup(as_integer(from));
-                uint64_t to_i = bphf.lookup(as_integer(to));
-                //std::cerr << "indexes " << from_i << " and " << to_i << std::endl;
-                simple_dset.unite(from_i, to_i);
+            if (graph.get_id(from) != graph.get_id(to)) {
+                // check if they can be linked across the edge
+                if (graph.get_degree(from, false) == 1
+                    && graph.get_degree(to, true) == 1
+                    && nodes_are_perfect_path_neighbors(graph, from, to)) {
+                    //std::cerr << "would merge " << graph.get_id(from)
+                    //          << " with " << graph.get_id(to) << std::endl;
+                    uint64_t from_i = bphf.lookup(as_integer(from));
+                    uint64_t to_i = bphf.lookup(as_integer(to));
+                    //std::cerr << "indexes " << from_i << " and " << to_i << std::endl;
+                    simple_dset.unite(from_i, to_i);
+                }
             }
         },
         true); // parallel

--- a/src/algorithms/simple_components.cpp
+++ b/src/algorithms/simple_components.cpp
@@ -65,6 +65,7 @@ std::vector<std::vector<handle_t>> simple_components(
     std::vector<std::vector<handle_t>> handle_components;
     for (auto& c : simple_components) {
         auto& comp = c.second;
+        assert(comp.size());
         if (comp.size() >= min_size) {
             // start somewhere
             ska::flat_hash_set<uint64_t> comp_set;
@@ -101,7 +102,19 @@ std::vector<std::vector<handle_t>> simple_components(
                     has_next = false;
                 }
             } while (has_next);
+            assert(sorted_comp.size() > 0);
+            if (sorted_comp.size() < min_size) {
+                handle_components.pop_back();
+            }
         }
+    }
+
+    if (min_size == 1) {
+        uint64_t seen_nodes = 0;
+        for (auto& comp : simple_components) {
+            seen_nodes += comp.second.size();
+        }
+        assert(seen_nodes == graph.get_node_count());
     }
 
     return handle_components;

--- a/src/algorithms/simple_components.hpp
+++ b/src/algorithms/simple_components.hpp
@@ -8,8 +8,11 @@
 #include <handlegraph/types.hpp>
 #include <handlegraph/util.hpp>
 #include <handlegraph/path_handle_graph.hpp>
+#include "flat_hash_map.hpp"
 
 #include "perfect_neighbors.hpp"
+#include "dset64-gccAtomic.hpp"
+#include "BooPHF.h"
 
 namespace odgi {
 
@@ -17,8 +20,10 @@ namespace algorithms {
 
 using namespace handlegraph;
 
+typedef boomphf::mphf<uint64_t, boomphf::SingleHashFunctor<uint64_t>> boophf_uint64_t;
+
 std::vector<std::vector<handle_t>> simple_components(
-        const PathHandleGraph& graph, uint64_t min_size, bool return_all_handles);
+    const PathHandleGraph &graph, const uint64_t& min_size, const bool return_all_handles);
 
 }
 

--- a/src/algorithms/unchop.cpp
+++ b/src/algorithms/unchop.cpp
@@ -24,7 +24,7 @@ namespace algorithms {
 ///
 /// After calling this on a vg::VG, paths will be invalid until
 /// Paths::compact_ranks() is called.
-    handle_t concat_nodes(handlegraph::MutablePathDeletableHandleGraph& graph, const std::vector<handle_t>& nodes) {
+handle_t concat_nodes(handlegraph::MutablePathDeletableHandleGraph& graph, const std::vector<handle_t>& nodes) {
 
     // Make sure we have at least 2 nodes
     assert(!nodes.empty() && nodes.front() != nodes.back());
@@ -32,15 +32,13 @@ namespace algorithms {
     /*
 #ifdef debug
     std::cerr << "Paths before concat: " << std::endl;
-   
     graph.for_each_path_handle([&](const path_handle_t p) {
-        std::cerr << graph.get_path_name(p) << ": ";
-        for (auto h : graph.scan_path(p)) {
-            std::cerr << graph.get_id(h) << (graph.get_is_reverse(h) ? '-' : '+') << " ";
-        }
-        std::cerr << std::endl;
-    });
-   
+                                   std::cerr << graph.get_path_name(p) << ": ";
+                                   for (auto h : graph.scan_path(p)) {
+                                       std::cerr << graph.get_id(h) << (graph.get_is_reverse(h) ? '-' : '+') << " ";
+                                   }
+                                   std::cerr << std::endl;
+                               });
 #endif
     */
 
@@ -72,37 +70,37 @@ namespace algorithms {
     // the run, or self loops.
     std::unordered_set<handle_t> left_neighbors;
     graph.follow_edges(nodes.front(), true, [&](const handle_t& left_neighbor) {
-        if (left_neighbor == nodes.back()) {
-            // Loop back to the end
-            left_neighbors.insert(new_node);
-        } else if (left_neighbor == graph.flip(nodes.front())) {
-            // Loop back to the front
-            left_neighbors.insert(graph.flip(new_node));
-        } else {
-            // Normal edge
-            left_neighbors.insert(left_neighbor);
-        }
-    });
+                                                if (left_neighbor == nodes.back()) {
+                                                    // Loop back to the end
+                                                    left_neighbors.insert(new_node);
+                                                } else if (left_neighbor == graph.flip(nodes.front())) {
+                                                    // Loop back to the front
+                                                    left_neighbors.insert(graph.flip(new_node));
+                                                } else {
+                                                    // Normal edge
+                                                    left_neighbors.insert(left_neighbor);
+                                                }
+                                            });
     
     std::unordered_set<handle_t> right_neighbors;
     graph.follow_edges(nodes.back(), false, [&](const handle_t& right_neighbor) {
-        if (right_neighbor == nodes.front()) {
-            // Loop back to the front.
-            // We will have seen it from the other side, so ignore it here.
-        } else if (right_neighbor == graph.flip(nodes.back())) {
-            // Loop back to the end
-            right_neighbors.insert(graph.flip(new_node));
-        } else {
-            // Normal edge
-            right_neighbors.insert(right_neighbor);
-        }
-    });
+                                                if (right_neighbor == nodes.front()) {
+                                                    // Loop back to the front.
+                                                    // We will have seen it from the other side, so ignore it here.
+                                                } else if (right_neighbor == graph.flip(nodes.back())) {
+                                                    // Loop back to the end
+                                                    right_neighbors.insert(graph.flip(new_node));
+                                                } else {
+                                                    // Normal edge
+                                                    right_neighbors.insert(right_neighbor);
+                                                }
+                                            });
     
     // Make all the edges, now that we can't interfere with edge listing
     for (auto& n : left_neighbors) {
 #ifdef debug
         std::cerr << "Creating edge " << graph.get_id(n) << (graph.get_is_reverse(n) ? "-" : "+") << " -> "
-            <<  graph.get_id(new_node) << (graph.get_is_reverse(new_node) ? "-" : "+") << std::endl;
+                  <<  graph.get_id(new_node) << (graph.get_is_reverse(new_node) ? "-" : "+") << std::endl;
 #endif
         graph.create_edge(n, new_node);
     }
@@ -110,7 +108,7 @@ namespace algorithms {
     
 #ifdef debug
         std::cerr << "Creating edge " << graph.get_id(new_node) << (graph.get_is_reverse(new_node) ? "-" : "+") << " -> "
-            <<  graph.get_id(n) << (graph.get_is_reverse(n) ? "-" : "+") << std::endl;
+                  <<  graph.get_id(n) << (graph.get_is_reverse(n) ? "-" : "+") << std::endl;
 #endif
     
         graph.create_edge(new_node, n);
@@ -125,38 +123,38 @@ namespace algorithms {
         std::vector<std::tuple<step_handle_t, step_handle_t, bool>> ranges_to_rewrite;
         
         graph.for_each_step_on_handle(nodes.front(), [&](const step_handle_t& front_step) {
-            auto path = graph.get_path_handle_of_step(front_step);
+                                                         auto path = graph.get_path_handle_of_step(front_step);
 #ifdef debug
-            std::cerr << "Consider path " << graph.get_path_name(path) << std::endl;
+                                                         std::cerr << "Consider path " << graph.get_path_name(path) << std::endl;
 #endif
         
-            // If we don't get the same oriented node as where this step is
-            // stepping, we must be stepping on the other orientation.
-            bool runs_reverse = (graph.get_handle_of_step(front_step) != nodes.front());
+                                                         // If we don't get the same oriented node as where this step is
+                                                         // stepping, we must be stepping on the other orientation.
+                                                         bool runs_reverse = (graph.get_handle_of_step(front_step) != nodes.front());
        
-            step_handle_t back_step = front_step;
+                                                         step_handle_t back_step = front_step;
             
-            while(graph.get_handle_of_step(back_step) != (runs_reverse ? graph.flip(nodes.back()) : nodes.back())) {
-                // Until we find the step on the path that visits the last node in our run.
-                // Go along the path towards where our last node should be, in our forward orientation.
-                back_step = runs_reverse ? graph.get_previous_step(back_step) : graph.get_next_step(back_step);
-            }
+                                                         while(graph.get_handle_of_step(back_step) != (runs_reverse ? graph.flip(nodes.back()) : nodes.back())) {
+                                                             // Until we find the step on the path that visits the last node in our run.
+                                                             // Go along the path towards where our last node should be, in our forward orientation.
+                                                             back_step = runs_reverse ? graph.get_previous_step(back_step) : graph.get_next_step(back_step);
+                                                         }
             
-            // Now we can record the range to rewrite
-            // Make sure to put it into path-forward order
-            if (runs_reverse) {
+                                                         // Now we can record the range to rewrite
+                                                         // Make sure to put it into path-forward order
+                                                         if (runs_reverse) {
 #ifdef debug
-                std::cerr << "\tGoing to rewrite between " << graph.get_id(graph.get_handle_of_step(front_step)) << " and " << graph.get_id(graph.get_handle_of_step(back_step)) << " backward" << std::endl;
+                                                             std::cerr << "\tGoing to rewrite between " << graph.get_id(graph.get_handle_of_step(front_step)) << " and " << graph.get_id(graph.get_handle_of_step(back_step)) << " backward" << std::endl;
 #endif
-                ranges_to_rewrite.emplace_back(back_step, front_step, true);
-            } else {
+                                                             ranges_to_rewrite.emplace_back(back_step, front_step, true);
+                                                         } else {
             
 #ifdef debug
-                std::cerr << "\tGoing to rewrite between " << graph.get_id(graph.get_handle_of_step(front_step)) << " and " << graph.get_id(graph.get_handle_of_step(back_step)) << std::endl;
+                                                             std::cerr << "\tGoing to rewrite between " << graph.get_id(graph.get_handle_of_step(front_step)) << " and " << graph.get_id(graph.get_handle_of_step(back_step)) << std::endl;
 #endif
-                ranges_to_rewrite.emplace_back(front_step, back_step, false);
-            }
-        });
+                                                             ranges_to_rewrite.emplace_back(front_step, back_step, false);
+                                                         }
+                                                     });
 
         uint64_t i = 0;
         for (auto& range : ranges_to_rewrite) {
@@ -192,27 +190,27 @@ namespace algorithms {
     }
 
     /*
-#ifdef debug
-    std::cerr << "Paths after concat: " << std::endl;
+      #ifdef debug
+      std::cerr << "Paths after concat: " << std::endl;
    
-    graph.for_each_path_handle([&](const path_handle_t p) {
-        std::cerr << graph.get_path_name(p) << ": ";
-        for (auto h : graph.scan_path(p)) {
-            std::cerr << graph.get_id(h) << (graph.get_is_reverse(h) ? '-' : '+') << " ";
-        }
-        std::cerr << std::endl;
-    });
+      graph.for_each_path_handle([&](const path_handle_t p) {
+      std::cerr << graph.get_path_name(p) << ": ";
+      for (auto h : graph.scan_path(p)) {
+      std::cerr << graph.get_id(h) << (graph.get_is_reverse(h) ? '-' : '+') << " ";
+      }
+      std::cerr << std::endl;
+      });
    
-#endif
+      #endif
     */
 
     // Return the new handle we merged to.
     return new_node;
 }
 
-    void unchop(handlegraph::MutablePathDeletableHandleGraph& graph) {
-        unchop(graph, false);
-    }
+void unchop(handlegraph::MutablePathDeletableHandleGraph& graph) {
+    unchop(graph, false);
+}
 
 void unchop(handlegraph::MutablePathDeletableHandleGraph& graph, const bool& show_info) {
 #ifdef debug

--- a/src/algorithms/unchop.cpp
+++ b/src/algorithms/unchop.cpp
@@ -232,7 +232,7 @@ void unchop(handlegraph::MutablePathDeletableHandleGraph& graph, const bool& sho
 
     uint64_t num_node_unchopped = 0;
     uint64_t num_new_nodes = 0;
-    for (auto& comp : simple_components(graph, 2, true)) {
+    for (auto& comp : simple_components(graph, 1, true)) {
 #ifdef debug
         std::cerr << "Unchop " << comp.size() << " nodes together" << std::endl;
 #endif
@@ -242,7 +242,7 @@ void unchop(handlegraph::MutablePathDeletableHandleGraph& graph, const bool& sho
 
             num_node_unchopped += comp.size();
             num_new_nodes++;
-        }else{
+        } else {
             handle_order.push_back(comp.front());
         }
     }
@@ -252,7 +252,7 @@ void unchop(handlegraph::MutablePathDeletableHandleGraph& graph, const bool& sho
     }
 
     // todo correct ordering.... these handles are invalidated
-    //graph.apply_ordering(handle_order, true);
+    graph.apply_ordering(handle_order, true);
 
     // validate the paths
     graph.for_each_path_handle(

--- a/src/dset64-gccAtomic.hpp
+++ b/src/dset64-gccAtomic.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <stdexcept>
+
+/**
+ * Lock-free parallel disjoint set data structure (aka UNION-FIND)
+ * with path compression and union by rank
+ *
+ * Supports concurrent find(), same() and unite() calls as described
+ * in the paper
+ *
+ * "Wait-free Parallel Algorithms for the Union-Find Problem"
+ * by Richard J. Anderson and Heather Woll
+ *
+ * This file is a modified version of dset.h from GitHub repository
+ * wjakob/dset by Wenzel Jacob.
+ *
+ * The original implementation by Wenzel Jakob uses 64-bit
+ * atomic primitives, and implements the union-find
+ * algorithm for 32-bit item ids, which allows up to
+ * 2^32^ items. This modified version
+ * uses 128-bit primitives for 64-bit item ids,
+ * which brings the maximum number of items to 2^64^.
+ *
+ * See the LICENSE file for licensing information
+ * specific to this file.
+ *
+ * \author Wenzel Jakob
+ *
+ *
+ * USAGE OF GCC ATOMIC PRIMITIVES
+ *
+ * The implementation in shasta/src/dset64.hpp uses std::atomic<__uint128_t>
+ * for lock-free synchronization.
+ * On older GCC versions, std::atomic<__uint128_t> is lock-free
+ * if compilation is done with -mcx16, which enables the use of the
+ * 16-byte (128 bit) compare-and-swap instruction, CMPXCHG16B.
+ *
+ * Unfortunately, on newer GCC versions, this is no longer true
+ * because of gcc bug 80878:
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878
+ *
+ * As a result, there was a significant performance loss in
+ * versions of Shasta built with gcc 7,
+ * which is used by default on Ubuntu 18.04, when using
+ * machines with large number of virtual processors.
+ *
+ * It is unlikely that this gcc bug will ever be fixed,
+ * and to avoid this performance loss this implementation
+ * uses gcc primitive __sync_bool_compare_and_swap instead
+ * for lock-free synchronization. When compilation
+ * is done with -mcx16 and optimization turned on,
+ * this primitive uses the CMPXCHG16B instruction
+ * and results in optimal speed.
+ *
+ * The CMPXCHG16B instruction is available on most modern 64-bit x86 processors.
+ * Some older processors that don't implement this instruction
+ * will crash with an "Illegal instruction" error
+ * upon attempting to run this code.
+ *
+ */
+
+// Sanity check that we are compiling on x86_64.
+#if !__x86_64__
+#error "odgi can only be built on an x86_64 machine (64-bit Intel/AMD)"
+#endif
+
+namespace odgi {
+
+class DisjointSets {
+public:
+
+    // Integer type used for synchronization primitives.
+    // This must have 128 bits and its atomic type must be lock-free
+    // (this is checked in the constructor).
+    // See the Compilation/Portability comment above.
+    using Aint = __uint128_t;
+    static_assert(sizeof(Aint) == 16, "Unexpected size of DisjointSets::Aint.");
+
+    // We use the 128 bits of Aint to hold the parent in the
+    // 64 least significant bits and the rank in the most significant bits.
+    // Define two masks for these two sets of bits.
+    static const Aint parentMask = Aint(~0ULL);
+    static const Aint rankMask = parentMask << 64;
+
+    // For memory allocation flexibility, the memory is allocated
+    // and owned by the caller.
+    DisjointSets(Aint* mData, uint64_t size) : mData(mData), n(size) {
+        for (uint64_t i=0; i<size; ++i)
+            mData[i] = Aint(i);
+    }
+
+    uint64_t find(uint64_t id) const {
+        while (id != parent(id)) {
+            Aint value = mData[id];
+            uint64_t new_parent = parent((uint64_t) value);
+            Aint new_value =
+                (value & rankMask) | new_parent;
+            /* Try to update parent (may fail, that's ok) */
+            if (value != new_value)
+                __sync_bool_compare_and_swap(&mData[id], value, new_value);
+            id = new_parent;
+        }
+        return id;
+    }
+
+    bool same(uint64_t id1, uint64_t id2) const {
+        for (;;) {
+            id1 = find(id1);
+            id2 = find(id2);
+            if (id1 == id2)
+                return true;
+            if (parent(id1) == id1)
+                return false;
+        }
+    }
+
+    uint64_t unite(uint64_t id1, uint64_t id2) {
+        for (;;) {
+            id1 = find(id1);
+            id2 = find(id2);
+
+            if (id1 == id2)
+                return id1;
+
+            uint64_t r1 = rank(id1), r2 = rank(id2);
+
+            if (r1 > r2 || (r1 == r2 && id1 < id2)) {
+                std::swap(r1, r2);
+                std::swap(id1, id2);
+            }
+
+            Aint oldEntry = ((Aint) r1 << 64) | id1;
+            Aint newEntry = ((Aint) r1 << 64) | id2;
+
+            if (!__sync_bool_compare_and_swap(&mData[id1], oldEntry, newEntry))
+                continue;
+
+            if (r1 == r2) {
+                oldEntry = ((Aint) r2 << 64) | id2;
+                newEntry = ((Aint) (r2+1) << 64) | id2;
+                /* Try to update the rank (may fail, that's ok) */
+                __sync_bool_compare_and_swap(&mData[id2], oldEntry, newEntry);
+            }
+
+            break;
+        }
+        return id2;
+    }
+
+    uint64_t size() const { return n; }
+
+    uint64_t rank(uint64_t id) const {
+        return ((uint64_t) (mData[id] >> 64)) & parentMask;
+    }
+
+    uint64_t parent(uint64_t id) const {
+        return (uint64_t) mData[id];
+    }
+
+    // Use memory supplied by the caller, rather than an owned vector.
+    // This provides more flexibility in allocating the memory.
+    Aint* mData;
+    uint64_t n;
+};
+
+}

--- a/src/dset64.hpp
+++ b/src/dset64.hpp
@@ -1,0 +1,171 @@
+#pragma once
+
+#include <atomic>
+#include <stdexcept>
+
+/**
+ * Lock-free parallel disjoint set data structure (aka UNION-FIND)
+ * with path compression and union by rank
+ *
+ * Supports concurrent find(), same() and unite() calls as described
+ * in the paper
+ *
+ * "Wait-free Parallel Algorithms for the Union-Find Problem"
+ * by Richard J. Anderson and Heather Woll
+ *
+ * This file is a modified version of dset.h from GitHub repository
+ * wjakob/dset by Wenzel Jacob.
+ *
+ * The original implementation by Wenzel Jakob uses 64-bit
+ * atomic primitives, and implements the union-find
+ * algorithm for 32-bit item ids, which allows up to
+ * 2^32^ items. This modified version
+ * uses 128-bit primitives for 64-bit item ids,
+ * which brings the maximum number of items to 2^64^.
+ *
+ * See the LICENSE file for licensing information
+ * specific to this file.
+ *
+ * \author Wenzel Jakob
+ *
+ *
+ * IMPORTANT COMPILATION AND PORTABILITY INFORMATION
+ *
+ * 128-bit integers and 128-bit atomic primitives
+ * are not available on all platforms.
+ * This code uses __uint128_t as the 128 integer type,
+ * and synchronization primitives available in C++11
+ * via std::atomic<uint128_t>
+ *
+ * Both __uint128_t and std::atomic<__uint128_t>
+ * are available with g++ on 64-bit x86 Linux,
+ * and std::atomic<uint128_t>::is_lock_free returns true,
+ * if the following compilation option is used to enable the
+ * 16-byte (128 bit) compare-and-swap instruction, CMPXCHG16B:
+ * -mcx16
+ * This instruction is available on most modern 64-bit x86 processors.
+ * Some older processors that don't implement this instruction
+ * will crash with an "Illegal instruction" error
+ * upon attempting to run this code.
+ *
+ * Unfortunately, however, beginning with gcc 7, a bug was introduced
+ * that causes std::atomic<uint128_t>::is_lock_free to return false,
+ * even when compile option -mcx16 is used (gcc bug 80878):
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80878
+ * When using a version of gcc with the bug, this
+ * code will run at reduced performance.
+ *
+ */
+
+// Sanity check that we are compiling on x86_64.
+#if !__x86_64__
+#error "odgi can only be built on an x86_64 machine (64-bit Intel/AMD)"
+#endif
+
+namespace odgi {
+
+class DisjointSets {
+public:
+
+    // Integer type used for synchronization primitives.
+    // This must have 128 bits and its atomic type must be lock-free
+    // (this is checked in the constructor).
+    // See the Compilation/Portability comment above.
+    using Aint = __uint128_t;
+    static_assert(sizeof(Aint) == 16, "Unexpected size of DisjointSets::Aint.");
+
+    // We use the 128 bits of Aint to hold the parent in the
+    // 64 least significant bits and the rank in the most significant bits.
+    // Define two masks for these two sets of bits.
+    static const Aint parentMask = Aint(~0ULL);
+    static const Aint rankMask = parentMask << 64;
+
+    // For memory allocation flexibility, the memory is allocated
+    // and owned by the caller.
+    DisjointSets(std::atomic<Aint>* mData, uint64_t size) : mData(mData), n(size) {
+        if(!mData->is_lock_free()) {
+            // If this happens with g++ on 64-bit x86 Linux, use
+            // compile option -mcx16.
+            // This throw is commented out to permit running on Ubuntu 18.04
+            // (see comments above), but at a performance penalty.
+            // throw std::runtime_error("DisjointSets::Aint is not lock-free.");
+        }
+        for (uint64_t i=0; i<size; ++i)
+            mData[i] = Aint(i);
+    }
+
+    uint64_t find(uint64_t id) const {
+        while (id != parent(id)) {
+            Aint value = mData[id];
+            uint64_t new_parent = parent((uint64_t) value);
+            Aint new_value =
+                (value & rankMask) | new_parent;
+            /* Try to update parent (may fail, that's ok) */
+            if (value != new_value)
+                mData[id].compare_exchange_weak(value, new_value);
+            id = new_parent;
+        }
+        return id;
+    }
+
+    bool same(uint64_t id1, uint64_t id2) const {
+        for (;;) {
+            id1 = find(id1);
+            id2 = find(id2);
+            if (id1 == id2)
+                return true;
+            if (parent(id1) == id1)
+                return false;
+        }
+    }
+
+    uint64_t unite(uint64_t id1, uint64_t id2) {
+        for (;;) {
+            id1 = find(id1);
+            id2 = find(id2);
+
+            if (id1 == id2)
+                return id1;
+
+            uint64_t r1 = rank(id1), r2 = rank(id2);
+
+            if (r1 > r2 || (r1 == r2 && id1 < id2)) {
+                std::swap(r1, r2);
+                std::swap(id1, id2);
+            }
+
+            Aint oldEntry = ((Aint) r1 << 64) | id1;
+            Aint newEntry = ((Aint) r1 << 64) | id2;
+
+            if (!mData[id1].compare_exchange_strong(oldEntry, newEntry))
+                continue;
+
+            if (r1 == r2) {
+                oldEntry = ((Aint) r2 << 64) | id2;
+                newEntry = ((Aint) (r2+1) << 64) | id2;
+                /* Try to update the rank (may fail, that's ok) */
+                mData[id2].compare_exchange_weak(oldEntry, newEntry);
+            }
+
+            break;
+        }
+        return id2;
+    }
+
+    uint64_t size() const { return n; }
+
+    uint64_t rank(uint64_t id) const {
+        return ((uint64_t) (mData[id] >> 64)) & parentMask;
+    }
+
+    uint64_t parent(uint64_t id) const {
+        return (uint64_t) mData[id];
+    }
+
+    // Use memory supplied by the caller, rather than an owned vector.
+    // This provides more flexibility in allocating the memory.
+    std::atomic<Aint>* mData;
+    uint64_t n;
+};
+
+}

--- a/src/subcommand/unchop_main.cpp
+++ b/src/subcommand/unchop_main.cpp
@@ -22,6 +22,7 @@ int main_unchop(int argc, char** argv) {
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> og_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> og_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});
+    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use", {'t', "threads"});
     args::Flag debug(parser, "debug", "print information about the process to stderr.", {'d', "debug"});
 
     try {
@@ -48,6 +49,9 @@ int main_unchop(int argc, char** argv) {
         std::cerr << "[odgi unchop] error: Please specify an output file to where to store the unchopped graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
+
+    const uint64_t num_threads = nthreads ? args::get(nthreads) : 1;
+    omp_set_num_threads(num_threads);
 
     graph_t graph;
     assert(argc > 0);

--- a/src/unittest/simplify.cpp
+++ b/src/unittest/simplify.cpp
@@ -6,6 +6,7 @@
 #include "odgi.hpp"
 #include "algorithms/simple_components.hpp"
 #include "algorithms/topological_sort.hpp"
+#include "algorithms/unchop.hpp"
 
 #include <iostream>
 #include <limits>
@@ -34,10 +35,7 @@ TEST_CASE("Graph simplification reduces a simple graph to a single node", "[simp
     graph.create_edge(n3, n4);
     graph.create_edge(n4, n5);
     graph.create_edge(n5, n6);
-    std::vector<std::vector<handle_t>> linear_components = algorithms::simple_components(graph, 2, false);
-    for (auto& v : linear_components) {
-        graph.combine_handles(v);
-    }
+    algorithms::unchop(graph);
     // sort the graph
     graph.apply_ordering(algorithms::topological_order(&graph), true);
     SECTION("The graph is as expected") {
@@ -90,10 +88,7 @@ TEST_CASE("Graph simplification reduces a graph with a self inverting +/- loop",
     graph.create_edge(n3, n4);
     graph.create_edge(n4, n5);
     graph.create_edge(n5, n6);
-    std::vector<std::vector<handle_t>> linear_components = algorithms::simple_components(graph, 2, false);
-    for (auto& v : linear_components) {
-        graph.combine_handles(v);
-    }
+    algorithms::unchop(graph);
     // sort the graph
     graph.apply_ordering(algorithms::topological_order(&graph), true);
     SECTION("The graph is as expected") {
@@ -118,10 +113,7 @@ TEST_CASE("Graph simplification reduces a graph with a self inverting -/+ loop",
     graph.create_edge(n3, n4);
     graph.create_edge(n4, n5);
     graph.create_edge(n5, n6);
-    std::vector<std::vector<handle_t>> linear_components = algorithms::simple_components(graph, 2, false);
-    for (auto& v : linear_components) {
-        graph.combine_handles(v);
-    }
+    algorithms::unchop(graph);
     // sort the graph
     graph.apply_ordering(algorithms::topological_order(&graph), true);
     SECTION("The graph is as expected") {


### PR DESCRIPTION
This corrects some problems with unchop that were limiting the compression of unbranching parts of the graph where the unbranching component was sorted in the reverse order.