### PR TITLE
fixes for smoothxg integration

### DIFF
--- a/src/node.hpp
+++ b/src/node.hpp
@@ -138,6 +138,7 @@ public:
                        const uint64_t& prev_id, const uint64_t& prev_rank,
                        const uint64_t& next_id, const uint64_t& next_rank);
     void set_path_step(const uint64_t& rank, const step_t& step);
+    void clear_path_step(const uint64_t& rank);
     void set_step_path_id(const uint64_t& rank, const uint64_t& path_id);
     void set_step_prev_id(const uint64_t& rank, const uint64_t& prev_id);
     void set_step_prev_rank(const uint64_t& rank, const uint64_t& prev_rank);

--- a/src/odgi.cpp
+++ b/src/odgi.cpp
@@ -1257,7 +1257,7 @@ void graph_t::destroy_step(const step_handle_t& step_handle) {
     --path_meta.length;
     node_t& curr_node = get_node_ref(get_handle_of_step(step_handle));
     curr_node.get_lock();
-    curr_node.set_path_step(as_integers(step_handle)[1], node_t::step_t());
+    curr_node.clear_path_step(as_integers(step_handle)[1]);
     curr_node.clear_lock();
 }
 

--- a/src/unittest/simplify.cpp
+++ b/src/unittest/simplify.cpp
@@ -44,6 +44,44 @@ TEST_CASE("Graph simplification reduces a simple graph to a single node", "[simp
     }
 }
 
+TEST_CASE("Graph simplification reduces a simple graph with paths", "[simplify]") {
+    graph_t graph;
+    handle_t n6 = graph.create_handle("TTG");
+    handle_t n4 = graph.create_handle("T");
+    handle_t n3 = graph.create_handle("G");
+    handle_t n5 = graph.create_handle("C");
+    handle_t n1 = graph.create_handle("CAAATAAG");
+    handle_t n2 = graph.create_handle("A");
+    graph.create_edge(n1, n2);
+    graph.create_edge(n2, n3);
+    graph.create_edge(n3, n4);
+    graph.create_edge(n3, n5);
+    graph.create_edge(n4, n5);
+    graph.create_edge(n5, n6);
+    path_handle_t p_x = graph.create_path_handle("x");
+    path_handle_t p_y = graph.create_path_handle("y");
+    for (auto& p : { p_x, p_y }) {
+        for (auto& h : { n1, n2, n3, n4, n5, n6 }) {
+            graph.append_step(p, h);
+        }
+    }
+    algorithms::unchop(graph);
+    // sort the graph
+    graph.apply_ordering(algorithms::topological_order(&graph), true);
+    graph.apply_ordering(algorithms::topological_order(&graph), true);
+    graph.apply_ordering(algorithms::topological_order(&graph), true);
+    SECTION("The graph is as expected") {
+        REQUIRE(graph.get_sequence(graph.get_handle(1)) == "CAAATAAGAG");
+        REQUIRE(graph.get_node_count() == 3);
+        step_handle_t s = graph.path_begin(p_x);
+        REQUIRE(graph.get_handle_of_step(s) == graph.get_handle(1));
+        s = graph.get_next_step(s);
+        REQUIRE(graph.get_handle_of_step(s) == graph.get_handle(2));
+        s = graph.get_next_step(s);
+        REQUIRE(graph.get_handle_of_step(s) == graph.get_handle(3));
+    }
+}
+
 TEST_CASE("Graph simplification reduces a graph with a self loop", "[simplify]") {
     graph_t graph;
     handle_t n1 = graph.create_handle("CAAATAAG");


### PR DESCRIPTION
First up, a quick fix: leave ghost nodes in our encodings after apply_ordering.

Next, I'll remove them outright, to save space and optimize the space. If that's OK then we'll continue testing in smoothxg.