### PR TITLE
odgi viz can visualize a subset of the graph, taking a path range in input

### DIFF
--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -73,11 +73,13 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
 *-s, --color-by-prefix*::
   Colors paths by their names looking at the prefix before the given character C.
 
+
 === Intervals selection
 
 *-r, --pangenomic-range*::
-Nucleotide pangenomic range to visualize: `STRING=start-end`. The nucleotide positions refer to the pangenome's sequence
-(i.e., the sequence obtained arranging all the graph's node from left to right).
+  Nucleotide pangenomic range to visualize: `STRING=start-end`. `\*-end` for `[0,end]`; `start-*` for `[start,pangenome_length]`.
+  The nucleotide positions refer to the pangenome's sequence (i.e., the sequence obtained arranging all the graph's node
+  from left to right).
 
 
 === Paths selection

--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -73,6 +73,12 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
 *-s, --color-by-prefix*::
   Colors paths by their names looking at the prefix before the given character C.
 
+=== Intervals selection
+
+*-r, --pangenomic-range*::
+Nucleotide pangenomic range to visualize: `STRING=start-end`. The nucleotide positions refer to the pangenome's sequence
+(i.e., the sequence obtained arranging all the graph's node from left to right).
+
 
 === Paths selection
 

--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -77,7 +77,7 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
 === Intervals selection
 
 *-r, --pangenomic-range*::
-  Nucleotide pangenomic range to visualize: `STRING=[PATH:]start-end`. `\*-end` for `[0,end]`; `start-*` for `[start,pangenome_length]`.
+  Nucleotide range to visualize: `STRING=[PATH:]start-end`. `\*-end` for `[0,end]`; `start-*` for `[start,pangenome_length]`.
   If no PATH is specified, the nucleotide positions refer to the pangenome's sequence (i.e., the sequence obtained arranging all the graph's node
   from left to right).
 

--- a/docs/asciidocs/odgi_viz.adoc
+++ b/docs/asciidocs/odgi_viz.adoc
@@ -77,8 +77,8 @@ please refer to <<odgi_bin.adoc#_odgi_bin1, odgi bin>>.
 === Intervals selection
 
 *-r, --pangenomic-range*::
-  Nucleotide pangenomic range to visualize: `STRING=start-end`. `\*-end` for `[0,end]`; `start-*` for `[start,pangenome_length]`.
-  The nucleotide positions refer to the pangenome's sequence (i.e., the sequence obtained arranging all the graph's node
+  Nucleotide pangenomic range to visualize: `STRING=[PATH:]start-end`. `\*-end` for `[0,end]`; `start-*` for `[start,pangenome_length]`.
+  If no PATH is specified, the nucleotide positions refer to the pangenome's sequence (i.e., the sequence obtained arranging all the graph's node
   from left to right).
 
 

