### PR TITLE
odgi stats with basic info on weakly connected components

### DIFF
--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -5,8 +5,7 @@
 namespace odgi {
     namespace algorithms {
 
-        ska::flat_hash_set<handlegraph::nid_t>
-        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component, const bool& ignore_paths) {
+        ska::flat_hash_set<handlegraph::nid_t> is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component) {
             ska::flat_hash_set<handlegraph::nid_t> head_nodes;
             if (component.empty()) { return head_nodes; }
 
@@ -251,7 +250,7 @@ namespace odgi {
 
             ska::flat_hash_set<handlegraph::nid_t> &component = components[component_id];
             size_t component_size = component.size();
-            ska::flat_hash_set<handlegraph::nid_t> head_nodes = is_nice_and_acyclic(graph, component, ignore_paths);
+            ska::flat_hash_set<handlegraph::nid_t> head_nodes = is_nice_and_acyclic(graph, component);
             bool acyclic = !(head_nodes.empty());
             if (show_progress) {
                 std::cerr << Coverage::name() << ": processing component " << (component_id + 1) << " / "

--- a/src/algorithms/cover.hpp
+++ b/src/algorithms/cover.hpp
@@ -27,7 +27,7 @@ namespace odgi {
           Ignores node ids that are not present in the graph.
         */
         ska::flat_hash_set<handlegraph::nid_t>
-        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component, const bool& ignore_paths);
+        is_nice_and_acyclic(const HandleGraph &graph, const ska::flat_hash_set<handlegraph::nid_t> &component);
 
         /*
           Find a path cover of the graph with num_paths_per_component paths per component, adding the generated paths in

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -8,6 +8,7 @@
 #include <omp.h>
 #include "algorithms/layout.hpp"
 #include "algorithms/weakly_connected_components.hpp"
+#include "cover.hpp"
 
 //#define debug_odgi_stats
 
@@ -142,11 +143,15 @@ int main_stats(int argc, char** argv) {
     if (args::get(weakly_connected_components)) {
         std::vector<ska::flat_hash_set<handlegraph::nid_t>> weak_components = algorithms::weakly_connected_components(&graph);
 
-        std::cout << "##weak_components: " << weak_components.size() << std::endl;
-        std::cout << "#component\tnodes" << std::endl;
+        std::cout << "##weakly_connected_components: " << weak_components.size() << std::endl;
+        std::cout << "#component\tnodes\tis_acyclic" << std::endl;
         for(uint64_t i = 0; i < weak_components.size(); ++i) {
             auto& weak_component = weak_components[i];
-            std::cout << i << "\t" << weak_components[i].size() << std::endl;
+
+            ska::flat_hash_set<handlegraph::nid_t> head_nodes = algorithms::is_nice_and_acyclic(graph, weak_components[i]);
+            bool acyclic = !(head_nodes.empty());
+
+            std::cout << i << "\t" << weak_components[i].size() << "\t" << (acyclic ? "yes" : "no") << std::endl;
         }
     }
 

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -143,7 +143,7 @@ int main_stats(int argc, char** argv) {
     if (args::get(weakly_connected_components)) {
         std::vector<ska::flat_hash_set<handlegraph::nid_t>> weak_components = algorithms::weakly_connected_components(&graph);
 
-        std::cout << "##weakly_connected_components: " << weak_components.size() << std::endl;
+        std::cout << "##num_weakly_connected_components: " << weak_components.size() << std::endl;
         std::cout << "#component\tnodes\tis_acyclic" << std::endl;
         for(uint64_t i = 0; i < weak_components.size(); ++i) {
             auto& weak_component = weak_components[i];

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -7,6 +7,7 @@
 //#include "io_helper.hpp"
 #include <omp.h>
 #include "algorithms/layout.hpp"
+#include "algorithms/weakly_connected_components.hpp"
 
 //#define debug_odgi_stats
 
@@ -28,7 +29,11 @@ int main_stats(int argc, char** argv) {
     args::HelpFlag help(parser, "help", "display this help summary", {'h', "help"});
     args::ValueFlag<std::string> dg_in_file(parser, "FILE", "load the variation graph from this file", {'i', "idx"});
     args::ValueFlag<std::string> layout_in_file(parser, "FILE", "read the layout coordinates from this file", {'c', "coords-in"});
+
     args::Flag summarize(parser, "summarize", "summarize the graph properties and dimensions", {'S', "summarize"});
+
+    args::Flag weakly_connected_components(parser, "show", "shows the properties of the weakly connected components", {'W', "weak-connected-components"});
+
     args::Flag base_content(parser, "base-content", "describe the base content of the graph", {'b', "base-content"});
     args::Flag path_coverage(parser, "coverage", "provide a histogram of path coverage over bases in the graph", {'C', "coverage"});
     args::Flag path_setcov(parser, "setcov", "provide a histogram of coverage over unique sets of paths", {'V', "set-coverage"});
@@ -133,6 +138,18 @@ int main_stats(int argc, char** argv) {
         std::cout << "#length\tnodes\tedges\tpaths" << std::endl;
         std::cout << length_in_bp << "\t" << node_count << "\t" << edge_count << "\t" << path_count << std::endl;
     }
+
+    if (args::get(weakly_connected_components)) {
+        std::vector<ska::flat_hash_set<handlegraph::nid_t>> weak_components = algorithms::weakly_connected_components(&graph);
+
+        std::cout << "##weak_components: " << weak_components.size() << std::endl;
+        std::cout << "#component\tnodes" << std::endl;
+        for(uint64_t i = 0; i < weak_components.size(); ++i) {
+            auto& weak_component = weak_components[i];
+            std::cout << i << "\t" << weak_components[i].size() << std::endl;
+        }
+    }
+
     if (args::get(base_content)) {
         std::vector<uint64_t> chars(256);
         graph.for_each_handle([&](const handle_t& h) {


### PR DESCRIPTION
This PR introduces the `-W/--weak-connected-components` option to show basic information on each weakly connected component in the graph.

**Yeast dataset**
```
odgi stats -i cerevisiae.pan.fa.gz.pggb-s50000-p90-n5-a70-K16-k71-w30000-j5000-e5000.sY.G30.og -W
```

```
##num_weakly_connected_components: 9
#component	nodes	is_acyclic
0	        8412	no
1	        50282	no
2	        12065	no
3	        18746	no
4	        188114	no
5	        34665	no
6	        26353	no
7	        36976	no
8	        30352	no
```