### PR TITLE
Meanderless

### DIFF
--- a/src/algorithms/path_sgd.cpp
+++ b/src/algorithms/path_sgd.cpp
@@ -230,32 +230,40 @@ namespace odgi {
                                         continue;
                                     }
 
-                                    if (s_rank > 0 && flip(gen) || s_rank == path_step_count-1) {
-                                        // go backward
-                                        uint64_t jump_space = std::min(space, s_rank);
-                                        uint64_t space = jump_space;
-                                        if (jump_space > space_max){
-                                            space = space_max + (jump_space - space_max) / space_quantization_step + 1;
+                                    if (flip(gen)) {
+                                        if (s_rank > 0 && flip(gen) || s_rank == path_step_count-1) {
+                                            // go backward
+                                            uint64_t jump_space = std::min(space, s_rank);
+                                            uint64_t space = jump_space;
+                                            if (jump_space > space_max){
+                                                space = space_max + (jump_space - space_max) / space_quantization_step + 1;
+                                            }
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
+                                            uint64_t z_i = z(gen);
+                                            //assert(z_i <= path_space);
+                                            as_integers(step_b)[0] = as_integer(path);
+                                            as_integers(step_b)[1] = s_rank - z_i;
+                                        } else {
+                                            // go forward
+                                            uint64_t jump_space = std::min(space, path_step_count - s_rank - 1);
+                                            uint64_t space = jump_space;
+                                            if (jump_space > space_max){
+                                                space = space_max + (jump_space - space_max) / space_quantization_step + 1;
+                                            }
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
+                                            uint64_t z_i = z(gen);
+                                            //assert(z_i <= path_space);
+                                            as_integers(step_b)[0] = as_integer(path);
+                                            as_integers(step_b)[1] = s_rank + z_i;
                                         }
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
-                                        uint64_t z_i = z(gen);
-                                        //assert(z_i <= path_space);
-                                        as_integers(step_b)[0] = as_integer(path);
-                                        as_integers(step_b)[1] = s_rank - z_i;
                                     } else {
-                                        // go forward
-                                        uint64_t jump_space = std::min(space, path_step_count - s_rank - 1);
-                                        uint64_t space = jump_space;
-                                        if (jump_space > space_max){
-                                            space = space_max + (jump_space - space_max) / space_quantization_step + 1;
-                                        }
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
-                                        uint64_t z_i = z(gen);
-                                        //assert(z_i <= path_space);
+                                        // sample randomly across the path
+                                        graph.get_step_count(path);
+                                        std::uniform_int_distribution<uint64_t> rando(0, graph.get_step_count(path)-1);
                                         as_integers(step_b)[0] = as_integer(path);
-                                        as_integers(step_b)[1] = s_rank + z_i;
+                                        as_integers(step_b)[1] = rando(gen);
                                     }
 
                                     // and the graph handles, which we need to record the update

--- a/src/algorithms/path_sgd_layout.cpp
+++ b/src/algorithms/path_sgd_layout.cpp
@@ -188,33 +188,42 @@ namespace odgi {
                                         continue;
                                     }
 
-                                    if (s_rank > 0 && flip(gen) || s_rank == path_step_count-1) {
-                                        // go backward
-                                        uint64_t jump_space = std::min(space, s_rank);
-                                        uint64_t space = jump_space;
-                                        if (jump_space > space_max){
-                                            space = space_max + (jump_space - space_max) / space_quantization_step + 1;
+                                    if (flip(gen)) {
+                                        if (s_rank > 0 && flip(gen) || s_rank == path_step_count-1) {
+                                            // go backward
+                                            uint64_t jump_space = std::min(space, s_rank);
+                                            uint64_t space = jump_space;
+                                            if (jump_space > space_max){
+                                                space = space_max + (jump_space - space_max) / space_quantization_step + 1;
+                                            }
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
+                                            uint64_t z_i = z(gen);
+                                            //assert(z_i <= path_space);
+                                            as_integers(step_b)[0] = as_integer(path);
+                                            as_integers(step_b)[1] = s_rank - z_i;
+                                        } else {
+                                            // go forward
+                                            uint64_t jump_space = std::min(space, path_step_count - s_rank - 1);
+                                            uint64_t space = jump_space;
+                                            if (jump_space > space_max){
+                                                space = space_max + (jump_space - space_max) / space_quantization_step + 1;
+                                            }
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
+                                            dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
+                                            uint64_t z_i = z(gen);
+                                            //assert(z_i <= path_space);
+                                            as_integers(step_b)[0] = as_integer(path);
+                                            as_integers(step_b)[1] = s_rank + z_i;
                                         }
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
-                                        uint64_t z_i = z(gen);
-                                        //assert(z_i <= path_space);
-                                        as_integers(step_b)[0] = as_integer(path);
-                                        as_integers(step_b)[1] = s_rank - z_i;
                                     } else {
-                                        // go forward
-                                        uint64_t jump_space = std::min(space, path_step_count - s_rank - 1);
-                                        uint64_t space = jump_space;
-                                        if (jump_space > space_max){
-                                            space = space_max + (jump_space - space_max) / space_quantization_step + 1;
-                                        }
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t>::param_type z_p(1, jump_space, theta, zetas[space]);
-                                        dirtyzipf::dirty_zipfian_int_distribution<uint64_t> z(z_p);
-                                        uint64_t z_i = z(gen);
-                                        //assert(z_i <= path_space);
+                                        // sample randomly across the path
+                                        graph.get_step_count(path);
+                                        std::uniform_int_distribution<uint64_t> rando(0, graph.get_step_count(path)-1);
                                         as_integers(step_b)[0] = as_integer(path);
-                                        as_integers(step_b)[1] = s_rank + z_i;
+                                        as_integers(step_b)[1] = rando(gen);
                                     }
+
 
                                     // and the graph handles, which we need to record the update
                                     handle_t term_i = path_index.get_handle_of_step(step_a);

--- a/src/subcommand/viz_main.cpp
+++ b/src/subcommand/viz_main.cpp
@@ -797,9 +797,9 @@ namespace odgi {
                         path_g = 220;
                         path_b = 220;
                     } else if (_binned_mode && _color_by_mean_coverage) {
-                        path_r = 0;
-                        path_g = 0;
-                        path_b = 255;
+                        path_r = 128;
+                        path_g = 255;
+                        path_b = 0;
                     } else if (_color_by_mean_inversion_rate) {
                         path_r = 255;
                         path_g = 0;


### PR DESCRIPTION
Fixes a major issue with path-guided graph sorting.

The radius of the zipf function we choose causes curls in the layout. These appear to occur for 1D and 2D, but they are easier to understand in 2D.

This can be seen in this plot of a yeast pangenome:

![Screenshot from 2021-03-15 12-36-25](https://user-images.githubusercontent.com/145425/111362133-baa84500-868e-11eb-96a6-a75126b6d87d.png)

The curving can be mitigated by sampling the pair of steps used to drive any update to the layout model completely randomly half of the time. The other half, we continue to use zipf sampling, thus tending to sample nodes that are close together.

![Screenshot from 2021-03-16 19-23-38](https://user-images.githubusercontent.com/145425/111362323-eb887a00-868e-11eb-9cdd-c1165ebbcc92.png)

