### PR TITLE
odgi viz longer path names

### DIFF
--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -84,13 +84,14 @@ paths can be specified.
 === Path names visualization Options
 
 *-H, --hide-path-names*::
-Hide the path names on the left of the generated image.
+  Hide the path names on the left of the generated image.
 
 *-C, --color-path-names-background*::
-Color path names background with the same color as paths
+  Color path names background with the same color as paths
 
 *-c, --max-num-of-characters*::
-Maximum number of characters to display for each path name. The default value is _20_.
+  Maximum number of characters to display for each path name (max 128 characters). The default value is
+  _the length of the longest path name_ (up to 128 characters).
 
 
 === Binned Mode Options

--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -91,7 +91,7 @@ paths can be specified.
 
 *-c, --max-num-of-characters*::
   Maximum number of characters to display for each path name (max 128 characters). The default value is
-  _the length of the longest path name_ (up to 128 characters).
+  _the length of the longest path name_ (up to 32 characters).
 
 
 === Binned Mode Options

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -198,7 +198,7 @@ namespace odgi {
         });
         position_map[position_map.size() - 1] = len;
 
-        uint64_t max_num_of_characters = args::get(_max_num_of_characters) > 1 ? min(args::get(_max_num_of_characters), (uint64_t) PATH_NAMES_MAX_NUM_OF_CHARACTERS) : 20;
+        uint64_t max_num_of_characters = args::get(_max_num_of_characters) > 1 ? min(args::get(_max_num_of_characters), (uint64_t) PATH_NAMES_MAX_NUM_OF_CHARACTERS) : PATH_NAMES_MAX_NUM_OF_CHARACTERS;
         uint64_t path_count = graph.get_path_count();
         uint64_t pix_per_path = args::get(path_height) ? args::get(path_height) : 10;
         uint64_t pix_per_link = std::max((uint64_t) 1, (uint64_t) std::round(args::get(link_path_pieces) * pix_per_path));

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -198,7 +198,7 @@ namespace odgi {
         });
         position_map[position_map.size() - 1] = len;
 
-        uint64_t max_num_of_characters = args::get(_max_num_of_characters) > 1 ? min(args::get(_max_num_of_characters), (uint64_t) PATH_NAMES_MAX_NUM_OF_CHARACTERS) : PATH_NAMES_MAX_NUM_OF_CHARACTERS;
+        uint64_t max_num_of_characters = args::get(_max_num_of_characters) > 1 ? min(args::get(_max_num_of_characters), (uint64_t) PATH_NAMES_MAX_NUM_OF_CHARACTERS) : 32;
         uint64_t path_count = graph.get_path_count();
         uint64_t pix_per_path = args::get(path_height) ? args::get(path_height) : 10;
         uint64_t pix_per_link = std::max((uint64_t) 1, (uint64_t) std::round(args::get(link_path_pieces) * pix_per_path));


### PR DESCRIPTION
By default, display a number of characters equal to the length of the longest path name, up to 32 characters. Users can go further up to 128 characters.