### PR TITLE
parallel apply ordering

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -73,3 +73,9 @@
 [submodule "deps/dirtyzipf"]
 	path = deps/dirtyzipf
 	url = https://github.com/ekg/dirtyzipf.git
+[submodule "deps/paryfor"]
+	path = deps/paryfor
+	url = https://github.com/ekg/paryfor.git
+[submodule "deps/atomicbitvector"]
+	path = deps/atomicbitvector
+	url = https://github.com/ekg/atomicbitvector.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -73,9 +73,6 @@
 [submodule "deps/dirtyzipf"]
 	path = deps/dirtyzipf
 	url = https://github.com/ekg/dirtyzipf.git
-[submodule "deps/paryfor"]
-	path = deps/paryfor
-	url = https://github.com/ekg/paryfor.git
 [submodule "deps/atomicbitvector"]
 	path = deps/atomicbitvector
 	url = https://github.com/ekg/atomicbitvector.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,16 +298,6 @@ ExternalProject_Add(xoshiro
 ExternalProject_Get_property(xoshiro SOURCE_DIR)
 set(xoshiro_INCLUDE "${SOURCE_DIR}")
 
-# paryfor parallel_for
-ExternalProject_Add(paryfor
-  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/paryfor"
-  UPDATE_COMMAND ""
-  INSTALL_COMMAND ""
-  BUILD_COMMAND ""
-  CONFIGURE_COMMAND "")
-ExternalProject_Get_property(paryfor SOURCE_DIR)
-set(paryfor_INCLUDE "${SOURCE_DIR}")
-
 ExternalProject_Add(atomicbitvector
         SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/atomicbitvector/include"
         UPDATE_COMMAND ""
@@ -446,8 +436,7 @@ set(odgi_DEPS
     mmmulti
     ips4o
     xoshiro
-    atomicqueue
-    paryfor)
+    atomicqueue)
 add_dependencies(odgi_objs ${odgi_DEPS})
 
 set(odgi_INCLUDES
@@ -479,7 +468,6 @@ set(odgi_INCLUDES
   "${random_distributions_INCLUDE}"
   "${dirtyzipf_INCLUDE}"
   "${xoshiro_INCLUDE}"
-  "${paryfor_INCLUDE}"
   "${atomicbitvector_INCLUDE}")
 
 set(odgi_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -298,6 +298,25 @@ ExternalProject_Add(xoshiro
 ExternalProject_Get_property(xoshiro SOURCE_DIR)
 set(xoshiro_INCLUDE "${SOURCE_DIR}")
 
+# paryfor parallel_for
+ExternalProject_Add(paryfor
+  SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/paryfor"
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND ""
+  CONFIGURE_COMMAND "")
+ExternalProject_Get_property(paryfor SOURCE_DIR)
+set(paryfor_INCLUDE "${SOURCE_DIR}")
+
+ExternalProject_Add(atomicbitvector
+        SOURCE_DIR "${CMAKE_SOURCE_DIR}/deps/atomicbitvector/include"
+        UPDATE_COMMAND ""
+        INSTALL_COMMAND ""
+        BUILD_COMMAND ""
+        CONFIGURE_COMMAND "")
+ExternalProject_Get_property(atomicbitvector SOURCE_DIR)
+set(atomicbitvector_INCLUDE "${SOURCE_DIR}")
+
 # pybind11
 #ExternalProject_Add(pybind11
 #    GIT_REPOSITORY https://github.com/pybind/pybind11.git 
@@ -427,7 +446,8 @@ set(odgi_DEPS
     mmmulti
     ips4o
     xoshiro
-    atomicqueue)
+    atomicqueue
+    paryfor)
 add_dependencies(odgi_objs ${odgi_DEPS})
 
 set(odgi_INCLUDES
@@ -458,7 +478,9 @@ set(odgi_INCLUDES
   "${httplib_INCLUDE}"
   "${random_distributions_INCLUDE}"
   "${dirtyzipf_INCLUDE}"
-  "${xoshiro_INCLUDE}")
+  "${xoshiro_INCLUDE}"
+  "${paryfor_INCLUDE}"
+  "${atomicbitvector_INCLUDE}")
 
 set(odgi_LIBS
   "${sdsl-lite_LIB}/libsdsl.a"

--- a/docs/asciidocs/odgi_build.adoc
+++ b/docs/asciidocs/odgi_build.adoc
@@ -52,8 +52,8 @@ The odgi build(1) command constructs a succinct variation graph from a GFA. Curr
 *-w, --warnings*::
   Turn on script warnings (applies to executed code).
 
-*-t, --timings*::
-  Print timings report to stderr (time to read, parse, and convert).
+*-t, --threads*=_N_::
+  Number of threads to use for the parallel operations.
 
 === Program Information
 

--- a/docs/asciidocs/odgi_chop.adoc
+++ b/docs/asciidocs/odgi_chop.adoc
@@ -38,7 +38,7 @@ The odgi chop(1) command chops long nodes into short ones while preserving the g
 === Threading
 
 *-t, --threads*=_N_::
-Number of threads to use for the parallel sorter.
+  Number of threads to use for the parallel operations.
 
 === Processing Information
 

--- a/docs/asciidocs/odgi_sort.adoc
+++ b/docs/asciidocs/odgi_sort.adoc
@@ -207,7 +207,7 @@ pipeline of sorts within one parameter.
 === Threading
 
 *-t, --threads*=_N_::
-  Number of threads to use for parallel sorting in SGD. Only specify this argument in combination with *-S, --linear-sgd*. No multi-threading support for any other sorting algorithm.
+  Number of threads to use for the parallel operations.
 
 === Processing Information
 

--- a/docs/asciidocs/odgi_unchop.adoc
+++ b/docs/asciidocs/odgi_unchop.adoc
@@ -37,6 +37,12 @@ The odgi unchop(1) command merges each unitig into a single node preserving the 
 Print information about the process to stderr.
 
 
+=== Threading
+
+*-t, --threads*=_N_::
+Number of threads to use for the parallel operations.
+
+
 === Program Information
 
 *-h, --help*::

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -832,8 +832,8 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
                 bool from_left_else_right = (idx & 1);
 
                 auto& p = path_metadata_v[idx];
-                step_handle_t step = from_left_else_right ? p.first : p.last;
-                step_handle_t xxx_step = from_left_else_right ? p.last : p.first;
+                step_handle_t* step = from_left_else_right ? &p.first : &p.last;
+                step_handle_t* xxx_step = from_left_else_right ? &p.last : &p.first;
 
                 path_handle_t new_path = ordered.get_path_handle(p.name);
                 auto& p_ordered = ordered.path_metadata_v[as_integer(new_path)-1];
@@ -841,7 +841,7 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
                 int64_t prec_xxx_handle_num = -1;
 
                 do {
-                    handle_t old_handle = as_handle(as_integers(step)[0]);
+                    handle_t old_handle = as_handle(as_integers(*step)[0]);
                     uint64_t xxx_handle_num = number_bool_packing::unpack_number(old_handle) - min_handle_rank;
 
                     handle_t new_handle = ordered.get_handle(
@@ -911,16 +911,16 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
 
                     if (from_left_else_right) {
                         // in circular paths, we'll always have a next step, so we always check if we're at our path's last step
-                        if (step != xxx_step && has_next_step(step)) {
-                            step = get_next_step(step);
+                        if (step != xxx_step && has_next_step(*step)) {
+                            *step = get_next_step(*step);
 
                             prec_xxx_handle_num = xxx_handle_num;
                         } else {
                             break;
                         }
                     } else {
-                        if (step != xxx_step && has_previous_step(step)) {
-                            step = get_previous_step(step);
+                        if (step != xxx_step && has_previous_step(*step)) {
+                            *step = get_previous_step(*step);
 
                             prec_xxx_handle_num = xxx_handle_num;
                         } else {

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -36,17 +36,17 @@ void graph_t::set_id_increment(const nid_t& min_id) {
 void graph_t::increment_node_ids(nid_t increment) {
     _id_increment += increment;
 }
-    
+
 /// Get the orientation of a handle
 bool graph_t::get_is_reverse(const handle_t& handle) const {
     return number_bool_packing::unpack_bit(handle);
 }
-    
+
 /// Invert the orientation of a handle (potentially without getting its ID)
 handle_t graph_t::flip(const handle_t& handle) const {
     return number_bool_packing::toggle_bit(handle);
 }
-    
+
 /// Get the length of a node
 size_t graph_t::get_length(const handle_t& handle) const {
     return node_v.at(number_bool_packing::unpack_number(handle)).sequence_size();
@@ -124,23 +124,23 @@ bool graph_t::for_each_handle_impl(const std::function<bool(const handle_t&)>& i
 size_t graph_t::get_node_count(void) const {
     return node_v.size()-_deleted_node_count;
 }
-    
+
 /// Return the smallest ID in the graph, or some smaller number if the
 /// smallest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t graph_t::min_node_id(void) const {
     return _min_node_id;
 }
-    
+
 /// Return the largest ID in the graph, or some larger number if the
 /// largest ID is unavailable. Return value is unspecified if the graph is empty.
 nid_t graph_t::max_node_id(void) const {
     return _max_node_id;
 }
-    
+
 ////////////////////////////////////////////////////////////////////////////
 // Additional optional interface with a default implementation
 ////////////////////////////////////////////////////////////////////////////
-    
+
 /// Get the number of edges on the right (go_left = false) or left (go_left
 /// = true) side of the given handle. The default implementation is O(n) in
 /// the number of edges returned, but graph implementations that track this
@@ -165,22 +165,22 @@ handle_t graph_t::forward(const handle_t& handle) const {
 edge_t graph_t::edge_handle(const handle_t& left, const handle_t& right) const {
     return std::make_pair(left, right);
 }
-    
+
 /**
  * This is the interface for a handle graph that stores embedded paths.
  */
-    
+
 ////////////////////////////////////////////////////////////////////////////
 // Path handle interface that needs to be implemented
 ////////////////////////////////////////////////////////////////////////////
-    
+
 /// Determine if a path name exists and is legal to get a path handle for.
 bool graph_t::has_path(const std::string& path_name) const {
     auto f = path_name_map.find(path_name);
     if (f == path_name_map.end()) return false;
     else return true;
 }
-    
+
 /// Look up the path handle for the given path name.
 /// The path with that name must exist.
 path_handle_t graph_t::get_path_handle(const std::string& path_name) const {
@@ -193,7 +193,7 @@ path_handle_t graph_t::get_path_handle(const std::string& path_name) const {
 std::string graph_t::get_path_name(const path_handle_t& path_handle) const {
     return path_metadata_v.at(as_integer(path_handle)-1).name;
 }
-    
+
 /// Returns the number of node steps in the path
 size_t graph_t::get_step_count(const path_handle_t& path_handle) const {
     return path_metadata_v.at(as_integer(path_handle)-1).length;
@@ -203,7 +203,7 @@ size_t graph_t::get_step_count(const path_handle_t& path_handle) const {
 size_t graph_t::get_path_count(void) const {
     return _path_count;
 }
-    
+
 /// Execute a function on each path in the graph
 bool graph_t::for_each_path_handle_impl(const std::function<bool(const path_handle_t&)>& iteratee) const {
     bool flag = true;
@@ -268,7 +268,7 @@ path_handle_t graph_t::get_path(const step_handle_t& step_handle) const {
 step_handle_t graph_t::path_begin(const path_handle_t& path_handle) const {
     return path_metadata_v.at(as_integer(path_handle)-1).first;
 }
-    
+
 /// Get a handle to the last step in a path
 /// The path MUST be nonempty.
 step_handle_t graph_t::path_back(const path_handle_t& path_handle) const {
@@ -300,13 +300,13 @@ bool graph_t::get_is_circular(const path_handle_t& path_handle) const {
 void graph_t::set_circularity(const path_handle_t& path_handle, bool circular) {
     path_metadata_v.at(as_integer(path_handle)-1).is_circular = circular;
 }
-    
+
 /// Returns true if the step is not the last step on the path, else false
 bool graph_t::has_next_step(const step_handle_t& step_handle) const {
     const node_t& node = node_v.at(number_bool_packing::unpack_number(get_handle_of_step(step_handle)));
     return node.get_path_step(as_integers(step_handle)[1]).next_id() != path_end_marker;
 }
-    
+
 /// Returns true if the step is not the first step on the path, else false
 bool graph_t::has_previous_step(const step_handle_t& step_handle) const {
     const node_t& node = node_v.at(number_bool_packing::unpack_number(get_handle_of_step(step_handle)));
@@ -380,7 +380,7 @@ path_handle_t graph_t::get_path_handle_of_step(const step_handle_t& step_handle)
     auto& step = node.get_path_step(as_integers(step_handle)[1]);
     return as_path_handle(step.path_id());
 }
-    
+
 ////////////////////////////////////////////////////////////////////////////
 // Additional optional interface with a default implementation
 ////////////////////////////////////////////////////////////////////////////
@@ -419,7 +419,7 @@ void graph_t::for_each_step_in_path(const path_handle_t& path, const std::functi
         }
     } while (keep_going);
 }
-    
+
 /// Create a new node with the given sequence and return the handle.
 handle_t graph_t::create_handle(const std::string& sequence) {
     // get first deleted node to recycle
@@ -474,7 +474,7 @@ handle_t graph_t::create_handle(const std::string& sequence, const nid_t& id) {
     // return handle
     return number_bool_packing::pack(handle_rank, 0);
 }
-    
+
 /// Remove the node belonging to the given handle and all of its edges.
 /// Does not update any stored paths.
 /// Invalidates the destroyed handle.
@@ -531,7 +531,7 @@ void graph_t::rebuild_id_handle_mapping(void) {
     _deleted_node_count = 0;
 }
 */
-    
+
 /// Create an edge connecting the given handles in the given order and orientations.
 /// Ignores existing edges.
 void graph_t::create_edge(const handle_t& left_h, const handle_t& right_h) {
@@ -547,7 +547,7 @@ void graph_t::create_edge(const handle_t& left_h, const handle_t& right_h) {
     uint64_t right_rank = number_bool_packing::unpack_number(right_h);
     uint64_t right_relative = edge_to_delta(right_h, left_h);
     uint64_t left_relative = edge_to_delta(left_h, right_h);
-    
+
     // insert the edge for each side
     auto& left_node = node_v.at(left_rank);
     left_node.add_edge(left_relative,
@@ -622,7 +622,7 @@ void graph_t::destroy_edge(const handle_t& left_h, const handle_t& right_h) {
             to_curr ^= 1;
         }
         if (other_id == right_node_id && other_rev == right_rev) {
-            left_node.remove_edge((i-2)/2); //convert to edge rank 
+            left_node.remove_edge((i-2)/2); //convert to edge rank
             found_edge = true;
             break;
         }
@@ -648,7 +648,7 @@ void graph_t::destroy_edge(const handle_t& left_h, const handle_t& right_h) {
 
     _edge_count -= found_edge;
 }
-        
+
 /// Remove all nodes and edges. Does not update any stored paths.
 void graph_t::clear(void) {
     suc_bv null_bv;
@@ -674,7 +674,7 @@ void graph_t::clear_paths(void) {
     path_metadata_v.clear();
     path_name_map.clear();
 }
-    
+
 /// Swap the nodes corresponding to the given handles, in the ordering used
 /// by for_each_handle when looping over the graph. Other handles to the
 /// nodes being swapped must not be invalidated. If a swap is made while
@@ -770,7 +770,7 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
     }
     // edges
     for (auto& handle : *order) {
-        node_t& node = node_v.at(number_bool_packing::unpack_number(handle));        
+        node_t& node = node_v.at(number_bool_packing::unpack_number(handle));
         follow_edges(handle, false, [&](const handle_t& h) {
                 ordered.create_edge(
                         ordered.get_handle(
@@ -818,13 +818,16 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
         0, path_metadata_v.size(), 16,
         [&](uint64_t idx, int tid) {
             if (path_metadata_v[idx].length > 0) {
+                bool from_left_else_right = (tid % 2 == 0);
+
                 auto& p = path_metadata_v.at(idx);
+                step_handle_t step = from_left_else_right ? p.first : p.last;
+                step_handle_t xxx_step = from_left_else_right ? p.last : p.first;
+
                 path_handle_t new_path = ordered.get_path_handle(p.name);
+                auto& p_ordered = ordered.path_metadata_v[as_integer(new_path)-1];
 
-                step_handle_t step = p.first;
-                step_handle_t end_step = p.last;
-
-                int64_t prec_xxx_handle_num = - 1;
+                int64_t prec_xxx_handle_num = -1;
 
                 do {
                     handle_t old_handle = as_handle(as_integers(step)[0]);
@@ -856,20 +859,64 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
                         std::this_thread::sleep_for(std::chrono::nanoseconds(1));
                     } while (true);
 
-                    ordered.append_step(new_path, new_handle);
+                    //////
+                    //ordered.append_step(new_path, new_handle);
 
+                    // create the new step
+                    step_handle_t new_step = ordered.create_step(new_path, new_handle);
+                    if (from_left_else_right) {
+                        if (!p_ordered.length) {
+                            p_ordered.first = new_step;
+                        } else {
+                            step_handle_t last_step = p_ordered.last;
+
+                            // link it to the last step
+                            ordered.link_steps(last_step, new_step);
+                        }
+
+                        // point to the new last step
+                        p_ordered.last = new_step;
+                    } else {
+                        if (!p_ordered.length) {
+                            p_ordered.last = new_step;
+                        } else {
+                            step_handle_t first_step = p_ordered.first;
+
+                            // link it to the last step
+                            ordered.link_steps(new_step, first_step);
+                        }
+
+                        // point to the new last step
+                        p_ordered.first = new_step;
+                    }
+
+                    // update our step count
+                    ++p_ordered.length;
+                    //////
+
+                    // Unlock
                     if (prec_xxx_handle_num >= 0){
                         node_unavailable.reset(prec_xxx_handle_num);
                     }
                     node_unavailable.reset(xxx_handle_num);
 
-                    // in circular paths, we'll always have a next step, so we always check if we're at our path's last step
-                    if (step != end_step && has_next_step(step)) {
-                        step = get_next_step(step);
+                    if (from_left_else_right) {
+                        // in circular paths, we'll always have a next step, so we always check if we're at our path's last step
+                        if (step != xxx_step && has_next_step(step)) {
+                            step = get_next_step(step);
 
-                        prec_xxx_handle_num = xxx_handle_num;
+                            prec_xxx_handle_num = xxx_handle_num;
+                        } else {
+                            break;
+                        }
                     } else {
-                        break;
+                        if (step != xxx_step && has_previous_step(step)) {
+                            step = get_previous_step(step);
+
+                            prec_xxx_handle_num = xxx_handle_num;
+                        } else {
+                            break;
+                        }
                     }
                 } while (true);
             }
@@ -992,7 +1039,7 @@ void graph_t::set_handle_sequence(const handle_t& handle, const std::string& seq
     assert(seq.size());
     node_v[number_bool_packing::unpack_number(handle)].set_sequence(seq);
 }
-    
+
 /// Split a handle's underlying node at the given offsets in the handle's
 /// orientation. Returns all of the handles to the parts. Other handles to
 /// the node being split may be invalidated. The split pieces stay in the
@@ -1150,7 +1197,7 @@ handle_t graph_t::combine_handles(const std::vector<handle_t>& handles) {
  * MutablePathMutableHandleGraph interface.
  * TODO: This is a very limited interface at the moment. It will probably need to be extended.
  */
-    
+
 /**
  * Destroy the given path. Invalidates handles to the path and its node steps.
  */
@@ -1393,7 +1440,7 @@ std::pair<step_handle_t, step_handle_t> graph_t::rewrite_segment(const step_hand
     auto& path_meta = path_metadata_v[as_integer(path)-1];
     // step destruction simply zeros out our step data
     // a final removal of the deleted steps requires a call to graph_t::optimize
-    
+
     for (auto& step : steps) {
         destroy_step(step);
     }

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -804,6 +804,11 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
                 });
         });*/
 
+    // Create paths first to avoid race conditions later
+    for (auto &p : path_metadata_v) {
+        ordered.create_path_handle(p.name);
+    }
+
     std::mutex node_unavailable_mutex;
     atomicbitvector::atomic_bv_t node_unavailable(ids.size());
 
@@ -812,7 +817,7 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
         [&](uint64_t idx, int tid) {
             if (path_metadata_v[idx].length > 0) {
                 auto& p = path_metadata_v.at(idx);
-                path_handle_t new_path = ordered.create_path_handle(p.name);
+                path_handle_t new_path = ordered.get_path_handle(p.name);
 
                 step_handle_t step = p.first;
                 step_handle_t end_step = p.last;

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -827,8 +827,13 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
                 int64_t prec_xxx_handle_num = - 1;
 
                 do {
-                    handle_t old_handle =  as_handle(as_integers(step)[0]);
+                    handle_t old_handle = as_handle(as_integers(step)[0]);
                     uint64_t xxx_handle_num = number_bool_packing::unpack_number(old_handle) - min_handle_rank;
+
+                    handle_t new_handle = ordered.get_handle(
+                            ids[xxx_handle_num],
+                            number_bool_packing::unpack_bit(old_handle)
+                    );
 
                     // Lock the current step and the previous one (if present or different from the current one)
                     do {
@@ -851,14 +856,7 @@ void graph_t::apply_ordering(const std::vector<handle_t>& order_in, bool compact
                         std::this_thread::sleep_for(std::chrono::nanoseconds(1));
                     } while (true);
 
-                    ordered.append_step(
-                            new_path,
-                            // new_handle
-                            ordered.get_handle(
-                                    ids[xxx_handle_num],
-                                    number_bool_packing::unpack_bit(old_handle)
-                            )
-                    );
+                    ordered.append_step(new_path, new_handle);
 
                     if (prec_xxx_handle_num >= 0){
                         node_unavailable.reset(prec_xxx_handle_num);

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -30,7 +30,7 @@
 #include "hash_map.hpp"
 #include "node.hpp"
 
-#include "paryfor.hpp"
+#include <omp.h>
 #include "atomic_bitvector.hpp"
 #include <mutex>
 

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -299,6 +299,8 @@ public:
     /// Optionally compact the id space of the graph to match the ordering, from 1->|ordering|.
     void apply_ordering(const std::vector<handle_t>& order, bool compact_ids = false);
 
+    void apply_ordering(const vector<handle_t> &order_in, bool compact_ids, uint64_t num_threads);
+
     /// Organize the graph for better performance and memory use
     void optimize(bool allow_id_reassignment = true);
 
@@ -503,7 +505,7 @@ private:
     /// get the backing node rank for a given node id
     uint64_t get_node_rank(const nid_t& node_id) const;
 
-};
+    };
 
 const static uint64_t path_begin_marker = 1;
 const static uint64_t path_end_marker = 2;

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -403,6 +403,8 @@ public:
 
     void set_number_of_threads(uint64_t num_threads);
 
+    uint64_t get_number_of_threads();
+
 /// These are the backing data structures that we use to fulfill the above functions
 
 private:

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -30,6 +30,10 @@
 #include "hash_map.hpp"
 #include "node.hpp"
 
+#include "paryfor.hpp"
+#include "atomic_bitvector.hpp"
+#include <mutex>
+
 namespace odgi {
 
 using namespace handlegraph;

--- a/src/odgi.hpp
+++ b/src/odgi.hpp
@@ -299,8 +299,6 @@ public:
     /// Optionally compact the id space of the graph to match the ordering, from 1->|ordering|.
     void apply_ordering(const std::vector<handle_t>& order, bool compact_ids = false);
 
-    void apply_ordering(const vector<handle_t> &order_in, bool compact_ids, uint64_t num_threads);
-
     /// Organize the graph for better performance and memory use
     void optimize(bool allow_id_reassignment = true);
 
@@ -403,6 +401,8 @@ public:
     /// Load
     void deserialize_members(std::istream& in);
 
+    void set_number_of_threads(uint64_t num_threads);
+
 /// These are the backing data structures that we use to fulfill the above functions
 
 private:
@@ -420,6 +420,8 @@ private:
     nid_t _id_increment = 0;
     /// records nodes that are hidden, but used to compactly store path sequence that has been removed from the node space
     hash_set<uint64_t> graph_id_hidden_set;
+
+    uint64_t _num_threads = 1;
 
     /// edge type conversion
     /// 1 = fwd->fwd, 2 = fwd->rev, 3 = rev->fwd, 4 = rev->rev

--- a/src/subcommand/build_main.cpp
+++ b/src/subcommand/build_main.cpp
@@ -26,6 +26,7 @@ int main_build(int argc, char** argv) {
     args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});
     args::Flag to_gfa(parser, "to_gfa", "write the graph to stdout in GFA format", {'G', "to-gfa"});
     args::Flag toposort(parser, "sort", "apply generalized topological sort to the graph and set node ids to order", {'s', "sort"});
+    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use for parallel operations", {'t', "threads"});
     args::Flag debug(parser, "debug", "enable debugging", {'d', "debug"});
     args::Flag progress(parser, "progress", "show progress updates", {'p', "progress"});
     try {
@@ -63,6 +64,10 @@ int main_build(int argc, char** argv) {
     if (gfa_filename.size()) {
         gfa_to_handle(gfa_filename, &graph, args::get(progress));
     }
+
+    const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+    graph.set_number_of_threads(num_threads);
+
     if (args::get(progress)) {
         std::cerr << std::endl;
     }

--- a/src/subcommand/chop_main.cpp
+++ b/src/subcommand/chop_main.cpp
@@ -23,7 +23,7 @@ int main_chop(int argc, char** argv) {
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> dg_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});
     args::ValueFlag<uint64_t> chop_to(parser, "N", "divide nodes to be shorter than this length", {'c', "chop-to"});
-    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use for the parallel sorter", {'t', "threads"});
+    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use for parallel operations", {'t', "threads"});
     args::Flag debug(parser, "debug", "print information about the process to stderr.", {'d', "debug"});
 
     try {
@@ -69,7 +69,8 @@ int main_chop(int argc, char** argv) {
         }
     }
 
-    uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+    const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+    graph.set_number_of_threads(num_threads);
 
     algorithms::chop(graph, args::get(chop_to), num_threads, args::get(debug));
     

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -85,7 +85,7 @@ int main_sort(int argc, char** argv) {
     args::ValueFlag<std::string> path_delim(parser, "path-delim", "sort paths in bins by their prefix up to this delimiter", {'D', "path-delim"});
     args::Flag progress(parser, "progress", "display progress of the sort", {'P', "progress"});
     args::Flag optimize(parser, "optimize", "use the MutableHandleGraph::optimize method", {'O', "optimize"});
-    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use for parallel sorters (currently only SGD is supported)", {'t', "threads"});
+    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use for parallel operations", {'t', "threads"});
 
     try {
         parser.ParseCLI(argc, argv);
@@ -141,7 +141,10 @@ int main_sort(int argc, char** argv) {
     double sgd_iter_max = args::get(lsgd_iter_max) ? args::get(lsgd_iter_max) : 30;
     double sgd_eps = args::get(lsgd_eps) ? args::get(lsgd_eps) : 0.01;
     double sgd_delta = args::get(lsgd_delta) ? args::get(lsgd_delta) : 0;
-    uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+
+    const uint64_t num_threads = args::get(nthreads) ? args::get(nthreads) : 1;
+    graph.set_number_of_threads(num_threads);
+
     bool sgd_use_paths = args::get(lsgd_use_paths);
     /// path guided linear 1D SGD sort helpers
     // TODO beautify this, maybe put into its own file
@@ -163,6 +166,7 @@ int main_sort(int argc, char** argv) {
                 }
                 return max_path_step_count;
               };
+
     // default parameters
     std::string path_sgd_seed;
     if (p_sgd_seed) {

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -407,6 +407,7 @@ int main_sort(int argc, char** argv) {
                 case 'g': {
                     graph_t groomed;
                     algorithms::groom(graph, groomed, progress);
+                    groomed.set_number_of_threads(graph.get_number_of_threads());
                     graph = groomed;
                     was_groomed = true;
                     break;

--- a/src/subcommand/unchop_main.cpp
+++ b/src/subcommand/unchop_main.cpp
@@ -22,7 +22,7 @@ int main_unchop(int argc, char** argv) {
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> og_in_file(parser, "FILE", "load the graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> og_out_file(parser, "FILE", "store the graph self index in this file", {'o', "out"});
-    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use", {'t', "threads"});
+    args::ValueFlag<uint64_t> nthreads(parser, "N", "number of threads to use for parallel operations", {'t', "threads"});
     args::Flag debug(parser, "debug", "print information about the process to stderr.", {'d', "debug"});
 
     try {
@@ -50,8 +50,6 @@ int main_unchop(int argc, char** argv) {
         return 1;
     }
 
-    const uint64_t num_threads = nthreads ? args::get(nthreads) : 1;
-
     graph_t graph;
     assert(argc > 0);
     std::string infile = args::get(og_in_file);
@@ -64,6 +62,9 @@ int main_unchop(int argc, char** argv) {
             f.close();
         }
     }
+
+    const uint64_t num_threads = nthreads ? args::get(nthreads) : 1;
+    graph.set_number_of_threads(num_threads);
 
     algorithms::unchop(graph, num_threads, args::get(debug));
     


### PR DESCRIPTION
This PR introduces the parallelization of the paths embedding in the `apply_ordering` function. This function is used by the `odgi sort`, `chop`, and `unchop` commands, and each time a sorting step is applied to the graph. The parallelization lead to a speed improvement of ~50/60%. The consensus graph generation in [smoothxg](https://github.com/pangenome/smoothxg) will be a bit happier for that.