--- a/src/algorithms/bin_path_info.cpp
+++ b/src/algorithms/bin_path_info.cpp
@@ -168,7 +168,7 @@ namespace odgi {
             if (drop_gap_links) {
                 uint64_t path_count = graph.get_path_count();
 
-                std::cerr << std::setprecision(4) << "Gap links removed: " << (100.0 *  ((double)gap_links_removed / (double)total_links))
+                std::cerr << std::setprecision(4) << "[odgi::bin_path_info] Gap links removed: " << (100.0 *  ((double)gap_links_removed / (double)total_links))
                           << "%, that is " << gap_links_removed << " gap links (" << path_count << " path start links + "
                           << path_count << " path end links + " << (gap_links_removed - path_count * 2) << " inner gap links) of "
                           << total_links << " total links" << std::endl;

--- a/src/algorithms/cover.cpp
+++ b/src/algorithms/cover.cpp
@@ -299,7 +299,7 @@ namespace odgi {
 
                 if (node_coverage.front().second >= min_node_coverage) {
                     if (show_progress) {
-                        std::cerr << "Minimum node coverage reached after generating " << i << " paths." << std::endl;
+                        std::cerr << Coverage::name() << ": minimum node coverage reached after generating " << i << " paths." << std::endl;
                     }
 
                     break;
@@ -340,7 +340,7 @@ namespace odgi {
             }
 
             if ((min_node_coverage != std::numeric_limits<uint64_t>::max()) && (i >= num_paths_per_component)){
-                std::cerr << "Maximum number of generable paths reached." << std::endl;
+                std::cerr << Coverage::name() <<": maximum number of generable paths reached." << std::endl;
             }
 
             if (write_node_covearges) {
@@ -377,7 +377,7 @@ namespace odgi {
                     processed_components++;
 
                     if (show_progress) {
-                        std::cerr << "Processed: " << processed_components << std::endl;
+                        std::cerr << "[odgi::path_cover] Processed: " << processed_components << std::endl;
                     }
                 }
             }

--- a/src/subcommand/bin_main.cpp
+++ b/src/subcommand/bin_main.cpp
@@ -45,7 +45,7 @@ int main_bin(int argc, char** argv) {
     }
 
     if (!dg_in_file) {
-        std::cerr << "[odgi bin] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::bin] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
@@ -82,7 +82,7 @@ int main_bin(int argc, char** argv) {
     // our aggregation matrix
     std::vector<std::pair<std::string, std::vector<algorithms::path_info_t>>> table;
     if (args::get(num_bins) + args::get(bin_width) == 0) {
-        std::cerr << "[odgi bin] error: a bin width or a bin count is required" << std::endl;
+        std::cerr << "[odgi::bin] error: a bin width or a bin count is required" << std::endl;
         return 1;
     }
 

--- a/src/subcommand/break_main.cpp
+++ b/src/subcommand/break_main.cpp
@@ -43,12 +43,12 @@ int main_break(int argc, char** argv) {
     }
 
     if (!odgi_in_file) {
-        std::cerr << "[odgi break] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::break] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!odgi_out_file) {
-        std::cerr << "[odgi break] error: Please specify an output file to where to store the broken graph via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::break] error: please specify an output file to where to store the broken graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
     

--- a/src/subcommand/chop_main.cpp
+++ b/src/subcommand/chop_main.cpp
@@ -42,17 +42,17 @@ int main_chop(int argc, char** argv) {
     }
 
     if (!dg_in_file) {
-        std::cerr << "[odgi chop] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::chop] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!dg_out_file) {
-        std::cerr << "[odgi chop] error: Please specify an output file to where to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::chop] error: please specify an output file to where to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
 
     if (!chop_to) {
-        std::cerr << "[odgi chop] error: Please specify a node chop length via -c=[N], --chop-to=[N]." << std::endl;
+        std::cerr << "[odgi::chop] error: please specify a node chop length via -c=[N], --chop-to=[N]." << std::endl;
         return 1;
     }
 

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -94,11 +94,11 @@ namespace odgi {
         uint64_t max_number_of_paths_generable = graph.get_node_count() * 5;
         if (args::get(debug)){
             if (_min_node_coverage) {
-                std::cerr << "There will be generated paths until the minimum node coverage is " << _min_node_coverage
+                std::cerr << "[odgi::cover] there will be generated paths until the minimum node coverage is " << _min_node_coverage
                           << ", or until the maximum number of allowed generated paths is reached ("
                           << max_number_of_paths_generable << ")." << std::endl;
             } else {
-                std::cerr << "There will be generated " << _num_paths_per_component << " paths per component."
+                std::cerr << "[odgi::cover] there will be generated " << _num_paths_per_component << " paths per component."
                           << std::endl;
             }
         }

--- a/src/subcommand/cover_main.cpp
+++ b/src/subcommand/cover_main.cpp
@@ -46,14 +46,14 @@ namespace odgi {
 
         if (!dg_in_file) {
             std::cerr
-                    << "[odgi cover] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+                    << "[odgi::cover] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
                     << std::endl;
             return 1;
         }
 
         if (!dg_out_file) {
             std::cerr
-                    << "[odgi cover] error: please specify an output file to where to store the graph via -o=[FILE], --out=[FILE]."
+                    << "[odgi::cover] error: please specify an output file to where to store the graph via -o=[FILE], --out=[FILE]."
                     << std::endl;
             return 1;
         }
@@ -62,7 +62,7 @@ namespace odgi {
         uint64_t _min_node_coverage = args::get(min_node_coverage);
         if (_num_paths_per_component && _min_node_coverage) {
             std::cerr
-                    << "[odgi cover] error: please specify -n/--num-paths-per-component or -c/--min-node-coverage, not both."
+                    << "[odgi::cover] error: please specify -n/--num-paths-per-component or -c/--min-node-coverage, not both."
                     << std::endl;
             return 1;
         } else if (!_num_paths_per_component && !_min_node_coverage) {
@@ -73,7 +73,7 @@ namespace odgi {
                                                                  : algorithms::PATH_COVER_DEFAULT_K;
         if (_node_window_size < 2) {
             std::cerr
-                    << "[odgi cover] error: please specify a node window size greater than or equal to 2 via -k=[N], --node-window-size=[N]."
+                    << "[odgi::cover] error: please specify a node window size greater than or equal to 2 via -k=[N], --node-window-size=[N]."
                     << std::endl;
             return 1;
         }

--- a/src/subcommand/draw_main.cpp
+++ b/src/subcommand/draw_main.cpp
@@ -64,14 +64,14 @@ int main_draw(int argc, char **argv) {
 
     if (!dg_in_file) {
         std::cerr
-            << "[odgi draw] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+            << "[odgi::draw] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
             << std::endl;
         return 1;
     }
 
     if (!tsv_out_file && !svg_out_file && !png_out_file) {
         std::cerr
-            << "[odgi draw] error: Please specify an output file to where to store the layout via -p/--png=[FILE], -s/--svg=[FILE], -T/--tsv=[FILE]"
+            << "[odgi::draw] error: please specify an output file to where to store the layout via -p/--png=[FILE], -s/--svg=[FILE], -T/--tsv=[FILE]"
             << std::endl;
         return 1;
     }

--- a/src/subcommand/flatten_main.cpp
+++ b/src/subcommand/flatten_main.cpp
@@ -41,7 +41,7 @@ int main_flatten(int argc, char** argv) {
     }
 
     if (!odgi_in_file) {
-        std::cerr << "[odgi flatten] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::flatten] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
@@ -59,7 +59,7 @@ int main_flatten(int argc, char** argv) {
     }
 
     if (args::get(fasta_out_file).empty() && args::get(bed_out_file).empty()) {
-        std::cerr << "[odgi flatten] Error: a FASTA or BED output must be specified" << std::endl;
+        std::cerr << "[odgi::flatten] error: a FASTA or BED output must be specified" << std::endl;
         return 2;
     }
 

--- a/src/subcommand/groom_main.cpp
+++ b/src/subcommand/groom_main.cpp
@@ -40,12 +40,12 @@ int main_groom(int argc, char** argv) {
     }
 
     if (!og_in_file) {
-        std::cerr << "[odgi groom] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::groom] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!og_out_file) {
-        std::cerr << "[odgi groom] error: Please specify an output file to where to store the groomped graph via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::groom] error: please specify an output file to where to store the groomped graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
 

--- a/src/subcommand/layout0_main.cpp
+++ b/src/subcommand/layout0_main.cpp
@@ -90,12 +90,12 @@ int main_layout0(int argc, char** argv) {
     }
 
     if (!dg_in_file) {
-        std::cerr << "[odgi layout0] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::layout0] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!svg_out_file) {
-        std::cerr << "[odgi layout0] error: Please specify an output file to where to store the layout via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::layout0] error: please specify an output file to where to store the layout via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
 

--- a/src/subcommand/layout_main.cpp
+++ b/src/subcommand/layout_main.cpp
@@ -105,14 +105,14 @@ int main_layout(int argc, char **argv) {
 
     if (!dg_in_file) {
         std::cerr
-            << "[odgi layout] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+            << "[odgi::layout] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
             << std::endl;
         return 1;
     }
 
     if (!layout_out_file && !svg_out_file && !png_out_file && !tsv_out_file) {
         std::cerr
-            << "[odgi layout] error: Please specify an output file to where to store the layout via -o/--out=[FILE], -p/--png=[FILE], -s/--svg=[FILE], -T/--tsv=[FILE]"
+            << "[odgi::layout] error: please specify an output file to where to store the layout via -o/--out=[FILE], -p/--png=[FILE], -s/--svg=[FILE], -T/--tsv=[FILE]"
             << std::endl;
         return 1;
     }
@@ -163,7 +163,7 @@ int main_layout(int argc, char **argv) {
     if (p_sgd_seed) {
         if (num_threads > 1) {
             std::cerr
-                << "[odgi layout] Error: Please only specify a seed for the path guided 2D linear SGD when using 1 thread."
+                << "[odgi::layout] error: please only specify a seed for the path guided 2D linear SGD when using 1 thread."
                 << std::endl;
             return 1;
         }
@@ -173,7 +173,7 @@ int main_layout(int argc, char **argv) {
     }
     if (p_sgd_min_term_updates_paths && p_sgd_min_term_updates_num_nodes) {
         std::cerr
-            << "[odgi layout] Error: There can only be one argument provided for the minimum number of term updates in the path guided 1D SGD."
+            << "[odgi::layout] error: there can only be one argument provided for the minimum number of term updates in the path guided 1D SGD."
             "Please either use -G=[N], path-sgd-min-term-updates-paths=[N] or -U=[N], path-sgd-min-term-updates-nodes=[N]."
             << std::endl;
         return 1;
@@ -216,7 +216,7 @@ int main_layout(int argc, char **argv) {
             if (graph.has_path(buf)) {
                 path_sgd_use_paths.push_back(graph.get_path_handle(buf));
             } else {
-                std::cerr << "[odgi layout] Error: Path '" << buf
+                std::cerr << "[odgi::layout] error: path '" << buf
                           << "' as was given by -f=[FILE], --path-sgd-use-paths=[FILE]"
                     " is not present in the graph. Please remove this path from the file and restart 'odgi sort'.";
             }
@@ -282,7 +282,7 @@ int main_layout(int argc, char **argv) {
     graph.for_each_handle([&](const handle_t &h) {
           nid_t node_id = graph.get_id(h);
           if (node_id - last_node_id > 1) {
-              std::cerr << "[odgi layout] error: The graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
+              std::cerr << "[odgi::layout] error: the graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
               exit(1);
           }
           last_node_id = node_id;

--- a/src/subcommand/matrix_main.cpp
+++ b/src/subcommand/matrix_main.cpp
@@ -38,7 +38,7 @@ int main_matrix(int argc, char** argv) {
     }
 
     if (!dg_in_file) {
-        std::cerr << "[odgi matrix] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::matrix] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 

--- a/src/subcommand/normalize_main.cpp
+++ b/src/subcommand/normalize_main.cpp
@@ -42,12 +42,12 @@ int main_normalize(int argc, char** argv) {
     }
 
     if (!og_in_file) {
-        std::cerr << "[odgi normalize] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::normalize] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!og_out_file) {
-        std::cerr << "[odgi normalize] error: Please specify an output file to where to store the unchopped graph via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::normalize] error: please specify an output file to where to store the unchopped graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
 

--- a/src/subcommand/panpos_main.cpp
+++ b/src/subcommand/panpos_main.cpp
@@ -38,15 +38,15 @@ namespace odgi {
         }
 
         if (!dg_in_file) {
-            std::cerr << "[odgi panpos] error: Please enter a file to read the index from via -i=[FILE], --idx=[FILE]." << std::endl;
+            std::cerr << "[odgi::panpos] error: please enter a file to read the index from via -i=[FILE], --idx=[FILE]." << std::endl;
             exit(1);
         }
         if (!path_name) {
-            std::cerr << "[odgi panpos] error: Please enter a valid path name to extract the pangenome position from via -p=[STRING], --path=[STRING]." << std::endl;
+            std::cerr << "[odgi::panpos] error: please enter a valid path name to extract the pangenome position from via -p=[STRING], --path=[STRING]." << std::endl;
             exit(1);
         }
         if (!nuc_pos) {
-            std::cerr << "[odgi panpos] error: Please enter a valid nucleotide position to extract the corresponding pangenome position from -n=[N], --nuc-pos=[N]." << std::endl;
+            std::cerr << "[odgi::panpos] error: please enter a valid nucleotide position to extract the corresponding pangenome position from -n=[N], --nuc-pos=[N]." << std::endl;
             exit(1);
         }
 

--- a/src/subcommand/pathindex_main.cpp
+++ b/src/subcommand/pathindex_main.cpp
@@ -39,14 +39,14 @@ namespace odgi {
 
         if (!dg_in_file) {
             std::cerr
-                    << "[odgi pathindex] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+                    << "[odgi::pathindex] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
                     << std::endl;
             return 1;
         }
 
         if (!idx_out_file) {
             std::cerr
-                    << "[odgi pathindex] error: Please specify an output file to where to store the path index via -o=[FILE], --out=[FILE]."
+                    << "[odgi::pathindex] error: please specify an output file to where to store the path index via -o=[FILE], --out=[FILE]."
                     << std::endl;
             return 1;
         }

--- a/src/subcommand/paths_main.cpp
+++ b/src/subcommand/paths_main.cpp
@@ -55,7 +55,7 @@ int main_paths(int argc, char** argv) {
     }
 
     if (!dg_in_file) {
-        std::cerr << "[odgi paths] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::paths] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 

--- a/src/subcommand/prune_main.cpp
+++ b/src/subcommand/prune_main.cpp
@@ -61,13 +61,13 @@ int main_prune(int argc, char** argv) {
     assert(argc > 0);
 
     if (!dg_in_file) {
-        std::cerr << "[odgi prune] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::prune] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!dg_out_file) {
         std::cerr
-                << "[odgi prune] error: Please specify an output file to where to store the pruned graph via -o=[FILE], --out=[FILE]."
+                << "[odgi::prune] error: please specify an output file to where to store the pruned graph via -o=[FILE], --out=[FILE]."
                 << std::endl;
         return 1;
     }

--- a/src/subcommand/server_main.cpp
+++ b/src/subcommand/server_main.cpp
@@ -40,12 +40,12 @@ namespace odgi {
         }
 
         if (!dg_in_file) {
-            std::cerr << "[odgi server]: Please enter a file to read the index from via -i=[FILE], --idx=[FILE]." << std::endl;
+            std::cerr << "[odgi::server]: please enter a file to read the index from via -i=[FILE], --idx=[FILE]." << std::endl;
             exit(1);
         }
 
         if (!port) {
-            std::cerr << "[odgi server]: Please enter a port for the server via -p=[N], --port=[N]." << std::endl;
+            std::cerr << "[odgi::server]: please enter a port for the server via -p=[N], --port=[N]." << std::endl;
             exit(1);
         }
 

--- a/src/subcommand/sort_main.cpp
+++ b/src/subcommand/sort_main.cpp
@@ -94,18 +94,18 @@ int main_sort(int argc, char** argv) {
     }
 
     if (!dg_in_file) {
-        std::cerr << "[odgi sort] Error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::sort] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!dg_out_file) {
-        std::cerr << "[odgi sort] Error: Please specify an output file to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::sort] error: please specify an output file to store the graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
 
     if (args::get(p_sgd_zipf_space_quantization_step) && args::get(p_sgd_zipf_max_number_of_distributions)){
         std::cerr
-                << "[odgi sort] error: Please specify -l/--path-sgd-zipf-space-quantization-step or -y/--path-sgd-zipf-max-num-distributions, not both."
+                << "[odgi::sort] error: please specify -l/--path-sgd-zipf-space-quantization-step or -y/--path-sgd-zipf-max-num-distributions, not both."
                 << std::endl;
         return 1;
     }
@@ -164,7 +164,7 @@ int main_sort(int argc, char** argv) {
     std::string path_sgd_seed;
     if (p_sgd_seed) {
         if (num_threads > 1) {
-            std::cerr << "[odgi sort] Error: Please only specify a seed for the path guided 1D linear SGD when using 1 thread." << std::endl;
+            std::cerr << "[odgi::sort] error: please only specify a seed for the path guided 1D linear SGD when using 1 thread." << std::endl;
             return 1;
         }
         path_sgd_seed = args::get(p_sgd_seed);
@@ -172,7 +172,7 @@ int main_sort(int argc, char** argv) {
         path_sgd_seed = "pangenomic!";
     }
     if (p_sgd_min_term_updates_paths && p_sgd_min_term_updates_num_nodes) {
-        std::cerr << "[odgi sort] Error: There can only be one argument provided for the minimum number of term updates in the path guided 1D SGD."
+        std::cerr << "[odgi::sort] error: there can only be one argument provided for the minimum number of term updates in the path guided 1D SGD."
                      "Please either use -G=[N], path-sgd-min-term-updates-paths=[N] or -U=[N], path-sgd-min-term-updates-nodes=[N]." << std::endl;
         return 1;
     }
@@ -215,7 +215,7 @@ int main_sort(int argc, char** argv) {
                 if (graph.has_path(buf)) {
                     path_sgd_use_paths.push_back(graph.get_path_handle(buf));
                 } else {
-                    std::cerr << "[odgi sort] Error: Path '" << buf
+                    std::cerr << "[odgi::sort] error: path '" << buf
                               << "' as was given by -f=[FILE], --path-sgd-use-paths=[FILE]"
                                  " is not present in the graph. Please remove this path from the file and restart 'odgi sort'.";
                 }
@@ -390,7 +390,7 @@ int main_sort(int argc, char** argv) {
                         break;
                 }
                 if (order.size() != graph.get_node_count()) {
-                    std::cerr << "[odgi sort] Error: expected " << graph.get_node_count()
+                    std::cerr << "[odgi::sort] error: expected " << graph.get_node_count()
                               << " handles in the order "
                               << "but got " << order.size() << std::endl;
                     assert(false);

--- a/src/subcommand/stats_main.cpp
+++ b/src/subcommand/stats_main.cpp
@@ -70,14 +70,14 @@ int main_stats(int argc, char** argv) {
     if (!args::get(mean_links_length) && !args::get(sum_of_path_node_distances)){
         if (args::get(path_statistics)){
             std::cerr
-                    << "[odgi stats] error: Please specify the -l/--mean-links-length and/or the -s/--sum-path-nodes-distances options to use the -P/--path-statistics option."
+                    << "[odgi::stats] error: please specify the -l/--mean-links-length and/or the -s/--sum-path-nodes-distances options to use the -P/--path-statistics option."
                     << std::endl;
             return 1;
         }
 
         if (layout_in_file){
             std::cerr
-                    << "[odgi stats] error: Please specify the -l/--mean-links-length and/or the -s/--sum-path-nodes-distances options to specify the layout coordinates (-c/--coords-in option)."
+                    << "[odgi::stats] error: please specify the -l/--mean-links-length and/or the -s/--sum-path-nodes-distances options to specify the layout coordinates (-c/--coords-in option)."
                     << std::endl;
             return 1;
         }
@@ -85,19 +85,19 @@ int main_stats(int argc, char** argv) {
 
     if (args::get(penalize_diff_orientation) && !args::get(sum_of_path_node_distances)){
         std::cerr
-                << "[odgi stats] error: Please specify the -s/--sum-path-nodes-distances option to use the -d/--penalize-different-orientation option."
+                << "[odgi::stats] error: please specify the -s/--sum-path-nodes-distances option to use the -d/--penalize-different-orientation option."
                 << std::endl;
         return 1;
     }
     if (args::get(dont_penalize_gap_links)){
         if (!args::get(mean_links_length)) {
             std::cerr
-                    << "[odgi stats] error: Please specify the -l/--mean-links-length option to use the -g/--no-gap-links option."
+                    << "[odgi::stats] error: please specify the -l/--mean-links-length option to use the -g/--no-gap-links option."
                     << std::endl;
             return 1;
         } else if (layout_in_file){
             std::cerr
-                    << "[odgi stats] error: The -g/--no-gap-links option can be specified together with the layout coordinates (-c/--coords-in option)."
+                    << "[odgi::stats] error: The -g/--no-gap-links option can be specified together with the layout coordinates (-c/--coords-in option)."
                     << std::endl;
             return 1;
         }
@@ -222,7 +222,7 @@ int main_stats(int argc, char** argv) {
         graph.for_each_handle([&](const handle_t &h) {
             nid_t node_id = graph.get_id(h);
             if (node_id - last_node_id > 1) {
-                std::cerr << "[odgi stats] error: The graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
+                std::cerr << "[odgi::stats] error: The graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
                 exit(1);
             }
             last_node_id = node_id;

--- a/src/subcommand/subset_main.cpp
+++ b/src/subcommand/subset_main.cpp
@@ -42,12 +42,12 @@ int main_subset(int argc, char** argv) {
     }
 
     if (!dg_in_file) {
-        std::cerr << "[odgi subset] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::subset] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!dg_out_file) {
-        std::cerr << "[odgi subset] error: Please specify an output file to where to store the unchopped graph via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::subset] error: please specify an output file to where to store the unchopped graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
 
@@ -83,7 +83,7 @@ int main_subset(int argc, char** argv) {
                 handle_t h = graph.get_handle(id);
                 subset.create_handle(graph.get_sequence(h), id);
             } else {
-                std::cerr << "[odgi subset] Warning, cannot find node " << id << std::endl;
+                std::cerr << "[odgi::subset] warning: cannot find node " << id << std::endl;
             }
         }
     }

--- a/src/subcommand/unchop_main.cpp
+++ b/src/subcommand/unchop_main.cpp
@@ -41,12 +41,12 @@ int main_unchop(int argc, char** argv) {
     }
 
     if (!og_in_file) {
-        std::cerr << "[odgi unchop] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
+        std::cerr << "[odgi::unchop] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]." << std::endl;
         return 1;
     }
 
     if (!og_out_file) {
-        std::cerr << "[odgi unchop] error: Please specify an output file to where to store the unchopped graph via -o=[FILE], --out=[FILE]." << std::endl;
+        std::cerr << "[odgi::unchop] error: please specify an output file to where to store the unchopped graph via -o=[FILE], --out=[FILE]." << std::endl;
         return 1;
     }
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -99,14 +99,14 @@ namespace odgi {
 
         if (!dg_in_file) {
             std::cerr
-                    << "[odgi viz] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+                    << "[odgi::viz] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
                     << std::endl;
             return 1;
         }
 
         if (!png_out_file) {
             std::cerr
-                    << "[odgi viz] error: Please specify an output file to where to store the PNG via -o=[FILE], --out=[FILE]."
+                    << "[odgi::viz] error: Please specify an output file to where to store the PNG via -o=[FILE], --out=[FILE]."
                     << std::endl;
             return 1;
         }
@@ -117,7 +117,7 @@ namespace odgi {
                 args::get(color_by_mean_coverage))
                 ){
             std::cerr
-                    << "[odgi viz] error: Please specify the -b/--binned-mode option to use the "
+                    << "[odgi::viz] error: Please specify the -b/--binned-mode option to use the "
                        "-w/--bin_width, -g/--no-gap-links, and -m/--color-by-mean-coverage "
                        "options."
                     << std::endl;
@@ -126,14 +126,14 @@ namespace odgi {
 
         if (!args::get(change_darkness) && (args::get(longest_path) || args::get(white_to_black))){
             std::cerr
-                    << "[odgi viz] error: Please specify the -d/--change-darkness option to use the -l/--longest-path and -u/--white-to-black options."
+                    << "[odgi::viz] error: Please specify the -d/--change-darkness option to use the -l/--longest-path and -u/--white-to-black options."
                     << std::endl;
             return 1;
         }
 
         if ((args::get(_color_by_prefix) != 0) + args::get(show_strands) + args::get(white_to_black) + args::get(color_by_mean_coverage) + args::get(color_by_mean_inversion_rate) > 1) {
             std::cerr
-                    << "[odgi viz] error: Please specify only one of the following options: "
+                    << "[odgi::viz] error: Please specify only one of the following options: "
                        "-s/--color-by-prefix, -S/--show-strand, -u/--white-to-black, "
                        "-m/--color-by-mean-coverage, and -z/--color-by-mean-inversion."
                     << std::endl;
@@ -142,7 +142,7 @@ namespace odgi {
 
         if (args::get(change_darkness) && (args::get(color_by_mean_coverage) || args::get(color_by_mean_inversion_rate))) {
             std::cerr
-                    << "[odgi viz] error: Please specify the -d/--change-darkness option without specifying "
+                    << "[odgi::viz] error: Please specify the -d/--change-darkness option without specifying "
                        "-m/--color-by-mean-coverage or -z/--color-by-mean-inversion."
                     << std::endl;
             return 1;
@@ -150,14 +150,14 @@ namespace odgi {
 
         if (args::get(pack_paths) && !args::get(path_names_file).empty()){
             std::cerr
-                    << "[odgi viz] error: Please specify -R/--pack-paths or -p/--paths-to-display, not both."
+                    << "[odgi::viz] error: Please specify -R/--pack-paths or -p/--paths-to-display, not both."
                     << std::endl;
             return 1;
         }
 
         if (args::get(hide_path_names) && (args::get(color_path_names_background) || args::get(_max_num_of_characters))){
             std::cerr
-                    << "[odgi viz] error: Please specify the -C/--color-path-names-background and -c/--max-num-of-characters "
+                    << "[odgi::viz] error: Please specify the -C/--color-path-names-background and -c/--max-num-of-characters "
                        "options without specifying -H/--hide-path-names." << std::endl;
             return 1;
         }
@@ -179,7 +179,7 @@ namespace odgi {
         //NOTE: this sample will overwrite the file or test.png without warning!
         //const char* filename = argc > 1 ? argv[1] : "test.png";
         if (args::get(png_out_file).empty()) {
-            std::cerr << "[odgi viz] error: output image required" << std::endl;
+            std::cerr << "[odgi::viz] error: output image required" << std::endl;
             return 1;
         }
         const char *filename = args::get(png_out_file).c_str();
@@ -190,7 +190,7 @@ namespace odgi {
         graph.for_each_handle([&](const handle_t &h) {
             nid_t node_id = graph.get_id(h);
             if (node_id - last_node_id > 1) {
-                std::cerr << "[odgi viz] error: The graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
+                std::cerr << "[odgi::viz] error: The graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
                 exit(1);
             }
             last_node_id = node_id;
@@ -220,14 +220,14 @@ namespace odgi {
 
                 if (splitted.size() != 2) {
                     std::cerr
-                            << "[odgi viz] error: Please specify a valid nucleotide pangenomic range: STRING=start-end."
+                            << "[odgi::viz] error: Please specify a valid nucleotide pangenomic range: STRING=start-end."
                             << std::endl;
                     return 1;
                 }
 
                 if ((splitted[0] != "*" && !is_number(splitted[0])) || (splitted[1] != "*" && !is_number(splitted[1]))) {
                     std::cerr
-                            << "[odgi viz] error: Please specify valid numbers for the nucleotide pangenomic range."
+                            << "[odgi::viz] error: Please specify valid numbers for the nucleotide pangenomic range."
                             << std::endl;
                     return 1;
                 }
@@ -246,7 +246,7 @@ namespace odgi {
 
                 if (pangenomic_start_pos >= pangenomic_end_pos) {
                     std::cerr
-                            << "[odgi viz] error: Please specify a start position less than the end position."
+                            << "[odgi::viz] error: Please specify a start position less than the end position."
                             << std::endl;
                     return 1;
                 }
@@ -285,9 +285,9 @@ namespace odgi {
             // Each pixel corresponds to a bin
             scale_x = 1; //scale_x*bin_width;
 
-            std::cerr << "[odgi viz] Binned mode" << std::endl;
-            std::cerr << "[odgi viz] bin width: " << _bin_width << std::endl;
-            std::cerr << "[odgi viz] image width: " << width << std::endl;
+            std::cerr << "[odgi::viz] Binned mode" << std::endl;
+            std::cerr << "[odgi::viz] bin width: " << _bin_width << std::endl;
+            std::cerr << "[odgi::viz] image width: " << width << std::endl;
         }else{
             _bin_width = 1;
         }
@@ -321,7 +321,7 @@ namespace odgi {
                             if (path_layout_y[path_rank] < 0){
                                 path_layout_y[path_rank] = rank_for_visualization;
                             }else{
-                                std::cerr << "[odgi viz] error: In the path list there are duplicated path names." << std::endl;
+                                std::cerr << "[odgi::viz] error: In the path list there are duplicated path names." << std::endl;
                                 exit(1);
                             }
 
@@ -332,10 +332,10 @@ namespace odgi {
                     }
                 }
 
-                std::cerr << "[odgi viz] Found " << rank_for_visualization << "/" << num_of_paths_in_file << " paths to display." << std::endl;
+                std::cerr << "[odgi::viz] Found " << rank_for_visualization << "/" << num_of_paths_in_file << " paths to display." << std::endl;
 
                 if (rank_for_visualization == 0){
-                    std::cerr << "[odgi viz] error: No path to display." << std::endl;
+                    std::cerr << "[odgi::viz] error: No path to display." << std::endl;
                     exit(1);
                 }
 
@@ -402,7 +402,7 @@ namespace odgi {
 
         if (width_path_names + width > 50000){
             std::cerr
-                    << "[odgi viz] warning: you are going to create a big image (width > 50000 pixels)."
+                    << "[odgi::viz] warning: you are going to create a big image (width > 50000 pixels)."
                     << std::endl;
         }
 
@@ -940,7 +940,7 @@ namespace odgi {
         });
 
         if (args::get(drop_gap_links)) {
-            std::cerr << std::setprecision(4) << "[odgi viz] Gap links removed: " << (100.0 *  ((double)gap_links_removed / (double)total_links))
+            std::cerr << std::setprecision(4) << "[odgi::viz] Gap links removed: " << (100.0 *  ((double)gap_links_removed / (double)total_links))
             << "%, that is " << gap_links_removed << " gap links (" << path_count << " path start links + "
             << path_count << " path end links + " << (gap_links_removed - path_count * 2) << " inner gap links) of "
             << total_links << " total links" << std::endl;

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -202,8 +202,8 @@ namespace odgi {
         });
         position_map[position_map.size() - 1] = len;
 
-        uint64_t pangenomic_start_pos = 0;
-        uint64_t pangenomic_end_pos = len - 1;
+        double pangenomic_start_pos = 0.0;
+        double pangenomic_end_pos = (double) (len - 1);
 
         {
             std::string nucleotide_pangenomic_range = args::get(_nucleotide_pangenomic_range);
@@ -226,8 +226,8 @@ namespace odgi {
 
                 //todo checks that they are numbers
 
-                pangenomic_start_pos = stoi(splitted[0]);
-                pangenomic_end_pos = stoi(splitted[1]);
+                pangenomic_start_pos = (double) stoi(splitted[0]);
+                pangenomic_end_pos = (double) stoi(splitted[1]);
 
                 if (pangenomic_start_pos >= pangenomic_end_pos) {
                     std::cerr
@@ -236,7 +236,7 @@ namespace odgi {
                     return 1;
                 }
 
-                pangenomic_end_pos = std::min((uint64_t)len - 1, pangenomic_end_pos);
+                pangenomic_end_pos = std::min((double)len - 1, pangenomic_end_pos);
             }
         }
 
@@ -254,6 +254,9 @@ namespace odgi {
         uint64_t width = std::min(len_to_visualize, (args::get(image_width) ? args::get(image_width) : 1000));
         uint64_t height = std::min(len_to_visualize, (args::get(image_height) ? args::get(image_height) : 1000) + bottom_padding);
 
+        /*std::cerr << "real len: " << len << std::endl;
+        std::cerr << "pangenomic_start_pos: " << pangenomic_start_pos << "\npangenomic_end_pos: " << pangenomic_end_pos << std::endl;
+        std::cerr << "len_to_visualize: " << len_to_visualize << std::endl;*/
 
         float scale_x = (float) width / (float) len_to_visualize;
         float scale_y = (float) height / (float) len_to_visualize;
@@ -420,19 +423,19 @@ namespace odgi {
 
             if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
                 for (; i < dist; i += 1 / scale_y) {
-                    add_point(a, i, rgb, rgb, rgb);
+                    add_point(a - pangenomic_start_pos, i, rgb, rgb, rgb);
                 }
             }
 
             while (a <= b) {
                 if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
-                    add_point(a, i, rgb, rgb, rgb);
+                    add_point(a - pangenomic_start_pos, i, rgb, rgb, rgb);
                 }
                 a += 1 / scale_x;
             }
             if (b >= pangenomic_start_pos && b <= pangenomic_end_pos) {
                 for (uint64_t j = 0; j < dist; j += 1 / scale_y) {
-                    add_point(b, j, rgb, rgb, rgb);
+                    add_point(b - pangenomic_start_pos, j, rgb, rgb, rgb);
                 }
             }
         };
@@ -484,7 +487,7 @@ namespace odgi {
                                 std::cerr << "position in map (" << p  << ") - curr_bin: " << curr_bin << std::endl;
 #endif
                                 if (p + k >= pangenomic_start_pos && p + k <= pangenomic_end_pos) {
-                                    add_point(curr_bin - 1, 0, RGB_BIN_LINKS, RGB_BIN_LINKS, RGB_BIN_LINKS);
+                                    add_point(curr_bin - 1 - ((p + k - pangenomic_start_pos) / _bin_width + 1), 0, RGB_BIN_LINKS, RGB_BIN_LINKS, RGB_BIN_LINKS);
                                 }
                             }
 
@@ -501,8 +504,8 @@ namespace odgi {
                         uint64_t hl = graph.get_length(h);
                         // make contents for the bases in the node
                         for (uint64_t i = 0; i < hl; i += 1 / scale_x) {
-                            if (p + i >= pangenomic_start_pos && p + i <= pangenomic_end_pos) {
-                                add_point(p + i, 0, 0, 0, 0);
+                            if ((p + i) >= pangenomic_start_pos && (p + i) <= pangenomic_end_pos) {
+                                add_point(p + i - pangenomic_start_pos, 0, 0, 0, 0);
                             }
                         }
 
@@ -802,8 +805,8 @@ namespace odgi {
                                     }
                                 }
 
-                                if (p + k >= pangenomic_start_pos && p + k <= pangenomic_end_pos) {
-                                    add_path_step(image, width, curr_bin - 1, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
+                                if ((p + k) >= pangenomic_start_pos && (p + k) <= pangenomic_end_pos) {
+                                    add_path_step(image, width, curr_bin - 1 - ((p + k - pangenomic_start_pos) / _bin_width + 1), path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
                                 }
 
                                 if (std::abs(curr_bin - last_bin) > 1 || last_bin == 0) {
@@ -888,8 +891,8 @@ namespace odgi {
                                 };
                             }
 
-                            if (p + i >= pangenomic_start_pos && p + i <= pangenomic_end_pos) {
-                                add_path_step(image, width, p+i, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
+                            if ((p + i) >= pangenomic_start_pos && (p + i) <= pangenomic_end_pos) {
+                                add_path_step(image, width, p+i - pangenomic_start_pos, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
                             }
                         }
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -20,6 +20,9 @@
 #define PATH_NAMES_MAX_NUM_OF_CHARACTERS 128
 #define PATH_NAMES_MAX_CHARACTER_SIZE 64
 
+bool is_number(const std::string &s) {
+    return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
+}
 
 namespace odgi {
 
@@ -58,7 +61,7 @@ namespace odgi {
         args::ValueFlag<char> _color_by_prefix(parser, "C", "colors paths by their names looking at the prefix before the given character C",{'s', "color-by-prefix"});
 
         /// Range selection
-        args::ValueFlag<std::string> _nucleotide_pangenomic_range(parser, "STRING","nucleotide pangenomic range to visualize [pos1-pos2]",{'r', "pangenomic-range"});
+        args::ValueFlag<std::string> _nucleotide_pangenomic_range(parser, "STRING","nucleotide pangenomic range to visualize: STRING=start-end. The nucleotide positions refer to the pangenome's sequence (i.e., the sequence obtained arranging all the graph's node from left to right).",{'r', "pangenomic-range"});
 
         /// Paths selection
         args::ValueFlag<std::string> path_names_file(parser, "FILE", "list of paths to display in the specified order; the file must contain one path name per line and a subset of all paths can be specified.", {'p', "paths-to-display"});
@@ -216,15 +219,18 @@ namespace odgi {
 
 
                 if (splitted.size() != 2) {
-                    //todo to improve the message
                     std::cerr
-                            << "[odgi viz] error: Please specify a nucleotide pangenomic range with a start position "
-                               "and an end position."
+                            << "[odgi viz] error: Please specify a valid nucleotide pangenomic range: STRING=start-end."
                             << std::endl;
                     return 1;
                 }
 
-                //todo checks that they are numbers
+                if (!is_number(splitted[0]) || !is_number(splitted[1])) {
+                    std::cerr
+                            << "[odgi viz] error: Please specify valid numbers for the nucleotide pangenomic range."
+                            << std::endl;
+                    return 1;
+                }
 
                 pangenomic_start_pos = std::min((double)len - 1, (double)stoi(splitted[0]));
                 pangenomic_end_pos = std::min((double)len - 1, (double)stoi(splitted[1]));

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -99,14 +99,14 @@ namespace odgi {
 
         if (!dg_in_file) {
             std::cerr
-                    << "[odgi::viz] error: Please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
+                    << "[odgi::viz] error: please specify an input file from where to load the graph via -i=[FILE], --idx=[FILE]."
                     << std::endl;
             return 1;
         }
 
         if (!png_out_file) {
             std::cerr
-                    << "[odgi::viz] error: Please specify an output file to where to store the PNG via -o=[FILE], --out=[FILE]."
+                    << "[odgi::viz] error: please specify an output file to where to store the PNG via -o=[FILE], --out=[FILE]."
                     << std::endl;
             return 1;
         }
@@ -117,7 +117,7 @@ namespace odgi {
                 args::get(color_by_mean_coverage))
                 ){
             std::cerr
-                    << "[odgi::viz] error: Please specify the -b/--binned-mode option to use the "
+                    << "[odgi::viz] error: please specify the -b/--binned-mode option to use the "
                        "-w/--bin_width, -g/--no-gap-links, and -m/--color-by-mean-coverage "
                        "options."
                     << std::endl;
@@ -126,14 +126,14 @@ namespace odgi {
 
         if (!args::get(change_darkness) && (args::get(longest_path) || args::get(white_to_black))){
             std::cerr
-                    << "[odgi::viz] error: Please specify the -d/--change-darkness option to use the -l/--longest-path and -u/--white-to-black options."
+                    << "[odgi::viz] error: please specify the -d/--change-darkness option to use the -l/--longest-path and -u/--white-to-black options."
                     << std::endl;
             return 1;
         }
 
         if ((args::get(_color_by_prefix) != 0) + args::get(show_strands) + args::get(white_to_black) + args::get(color_by_mean_coverage) + args::get(color_by_mean_inversion_rate) > 1) {
             std::cerr
-                    << "[odgi::viz] error: Please specify only one of the following options: "
+                    << "[odgi::viz] error: please specify only one of the following options: "
                        "-s/--color-by-prefix, -S/--show-strand, -u/--white-to-black, "
                        "-m/--color-by-mean-coverage, and -z/--color-by-mean-inversion."
                     << std::endl;
@@ -142,7 +142,7 @@ namespace odgi {
 
         if (args::get(change_darkness) && (args::get(color_by_mean_coverage) || args::get(color_by_mean_inversion_rate))) {
             std::cerr
-                    << "[odgi::viz] error: Please specify the -d/--change-darkness option without specifying "
+                    << "[odgi::viz] error: please specify the -d/--change-darkness option without specifying "
                        "-m/--color-by-mean-coverage or -z/--color-by-mean-inversion."
                     << std::endl;
             return 1;
@@ -150,14 +150,14 @@ namespace odgi {
 
         if (args::get(pack_paths) && !args::get(path_names_file).empty()){
             std::cerr
-                    << "[odgi::viz] error: Please specify -R/--pack-paths or -p/--paths-to-display, not both."
+                    << "[odgi::viz] error: please specify -R/--pack-paths or -p/--paths-to-display, not both."
                     << std::endl;
             return 1;
         }
 
         if (args::get(hide_path_names) && (args::get(color_path_names_background) || args::get(_max_num_of_characters))){
             std::cerr
-                    << "[odgi::viz] error: Please specify the -C/--color-path-names-background and -c/--max-num-of-characters "
+                    << "[odgi::viz] error: please specify the -C/--color-path-names-background and -c/--max-num-of-characters "
                        "options without specifying -H/--hide-path-names." << std::endl;
             return 1;
         }
@@ -190,7 +190,7 @@ namespace odgi {
         graph.for_each_handle([&](const handle_t &h) {
             nid_t node_id = graph.get_id(h);
             if (node_id - last_node_id > 1) {
-                std::cerr << "[odgi::viz] error: The graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
+                std::cerr << "[odgi::viz] error: the graph is not optimized. Please run 'odgi sort' using -O, --optimize" << std::endl;
                 exit(1);
             }
             last_node_id = node_id;
@@ -218,7 +218,7 @@ namespace odgi {
 
                     if (!graph.has_path(path_name)) {
                         std::cerr
-                                << "[odgi::viz] error: Please specify a valid path name."
+                                << "[odgi::viz] error: please specify a valid path name."
                                 << std::endl;
                         return 1;
                     }
@@ -234,14 +234,14 @@ namespace odgi {
 
                 if (splitted.size() != 2) {
                     std::cerr
-                            << "[odgi::viz] error: Please specify a valid nucleotide range: STRING=[PATH:]start-end."
+                            << "[odgi::viz] error: please specify a valid nucleotide range: STRING=[PATH:]start-end."
                             << std::endl;
                     return 1;
                 }
 
                 if ((splitted[0] != "*" && !is_number(splitted[0])) || (splitted[1] != "*" && !is_number(splitted[1]))) {
                     std::cerr
-                            << "[odgi::viz] error: Please specify valid numbers for the nucleotide range."
+                            << "[odgi::viz] error: please specify valid numbers for the nucleotide range."
                             << std::endl;
                     return 1;
                 }
@@ -300,7 +300,7 @@ namespace odgi {
 
                 if (pangenomic_start_pos >= pangenomic_end_pos) {
                     std::cerr
-                            << "[odgi::viz] error: Please specify a start position less than the end position."
+                            << "[odgi::viz] error: please specify a start position less than the end position."
                             << std::endl;
                     return 1;
                 }

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -270,9 +270,9 @@ namespace odgi {
             // Each pixel corresponds to a bin
             scale_x = 1; //scale_x*bin_width;
 
-            std::cerr << "Binned mode" << std::endl;
-            std::cerr << "bin width: " << _bin_width << std::endl;
-            std::cerr << "image width: " << width << std::endl;
+            std::cerr << "[odgi viz] Binned mode" << std::endl;
+            std::cerr << "[odgi viz] bin width: " << _bin_width << std::endl;
+            std::cerr << "[odgi viz] image width: " << width << std::endl;
         }else{
             _bin_width = 1;
         }
@@ -317,7 +317,7 @@ namespace odgi {
                     }
                 }
 
-                std::cerr << "Found " << rank_for_visualization << "/" << num_of_paths_in_file << " paths to display." << std::endl;
+                std::cerr << "[odgi viz] Found " << rank_for_visualization << "/" << num_of_paths_in_file << " paths to display." << std::endl;
 
                 if (rank_for_visualization == 0){
                     std::cerr << "[odgi viz] error: No path to display." << std::endl;
@@ -925,7 +925,7 @@ namespace odgi {
         });
 
         if (args::get(drop_gap_links)) {
-            std::cerr << std::setprecision(4) << "Gap links removed: " << (100.0 *  ((double)gap_links_removed / (double)total_links))
+            std::cerr << std::setprecision(4) << "[odgi viz] Gap links removed: " << (100.0 *  ((double)gap_links_removed / (double)total_links))
             << "%, that is " << gap_links_removed << " gap links (" << path_count << " path start links + "
             << path_count << " path end links + " << (gap_links_removed - path_count * 2) << " inner gap links) of "
             << total_links << " total links" << std::endl;

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -410,7 +410,7 @@ namespace odgi {
             std::vector<path_handle_t> path_order = algorithms::id_ordered_paths(graph);
             for (auto &path : path_order) {
                 // get the block which this path covers
-                uint64_t min_x = std::numeric_limits<uint64_t>::max();
+                uint64_t min_x = len_to_visualize;
                 uint64_t max_x = std::numeric_limits<uint64_t>::min(); // 0
                 graph.for_each_step_in_path(path, [&](const step_handle_t &occ) {
                     handle_t h = graph.get_handle_of_step(occ);
@@ -421,6 +421,7 @@ namespace odgi {
                         max_x = std::max(max_x, (uint64_t) (p + graph.get_length(h) - pangenomic_start_pos));
                     }
                 });
+
                 //std::cerr << "min and max x " << min_x << " " << max_x << " vs " << len_to_visualize << std::endl;
                 // now find where this would fit and mark the layout buffer
                 // due to our sorted paths, we are able to drop to the lowest available layout position
@@ -1011,9 +1012,9 @@ namespace odgi {
         }
 
         // trim horizontal and vertical spaces to fit
-        uint64_t min_x = std::numeric_limits<uint64_t>::max();
+        uint64_t min_x = width;
         uint64_t max_x = std::numeric_limits<uint64_t>::min(); // 0
-        uint64_t min_y = std::numeric_limits<uint64_t>::max();
+        uint64_t min_y = height + path_space;
         uint64_t max_y = std::numeric_limits<uint64_t>::min(); // 0
         for (uint64_t y = 0; y < height + path_space; ++y) {
             for (uint64_t x = 0; x < width; ++x) {

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -301,6 +301,10 @@ namespace odgi {
                             << std::endl;
                     return 1;
                 }
+
+                std::cerr
+                        << "[odgi::viz]: visualizing pangenomic range [" << pangenomic_start_pos << ", " << pangenomic_end_pos << "]"
+                        << std::endl;
             }
         }
 
@@ -408,8 +412,11 @@ namespace odgi {
                 graph.for_each_step_in_path(path, [&](const step_handle_t &occ) {
                     handle_t h = graph.get_handle_of_step(occ);
                     uint64_t p = position_map[number_bool_packing::unpack_number(h)];
-                    min_x = std::min(min_x, p);
-                    max_x = std::max(max_x, p + graph.get_length(h));
+
+                    if (p >= pangenomic_start_pos && p <= pangenomic_end_pos) {
+                        min_x = std::min(min_x, (uint64_t) (p - pangenomic_start_pos));
+                        max_x = std::max(max_x, (uint64_t) (p + graph.get_length(h) - pangenomic_start_pos));
+                    }
                 });
                 //std::cerr << "min and max x " << min_x << " " << max_x << " vs " << len_to_visualize << std::endl;
                 // now find where this would fit and mark the layout buffer

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -249,13 +249,13 @@ namespace odgi {
                 if (splitted[0] == "*") {
                     pangenomic_start_pos = 0;
                 } else {
-                    pangenomic_start_pos = std::min((double)len - 1, (double)stoi(splitted[0]));
+                    pangenomic_start_pos = std::min((double)len - 1, stod(splitted[0]));
                 }
 
                 if (splitted[1] == "*") {
                     pangenomic_end_pos = (double)len - 1;
                 } else {
-                    pangenomic_end_pos = std::min((double)len - 1, (double)stoi(splitted[1]));
+                    pangenomic_end_pos = std::min((double)len - 1, stod(splitted[1]));
                 }
 
                 //std::cerr << "input A: " << pangenomic_start_pos << std::endl;
@@ -264,7 +264,7 @@ namespace odgi {
                 if (!path_name.empty()) {
                     // Convert the nucleotide path range in a nucleotide pangenomic range
                     std::cerr
-                            << "[odgi::viz]: path range to pangenomic range conversion."
+                            << "[odgi::viz] Path range to pangenomic range conversion."
                             << std::endl;
 
                     double new_pangenomic_start_pos = (double) (len - 1);
@@ -306,7 +306,7 @@ namespace odgi {
                 }
 
                 std::cerr
-                        << "[odgi::viz]: visualizing the graph in the pangenomic range [" << pangenomic_start_pos << ", " << pangenomic_end_pos << "]"
+                        << "[odgi::viz] Visualizing the graph in the pangenomic range [" << pangenomic_start_pos << ", " << pangenomic_end_pos << "]"
                         << std::endl;
             }
         }
@@ -379,7 +379,7 @@ namespace odgi {
                             if (path_layout_y[path_rank] < 0){
                                 path_layout_y[path_rank] = rank_for_visualization;
                             }else{
-                                std::cerr << "[odgi::viz] error: In the path list there are duplicated path names." << std::endl;
+                                std::cerr << "[odgi::viz] error: in the path list there are duplicated path names." << std::endl;
                                 exit(1);
                             }
 
@@ -393,7 +393,7 @@ namespace odgi {
                 std::cerr << "[odgi::viz] Found " << rank_for_visualization << "/" << num_of_paths_in_file << " paths to display." << std::endl;
 
                 if (rank_for_visualization == 0){
-                    std::cerr << "[odgi::viz] error: No path to display." << std::endl;
+                    std::cerr << "[odgi::viz] error: no path to display." << std::endl;
                     exit(1);
                 }
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -488,21 +488,24 @@ namespace odgi {
 
             uint64_t i = 0;
 
-            for (; i < dist; i += 1 / scale_y) {
-                if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
-                    add_point(a - pangenomic_start_pos, i, rgb, rgb, rgb);
+            // Show the link if at least one of its 2 extremes is visible
+            if (a >= pangenomic_start_pos && a <= pangenomic_end_pos || b >= pangenomic_start_pos && b <= pangenomic_end_pos) {
+                for (; i < dist; i += 1 / scale_y) {
+                    if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
+                        add_point(a - pangenomic_start_pos, i, rgb, rgb, rgb);
+                    }
                 }
-            }
 
-            while (a <= b) {
-                if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
-                    add_point(a - pangenomic_start_pos, i, rgb, rgb, rgb);
+                while (a <= b) {
+                    if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
+                        add_point(a - pangenomic_start_pos, i, rgb, rgb, rgb);
+                    }
+                    a += 1 / scale_x;
                 }
-                a += 1 / scale_x;
-            }
-            if (b >= pangenomic_start_pos && b <= pangenomic_end_pos) {
-                for (uint64_t j = 0; j < dist; j += 1 / scale_y) {
-                    add_point(b - pangenomic_start_pos, j, rgb, rgb, rgb);
+                if (b >= pangenomic_start_pos && b <= pangenomic_end_pos) {
+                    for (uint64_t j = 0; j < dist; j += 1 / scale_y) {
+                        add_point(b - pangenomic_start_pos, j, rgb, rgb, rgb);
+                    }
                 }
             }
         };

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -61,7 +61,7 @@ namespace odgi {
         args::ValueFlag<char> _color_by_prefix(parser, "C", "colors paths by their names looking at the prefix before the given character C",{'s', "color-by-prefix"});
 
         /// Range selection
-        args::ValueFlag<std::string> _nucleotide_pangenomic_range(parser, "STRING","nucleotide pangenomic range to visualize: STRING=start-end. The nucleotide positions refer to the pangenome's sequence (i.e., the sequence obtained arranging all the graph's node from left to right).",{'r', "pangenomic-range"});
+        args::ValueFlag<std::string> _nucleotide_pangenomic_range(parser, "STRING","nucleotide pangenomic range to visualize: STRING=start-end. `*-end` for `[0,end]`; `start-*` for `[start,pangenome_length]`. The nucleotide positions refer to the pangenome's sequence (i.e., the sequence obtained arranging all the graph's node from left to right).",{'r', "pangenomic-range"});
 
         /// Paths selection
         args::ValueFlag<std::string> path_names_file(parser, "FILE", "list of paths to display in the specified order; the file must contain one path name per line and a subset of all paths can be specified.", {'p', "paths-to-display"});
@@ -225,15 +225,24 @@ namespace odgi {
                     return 1;
                 }
 
-                if (!is_number(splitted[0]) || !is_number(splitted[1])) {
+                if ((splitted[0] != "*" && !is_number(splitted[0])) || (splitted[1] != "*" && !is_number(splitted[1]))) {
                     std::cerr
                             << "[odgi viz] error: Please specify valid numbers for the nucleotide pangenomic range."
                             << std::endl;
                     return 1;
                 }
 
-                pangenomic_start_pos = std::min((double)len - 1, (double)stoi(splitted[0]));
-                pangenomic_end_pos = std::min((double)len - 1, (double)stoi(splitted[1]));
+                if (splitted[0] == "*") {
+                    pangenomic_start_pos = 0;
+                } else {
+                    pangenomic_start_pos = std::min((double)len - 1, (double)stoi(splitted[0]));
+                }
+
+                if (splitted[1] == "*") {
+                    pangenomic_end_pos = (double)len - 1;
+                } else {
+                    pangenomic_end_pos = std::min((double)len - 1, (double)stoi(splitted[1]));
+                }
 
                 if (pangenomic_start_pos >= pangenomic_end_pos) {
                     std::cerr

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -263,6 +263,9 @@ namespace odgi {
 
                 if (!path_name.empty()) {
                     // Convert the nucleotide path range in a nucleotide pangenomic range
+                    std::cerr
+                            << "[odgi::viz]: path range to pangenomic range conversion."
+                            << std::endl;
 
                     double new_pangenomic_start_pos = (double) (len - 1);
                     double new_pangenomic_end_pos = 0;
@@ -303,7 +306,7 @@ namespace odgi {
                 }
 
                 std::cerr
-                        << "[odgi::viz]: visualizing pangenomic range [" << pangenomic_start_pos << ", " << pangenomic_end_pos << "]"
+                        << "[odgi::viz]: visualizing the graph in the pangenomic range [" << pangenomic_start_pos << ", " << pangenomic_end_pos << "]"
                         << std::endl;
             }
         }

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -277,9 +277,9 @@ namespace odgi {
             _bin_width = 1;
         }
 
-        std::cerr << "real len: " << len << std::endl;
+        /*std::cerr << "real len: " << len << std::endl;
         std::cerr << "pangenomic_start_pos: " << pangenomic_start_pos << "\npangenomic_end_pos: " << pangenomic_end_pos << std::endl;
-        std::cerr << "len_to_visualize: " << len_to_visualize << std::endl;
+        std::cerr << "len_to_visualize: " << len_to_visualize << std::endl;*/
 
         // After the bin_width and scale_xy calculations
         uint16_t width_path_names = 0;
@@ -422,8 +422,8 @@ namespace odgi {
 
             uint64_t i = 0;
 
-            if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
-                for (; i < dist; i += 1 / scale_y) {
+            for (; i < dist; i += 1 / scale_y) {
+                if (a >= pangenomic_start_pos && a <= pangenomic_end_pos) {
                     add_point(a - pangenomic_start_pos, i, rgb, rgb, rgb);
                 }
             }
@@ -487,7 +487,7 @@ namespace odgi {
 #ifdef debug_odgi_viz
                                 std::cerr << "position in map (" << p  << ") - curr_bin: " << curr_bin << std::endl;
 #endif
-                                if (curr_bin >= pangenomic_start_pos && curr_bin <= pangenomic_end_pos) {
+                                if (curr_bin - 1 >= pangenomic_start_pos && curr_bin - 1 <= pangenomic_end_pos) {
                                     add_point(curr_bin - 1 - pangenomic_start_pos, 0, RGB_BIN_LINKS, RGB_BIN_LINKS, RGB_BIN_LINKS);
                                 }
                             }
@@ -806,7 +806,7 @@ namespace odgi {
                                     }
                                 }
 
-                                if (curr_bin >= pangenomic_start_pos && curr_bin <= pangenomic_end_pos) {
+                                if (curr_bin - 1 >= pangenomic_start_pos && curr_bin - 1 <= pangenomic_end_pos) {
                                     add_path_step(image, width, curr_bin - 1 - pangenomic_start_pos, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
                                 }
 

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -226,8 +226,8 @@ namespace odgi {
 
                 //todo checks that they are numbers
 
-                pangenomic_start_pos = (double) stoi(splitted[0]);
-                pangenomic_end_pos = (double) stoi(splitted[1]);
+                pangenomic_start_pos = std::min((double)len - 1, (double)stoi(splitted[0]));
+                pangenomic_end_pos = std::min((double)len - 1, (double)stoi(splitted[1]));
 
                 if (pangenomic_start_pos >= pangenomic_end_pos) {
                     std::cerr
@@ -235,8 +235,6 @@ namespace odgi {
                             << std::endl;
                     return 1;
                 }
-
-                pangenomic_end_pos = std::min((double)len - 1, pangenomic_end_pos);
             }
         }
 
@@ -254,10 +252,6 @@ namespace odgi {
         uint64_t width = std::min(len_to_visualize, (args::get(image_width) ? args::get(image_width) : 1000));
         uint64_t height = std::min(len_to_visualize, (args::get(image_height) ? args::get(image_height) : 1000) + bottom_padding);
 
-        /*std::cerr << "real len: " << len << std::endl;
-        std::cerr << "pangenomic_start_pos: " << pangenomic_start_pos << "\npangenomic_end_pos: " << pangenomic_end_pos << std::endl;
-        std::cerr << "len_to_visualize: " << len_to_visualize << std::endl;*/
-
         float scale_x = (float) width / (float) len_to_visualize;
         float scale_y = (float) height / (float) len_to_visualize;
 
@@ -270,6 +264,9 @@ namespace odgi {
                 width = len_to_visualize / _bin_width;// + (len_to_visualize % bin_width ? 1 : 0);
             }
 
+            pangenomic_start_pos /= _bin_width;
+            pangenomic_end_pos /= _bin_width;
+
             // Each pixel corresponds to a bin
             scale_x = 1; //scale_x*bin_width;
 
@@ -279,6 +276,10 @@ namespace odgi {
         }else{
             _bin_width = 1;
         }
+
+        std::cerr << "real len: " << len << std::endl;
+        std::cerr << "pangenomic_start_pos: " << pangenomic_start_pos << "\npangenomic_end_pos: " << pangenomic_end_pos << std::endl;
+        std::cerr << "len_to_visualize: " << len_to_visualize << std::endl;
 
         // After the bin_width and scale_xy calculations
         uint16_t width_path_names = 0;
@@ -486,8 +487,8 @@ namespace odgi {
 #ifdef debug_odgi_viz
                                 std::cerr << "position in map (" << p  << ") - curr_bin: " << curr_bin << std::endl;
 #endif
-                                if (p + k >= pangenomic_start_pos && p + k <= pangenomic_end_pos) {
-                                    add_point(curr_bin - 1 - ((p + k - pangenomic_start_pos) / _bin_width + 1), 0, RGB_BIN_LINKS, RGB_BIN_LINKS, RGB_BIN_LINKS);
+                                if (curr_bin >= pangenomic_start_pos && curr_bin <= pangenomic_end_pos) {
+                                    add_point(curr_bin - 1 - pangenomic_start_pos, 0, RGB_BIN_LINKS, RGB_BIN_LINKS, RGB_BIN_LINKS);
                                 }
                             }
 
@@ -805,8 +806,8 @@ namespace odgi {
                                     }
                                 }
 
-                                if ((p + k) >= pangenomic_start_pos && (p + k) <= pangenomic_end_pos) {
-                                    add_path_step(image, width, curr_bin - 1 - ((p + k - pangenomic_start_pos) / _bin_width + 1), path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
+                                if (curr_bin >= pangenomic_start_pos && curr_bin <= pangenomic_end_pos) {
+                                    add_path_step(image, width, curr_bin - 1 - pangenomic_start_pos, path_y, (float)path_r * x, (float)path_g * x, (float)path_b * x);
                                 }
 
                                 if (std::abs(curr_bin - last_bin) > 1 || last_bin == 0) {


### PR DESCRIPTION
This PR introduces a very basic (unmagic) way to take a look at pangenome's regions, without being forced to put the whole graph in the output image.

**yeast dataset**
```
odgi stats -i cerevisiae.pan.fa.og -S

#length	nodes	edges	paths
16435869	405965	546636	112
```
```
time odgi viz -i cerevisiae.pan.og -o cerevisiae.pan.png

real	0m0,811s
```

![cerevisiae pan fa](https://user-images.githubusercontent.com/62253982/108098144-4eccbf80-7083-11eb-9978-1dacfec90da2.png)

First 50kbps in the pangenome's sequence:
`odgi viz -i cerevisiae.pan.fa.og -o cerevisiae.pan.fa.png -r 0-50000`
or
`odgi viz -i cerevisiae.pan.fa.og -o cerevisiae.pan.fa.png -r *-50000`

```
real	0m0,805s
```
![cerevisiae pan fa](https://user-images.githubusercontent.com/62253982/108098422-a10de080-7083-11eb-8450-a18a6958259f.png)


In the middle:
```
odgi viz -i cerevisiae.pan.fa.og -o cerevisiae.pan.fa.png -r 7000000-9000000

real	0m0,749s
```

![cerevisiae pan fa](https://user-images.githubusercontent.com/62253982/108098789-15488400-7084-11eb-9a2b-48861217f78d.png)


At the end:
```
odgi viz -i cerevisiae.pan.fa.og -o cerevisiae.pan.fa.png -r 14000000-*

real	0m0,736s
```

![image](https://user-images.githubusercontent.com/62253982/108099378-d0711d00-7084-11eb-87d8-2dd8390fcd03.png)