### PR TITLE
faster odgi explode

### DIFF
--- a/src/algorithms/explode.cpp
+++ b/src/algorithms/explode.cpp
@@ -83,16 +83,6 @@ namespace odgi {
             add_connecting_edges_to_subgraph(source, subgraph);
         }
 
-        // Create a subpath name
-        string Paths_make_subpath_name(const string &path_name, size_t offset, size_t end_offset) {
-            string out_name = path_name + "[" + std::to_string(offset);
-            if (end_offset > 0) {
-                out_name += "-" + std::to_string(end_offset);
-            }
-            out_name += "]";
-            return out_name;
-        }
-
         void add_full_paths_to_component(const graph_t &source, graph_t &component) {
 
             // We want to track the path names in each component

--- a/src/subcommand/explode_main.cpp
+++ b/src/subcommand/explode_main.cpp
@@ -103,7 +103,7 @@ namespace odgi {
                 subgraph.create_handle(graph.get_sequence(graph.get_handle(node_id)), node_id);
             }
 
-            algorithms::expand_subgraph_by_steps(graph, subgraph, numeric_limits<uint64_t>::max(), false);
+            algorithms::add_connecting_edges_to_subgraph(graph, subgraph);
             algorithms::add_full_paths_to_component(graph, subgraph);
 
             if (optimize) {


### PR DESCRIPTION
Breaking apart connected components is a specific case of a more general extraction of subgraphs. This specificity allows to optimize execution times.