### PR TITLE
Color paths by pattern

### DIFF
--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -65,14 +65,20 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
   Use red and blue coloring to display forward and reverse alignments. This parameter can be set in combination with
   [*-A, --alignment-prefix*=_STRING_].
 
-*-p, --paths-to-display*::
-  List of paths to display in the specified order; the file must contain one path name per line and a subset of all
-  paths can be specified.
-
 *-z, --color-by-mean-inversion-rate*::
-Change the color respect to the node strandness (black for forward, red for reverse); in binned mode (*-b, --binned-mode*),
-change the color respect to the mean inversion rate of the path for each bin, from black (no inversions) to red (bin
-mean inversion rate equals to 1).
+  Change the color respect to the node strandness (black for forward, red for reverse); in binned mode (*-b, --binned-mode*),
+  change the color respect to the mean inversion rate of the path for each bin, from black (no inversions) to red (bin
+  mean inversion rate equals to 1).
+
+*-s, --color-by-prefix*::
+  Colors paths by their names looking at the prefix before the given character C.
+
+
+=== Paths selection
+
+*-p, --paths-to-display*::
+List of paths to display in the specified order; the file must contain one path name per line and a subset of all
+paths can be specified.
 
 
 === Path names visualization Options

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -124,10 +124,10 @@ namespace odgi {
             return 1;
         }
 
-        if (args::get(show_strands) + args::get(white_to_black) + args::get(color_by_mean_coverage)  + args::get(color_by_mean_inversion_rate) > 1) {
+        if ((args::get(_color_by_prefix) != 0) + args::get(show_strands) + args::get(white_to_black) + args::get(color_by_mean_coverage) + args::get(color_by_mean_inversion_rate) > 1) {
             std::cerr
                     << "[odgi viz] error: Please specify only one of the following options: "
-                       "-S/--show-strand, -u/--white-to-black, "
+                       "-s/--color-by-prefix, -S/--show-strand, -u/--white-to-black, "
                        "-m/--color-by-mean-coverage, and -z/--color-by-mean-inversion."
                     << std::endl;
             return 1;

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -54,7 +54,7 @@ namespace odgi {
         args::Flag show_strands(parser, "bool","use reds and blues to show forward and reverse alignments",{'S', "show-strand"});
         args::Flag color_by_mean_inversion_rate(parser, "color-by-mean-inversion-rate", "change the color respect to the node strandness (black for forward, red for reverse); in binned mode, change the color respect to the mean inversion rate of the path for each bin, from black (no inversions) to red (bin mean inversion rate equals to 1)", {'z', "color-by-mean-inversion-rate"});
 
-        args::ValueFlag<char> _color_by_prefix_before_separator(parser, "STRING", "colors paths by their names looking at the prefix before the specified separator",{'s', "separator-before-prefix"});
+        args::ValueFlag<char> _color_by_prefix(parser, "C", "colors paths by their names looking at the prefix before the given character C",{'s', "color-by-prefix"});
 
         /// Horizontal selection
         args::ValueFlag<std::string> path_names_file(parser, "FILE", "list of paths to display in the specified order; the file must contain one path name per line and a subset of all paths can be specified.", {'p', "paths-to-display"});
@@ -347,8 +347,8 @@ namespace odgi {
         }
 
         char path_name_prefix_separator = '\0';
-        if (_color_by_prefix_before_separator) {
-            path_name_prefix_separator = args::get(_color_by_prefix_before_separator);
+        if (_color_by_prefix) {
+            path_name_prefix_separator = args::get(_color_by_prefix);
         }
 
         auto add_point = [&](const uint64_t &_x, const uint64_t &_y,
@@ -561,7 +561,7 @@ namespace odgi {
                 }
                 // use a sha256 to get a few bytes that we'll use for a color
                 picosha2::byte_t hashed[picosha2::k_digest_size];
-                if (_color_by_prefix_before_separator) {
+                if (_color_by_prefix) {
                     std::string path_name_prefix = prefix(path_name, path_name_prefix_separator);
                     picosha2::hash256(path_name_prefix.begin(), path_name_prefix.end(), hashed, hashed + picosha2::k_digest_size);
                 } else {

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -56,7 +56,7 @@ namespace odgi {
 
         args::ValueFlag<char> _color_by_prefix(parser, "C", "colors paths by their names looking at the prefix before the given character C",{'s', "color-by-prefix"});
 
-        /// Horizontal selection
+        /// Paths selection
         args::ValueFlag<std::string> path_names_file(parser, "FILE", "list of paths to display in the specified order; the file must contain one path name per line and a subset of all paths can be specified.", {'p', "paths-to-display"});
 
         /// Path names


### PR DESCRIPTION
This PR introduces the `-s[C], --color-by-prefix=[C]` option to color paths by their names looking at the prefix before the given character C.

This colouring can be useful for quickly visualizing the paths of different strains in the same (and big) pangenome.

**Tiny mock example**

```
odgi build -g two_strains.gfa -o - | odgi viz -i - -o two_strains.png
```
![image](https://user-images.githubusercontent.com/62253982/99289704-969e3980-283d-11eb-8022-76cbd8e110fd.png)


```
odgi build -g two_strains.gfa -o - | odgi viz -i - -o two_strains.s.png -s '#'
```
![image](https://user-images.githubusercontent.com/62253982/99289733-a0c03800-283d-11eb-8bf6-b80661824bf2.png)


```
odgi build -g two_strains.gfa -o - | odgi viz -i - -o two_strains.s.R.png -s '#' -R
```
![image](https://user-images.githubusercontent.com/62253982/99289769-b2a1db00-283d-11eb-9b3f-a9dccfa6bf35.png)

@Flavia95 and @ezcn, pangenomes as you've never seen them.