### PR TITLE
the path handle are not stable 

### DIFF
--- a/src/algorithms/unchop.cpp
+++ b/src/algorithms/unchop.cpp
@@ -378,6 +378,7 @@ namespace odgi {
                     ok.store(false);
                 }
 
+                std::string().swap(path_names[rank]);
                 std::string().swap(path_sequences[rank]);
             }
 


### PR DESCRIPTION
This avoid a problem which happens for particular paths (like ```Link_Consensus_0_Consensus_0_23_0```, created during the consensus graphs generation), whom handles are not stable after an ```apply_ordering``` step.