### PR TITLE
unchop loops correctly

### DIFF
--- a/src/algorithms/simple_components.cpp
+++ b/src/algorithms/simple_components.cpp
@@ -73,6 +73,7 @@ std::vector<std::vector<handle_t>> simple_components(
             ska::flat_hash_set<uint64_t> comp_set;
             for (auto& h : comp) comp_set.insert(as_integer(h));
             handle_t h = comp.front();
+            handle_t base = h; // so we don't loop endlessly in self-linking components
             bool has_prev = false;
             do {
                 has_prev = graph.get_degree(h, true) == 1;
@@ -80,7 +81,9 @@ std::vector<std::vector<handle_t>> simple_components(
                 if (has_prev) {
                     graph.follow_edges(h, true, [&](const handle_t& p) { prev = p; });
                 }
-                if (comp_set.count(as_integer(prev))) {
+                if (h != prev
+                    && prev != base
+                    && comp_set.count(as_integer(prev))) {
                     h = prev;
                 } else {
                     has_prev = false;
@@ -98,7 +101,9 @@ std::vector<std::vector<handle_t>> simple_components(
                 if (has_next) {
                     graph.follow_edges(h, false, [&](const handle_t& n) { next = n; });
                 }
-                if (comp_set.count(as_integer(next))) {
+                if (h != next
+                    && next != base
+                    && comp_set.count(as_integer(next))) {
                     h = next;
                 } else {
                     has_next = false;

--- a/src/unittest/simplify.cpp
+++ b/src/unittest/simplify.cpp
@@ -74,7 +74,7 @@ TEST_CASE("Graph simplification reduces a graph with a self loop", "[simplify]")
     }
 }
 
-TEST_CASE("Graph simplification reduces a graph with a self inverting +/- loop", "[simplify]") {
+TEST_CASE("Unchop reduces a graph with a self inverting +/- loop", "[simplify]") {
     graph_t graph;
     handle_t n1 = graph.create_handle("CAAATAAG");
     handle_t n2 = graph.create_handle("A");
@@ -96,6 +96,31 @@ TEST_CASE("Graph simplification reduces a graph with a self inverting +/- loop",
         REQUIRE(graph.get_sequence(graph.get_handle(2)) == "TCTTG");
         REQUIRE(graph.has_edge(graph.get_handle(1), graph.get_handle(2)));
         REQUIRE(graph.has_edge(graph.get_handle(1), graph.flip(graph.get_handle(1))));
+    }
+}
+
+TEST_CASE("Unchop reduces a graph that makes a simple loop", "[simplify]") {
+    graph_t graph;
+    handle_t n1 = graph.create_handle("CAAATAAG");
+    handle_t n2 = graph.create_handle("A");
+    handle_t n3 = graph.create_handle("G");
+    handle_t n4 = graph.create_handle("T");
+    handle_t n5 = graph.create_handle("C");
+    handle_t n6 = graph.create_handle("TTG");
+    graph.create_edge(n1, n2);
+    graph.create_edge(n2, n3);
+    graph.create_edge(n3, n4);
+    graph.create_edge(n4, n5);
+    graph.create_edge(n5, n6);
+    graph.create_edge(n6, n1);
+    algorithms::unchop(graph);
+    // sort the graph
+    graph.apply_ordering(algorithms::topological_order(&graph), true);
+    SECTION("The graph is as expected") {
+        REQUIRE(graph.get_sequence(graph.get_handle(1)) == "CAAATAAG");
+        REQUIRE(graph.get_sequence(graph.get_handle(2)) == "AGTCTTG");
+        REQUIRE(graph.has_edge(graph.get_handle(1), graph.get_handle(2)));
+        REQUIRE(graph.has_edge(graph.get_handle(2), graph.get_handle(1)));
     }
 }
 


### PR DESCRIPTION
Avoid infinite loops when looking for the start and end of cyclic simple components.